### PR TITLE
resolved: #26

### DIFF
--- a/src/Horse.Router.pas
+++ b/src/Horse.Router.pas
@@ -161,8 +161,11 @@ begin
       else
         CallNextPath(APath, AHTTPType, ARequest, AResponse);
     end;
-  LNext;
-  LNext := nil;
+  try
+    LNext;
+  finally
+    LNext := nil;
+  end;
 end;
 
 function THorseRouterTree.ForcePath(APath: String): THorseRouterTree;


### PR DESCRIPTION
if the "next" procedure is executed with any error, the "next" variable will not be set to nil, causing a memory leak. Now, with the "try finally" block, it didn't cause any memory leaks!