### PR TITLE
HTTP status for connections exceeded

### DIFF
--- a/src/Horse.HTTP.pas
+++ b/src/Horse.HTTP.pas
@@ -3,7 +3,7 @@ unit Horse.HTTP;
 interface
 
 uses System.SysUtils, System.Classes, System.Generics.Collections, Web.HTTPApp, IdHTTPHeaderInfo,
-  IdHTTPWebBrokerBridge, IdIOHandler, IdGlobal, Horse.Commons, IdURI;
+  IdHTTPWebBrokerBridge, IdIOHandler, Horse.Commons, IdURI;
 
 type
   THorseList = TDictionary<string, string>;

--- a/src/Horse.HTTP.pas
+++ b/src/Horse.HTTP.pas
@@ -2,7 +2,8 @@ unit Horse.HTTP;
 
 interface
 
-uses System.SysUtils, System.Classes, System.Generics.Collections, Web.HTTPApp, IdHTTPHeaderInfo, Horse.Commons, IdURI;
+uses System.SysUtils, System.Classes, System.Generics.Collections, Web.HTTPApp, IdHTTPHeaderInfo,
+  IdHTTPWebBrokerBridge, IdIOHandler, IdGlobal, Horse.Commons, IdURI;
 
 type
   THorseList = TDictionary<string, string>;
@@ -58,6 +59,11 @@ type
   public
     function GetWebResponse: TWebResponse;
     function GetContent: TObject;
+  end;
+
+  THorseHTTPWebBroker = class(TIdHTTPWebBrokerBridge)
+  protected
+    procedure DoMaxConnectionsExceeded(AIOHandler: TIdIOHandler); override;
   end;
 
 implementation
@@ -233,6 +239,22 @@ end;
 function THorseHackResponse.GetWebResponse: TWebResponse;
 begin
   Result := FWebResponse;
+end;
+
+{ THorseHTTPWebBroker }
+
+procedure THorseHTTPWebBroker.DoMaxConnectionsExceeded(AIOHandler: TIdIOHandler);
+var
+  Body: string;
+begin
+  Body := 'Site is overloaded';
+  AIOHandler.WriteLn('HTTP/1.1 529 Site is overloaded');
+  AIOHandler.WriteLn('Connection: close');
+  AIOHandler.WriteLn('Content-Type: text/plain');
+  AIOHandler.WriteLn('Content-Length: ' + IntToStr(Length(Body)));
+  AIOHandler.WriteLn;
+  AIOHandler.Write(Body);
+  AIOHandler.WaitFor('');
 end;
 
 end.

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -2,7 +2,7 @@ unit Horse;
 
 interface
 
-uses IdHTTPWebBrokerBridge, Horse.Core, IdContext, Horse.HTTP, System.SysUtils, Horse.Router, Horse.Exception;
+uses Horse.Core, IdContext, Horse.HTTP, System.SysUtils, Horse.Router, Horse.Exception;
 
 type
   EHorseException = Horse.Exception.EHorseException;
@@ -21,7 +21,7 @@ type
     FPort: Integer;
     FMaxConnections: Integer;
     FListenQueue: Integer;
-    FHTTPWebBroker: TIdHTTPWebBrokerBridge;
+    FHTTPWebBroker: THorseHTTPWebBroker;
     class var FInstance: THorse;
     procedure OnAuthentication(AContext: TIdContext; const AAuthType, AAuthData: String; var VUsername, VPassword: String;
       var VHandled: Boolean);
@@ -56,7 +56,7 @@ begin
   inherited Create;
   FAddr := AAddr;
   FPort := APort;
-  FHTTPWebBroker := TIdHTTPWebBrokerBridge.Create(nil);
+  FHTTPWebBroker := THorseHTTPWebBroker.Create(nil);
   FHTTPWebBroker.OnParseAuthentication := OnAuthentication;
   FListenQueue := IdListenQueueDefault;
   MaxConnections := 0;
@@ -103,8 +103,8 @@ begin
   inherited;
   WebRequestHandler.WebModuleClass := WebModuleClass;
   try
-    if FMaxConnections > 0 then
-      WebRequestHandler.MaxConnections := FMaxConnections;
+    WebRequestHandler.MaxConnections := 0;
+    FHTTPWebBroker.MaxConnections := FMaxConnections;
     FHTTPWebBroker.ListenQueue := FListenQueue;
     FHTTPWebBroker.Bindings.Clear;
     FHTTPWebBroker.Bindings.Add;


### PR DESCRIPTION
Permite o retorno do status http 529 para quando o limite de conexões simultâneas for atingido (MaxConnections).
Será útil para que a aplicação cliente faça um tratamento adequado caso ocorra uma sobrecarga no servidor.
529 não é um status http oficial, mas é usado por diversos serviços devido a falta de um código próprio para essa situação.