### PR TITLE
A small correction in error handling

### DIFF
--- a/src/Horse.Router.pas
+++ b/src/Horse.Router.pas
@@ -38,7 +38,7 @@ implementation
 
 { THorseRouterTree }
 
-uses Horse.Commons;
+uses Horse.Commons, Horse.Exception;
 
 procedure THorseRouterTree.RegisterRoute(AHTTPType: TMethodType; APath: string; ACallback: THorseCallback);
 var
@@ -147,7 +147,8 @@ begin
             except
               on E: Exception do
               begin
-                AResponse.Send('Internal Application Error').Status(THTTPStatus.InternalServerError);
+                if (not (E is EHorseCallbackInterrupted)) and (not (E is EHorseException)) then
+                  AResponse.Send('Internal Application Error').Status(THTTPStatus.InternalServerError);
                 raise;
               end;
             end;


### PR DESCRIPTION
Was ignoring the status code and error message when the middleware was throwing the exception and it was not being used in the 'Use' method.