### PR TITLE
Alterar o MaxConnections default

### DIFF
--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -83,7 +83,7 @@ begin
   WebRequestHandler.WebModuleClass := WebModuleClass;
   try
     if FMaxConnections > 0 then
-      FHTTPWebBroker.MaxConnections := FMaxConnections;
+      WebRequestHandler.MaxConnections := FMaxConnections;
     FHTTPWebBroker.ListenQueue := FListenQueue;
     FHTTPWebBroker.DefaultPort := FPort;
     FHTTPWebBroker.Active := True;


### PR DESCRIPTION
Quando simulava 50 requisições simultaneas que levavam 3 segundos pra responder, ele dava erro de limite de conexoes maior que 32, mesmo configurando assim

`
API := THorse.Create(9000);
API.MaxConnections := 50;`

Resolvi o caso alterando no método THorse.Start de

`FHTTPWebBroker.MaxConnections := FMaxConnections;`

para 

`WebRequestHandler.MaxConnections := FMaxConnections;`