### PR TITLE
Opção para atribuir em qual endereço IP o servidor irá rodar

### DIFF
--- a/src/Horse.Constants.pas
+++ b/src/Horse.Constants.pas
@@ -4,11 +4,12 @@ interface
 
 const
   DEFAULT_PORT = 9000;
+  DEFAULT_ADDR = '0.0.0.0';
   HORSE_ENV = 'HORSE_ENV';
   ENV_D = 'd';
   ENV_DEV = 'dev';
   ENV_DEVELOPMENT = 'development';
-  START_RUNNING = 'Server is runing on port %d';
+  START_RUNNING = 'Server is runing on %s:%d';
 
 implementation
 

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -17,6 +17,7 @@ type
 
   THorse = class(THorseCore)
   private
+    FAddr: string;
     FPort: Integer;
     FMaxConnections: Integer;
     FListenQueue: Integer;
@@ -27,6 +28,7 @@ type
   public
     constructor Create; overload;
     constructor Create(APort: Integer); overload;
+    constructor Create(AAddr: string; APort: Integer); overload;
     destructor Destroy; override;
     property ListenQueue: Integer read FListenQueue write FListenQueue;
     property MaxConnections: Integer read FMaxConnections write FMaxConnections;
@@ -45,7 +47,13 @@ uses Horse.Constants, Horse.WebModule, Web.WebReq, IdCustomTCPServer;
 
 constructor THorse.Create(APort: Integer);
 begin
+  Create(DEFAULT_ADDR, APort);
+end;
+
+constructor THorse.Create(AAddr: string; APort: Integer);
+begin
   inherited Create;
+  FAddr := AAddr;
   FPort := APort;
   FHTTPWebBroker := TIdHTTPWebBrokerBridge.Create(nil);
   FHTTPWebBroker.OnParseAuthentication := OnAuthentication;
@@ -63,7 +71,7 @@ end;
 
 constructor THorse.Create;
 begin
-  Create(DEFAULT_PORT);
+  Create(DEFAULT_ADDR, DEFAULT_PORT);
 end;
 
 class function THorse.GetInstance: THorse;
@@ -87,13 +95,17 @@ begin
     if FMaxConnections > 0 then
       WebRequestHandler.MaxConnections := FMaxConnections;
     FHTTPWebBroker.ListenQueue := FListenQueue;
+    FHTTPWebBroker.Bindings.Clear;
+    FHTTPWebBroker.Bindings.Add;
+    FHTTPWebBroker.Bindings.Items[0].IP:= FAddr;
+    FHTTPWebBroker.Bindings.Items[0].Port:= FPort;
     FHTTPWebBroker.DefaultPort := FPort;
     FHTTPWebBroker.Active := True;
     FHTTPWebBroker.StartListening;
 
     if IsConsole then
     begin
-      Writeln(Format(START_RUNNING, [FPort]));
+      Writeln(Format(START_RUNNING, [FAddr, FPort]));
       Write('Press return to stop ...');
       Read(LAttach);
     end;


### PR DESCRIPTION
Opção para definir em qual endereço IP o servidor irá rodar, muito útil quando utilizado com servidor proxy.

Com proxy pode haver necessidade do app rodar somente em **localhost (127.0.0.1)**, não sendo necessário o mesmo está disponível em todos os endereços IPs da máquina.

**App:= THorse.Create('127.0.0.101', 9000);**