### PR TITLE
Settings for compilation in Delphi XE6

### DIFF
--- a/src/Horse.Core.Group.Contract.pas
+++ b/src/Horse.Core.Group.Contract.pas
@@ -28,10 +28,12 @@ type
     function Put(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
+    {$IFEND}
 
     function Head(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Head(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
@@ -43,10 +45,13 @@ type
     function Post(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Delete(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
+    {$IFEND}
+
     function &End: T;
   end;
 

--- a/src/Horse.Core.Group.Contract.pas
+++ b/src/Horse.Core.Group.Contract.pas
@@ -28,7 +28,7 @@ type
     function Put(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
@@ -45,7 +45,7 @@ type
     function Post(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Delete(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -40,7 +40,7 @@ type
     function Put(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
@@ -57,7 +57,7 @@ type
     function Post(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Delete(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
@@ -168,7 +168,7 @@ begin
   THorseCore(FHorseCore).Put(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 function THorseCoreGroup<T>.Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;
@@ -247,7 +247,7 @@ begin
   THorseCore(FHorseCore).Post(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 function THorseCoreGroup<T>.Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -40,10 +40,12 @@ type
     function Put(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
+    {$IFEND}
 
     function Head(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Head(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
@@ -55,10 +57,12 @@ type
     function Post(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Delete(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
+    {$IFEND}
 
     function &End: T;
   end;
@@ -164,6 +168,7 @@ begin
   THorseCore(FHorseCore).Put(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
+{$IF CompilerVersion <> 27.0}
 function THorseCoreGroup<T>.Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;
@@ -187,6 +192,7 @@ begin
   Result := Self;
   THorseCore(FHorseCore).Patch(NormalizePath(APath), AMiddleware, ACallback);
 end;
+{$IFEND}
 
 function THorseCoreGroup<T>.Head(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>;
 begin
@@ -241,6 +247,7 @@ begin
   THorseCore(FHorseCore).Post(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
+{$IF CompilerVersion <> 27.0}
 function THorseCoreGroup<T>.Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;
@@ -264,5 +271,6 @@ begin
   Result := Self;
   THorseCore(FHorseCore).Delete(NormalizePath(APath), ACallbacks, ACallback);
 end;
+{$IFEND}
 
 end.

--- a/src/Horse.Core.Route.Contract.pas
+++ b/src/Horse.Core.Route.Contract.pas
@@ -25,7 +25,7 @@ type
     function Put(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Put(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Patch(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
@@ -42,7 +42,7 @@ type
     function Post(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Post(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Delete(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;

--- a/src/Horse.Core.Route.Contract.pas
+++ b/src/Horse.Core.Route.Contract.pas
@@ -25,10 +25,12 @@ type
     function Put(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Put(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Patch(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
+    {$IFEND}
 
     function Head(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Head(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
@@ -40,10 +42,13 @@ type
     function Post(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Post(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Delete(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
+    {$IFEND}
+
     function &End: T;
   end;
 

--- a/src/Horse.Core.Route.pas
+++ b/src/Horse.Core.Route.pas
@@ -37,7 +37,7 @@ type
     function Put(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Put(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Patch(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
@@ -54,7 +54,7 @@ type
     function Post(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Post(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     function Delete(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
@@ -112,7 +112,7 @@ begin
   THorseCore(FHorseCore).Use(FPath, [ACallback]);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 function THorseCoreRoute<T>.Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>;
 begin
   Result := Self;
@@ -186,7 +186,7 @@ begin
   THorseCore(FHorseCore).Head(FPath, ACallback);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 function THorseCoreRoute<T>.Patch(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>;
 begin
   Result := Self;

--- a/src/Horse.Core.Route.pas
+++ b/src/Horse.Core.Route.pas
@@ -37,10 +37,12 @@ type
     function Put(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Put(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Patch(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Patch(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
+    {$IFEND}
 
     function Head(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Head(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
@@ -52,10 +54,12 @@ type
     function Post(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Post(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
 
+    {$IF CompilerVersion <> 27.0}
     function Delete(ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>; overload;
     function Delete(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>; overload;
+    {$IFEND}
 
     function &End: T;
   end;
@@ -108,6 +112,7 @@ begin
   THorseCore(FHorseCore).Use(FPath, [ACallback]);
 end;
 
+{$IF CompilerVersion <> 27.0}
 function THorseCoreRoute<T>.Delete(ACallbacks: array of THorseCallback): IHorseCoreRoute<T>;
 begin
   Result := Self;
@@ -131,6 +136,7 @@ begin
   Result := Self;
   THorseCore(FHorseCore).Delete(FPath, ACallbacks, ACallback);
 end;
+{$IFEND}
 
 function THorseCoreRoute<T>.Get(AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<T>;
 begin
@@ -180,6 +186,7 @@ begin
   THorseCore(FHorseCore).Head(FPath, ACallback);
 end;
 
+{$IF CompilerVersion <> 27.0}
 function THorseCoreRoute<T>.Patch(ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreRoute<T>;
 begin
   Result := Self;
@@ -203,6 +210,7 @@ begin
   Result := Self;
   THorseCore(FHorseCore).Patch(FPath, ACallback);
 end;
+{$IFEND}
 
 function THorseCoreRoute<T>.Post(ACallback: THorseCallback): IHorseCoreRoute<T>;
 begin

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -71,10 +71,12 @@ type
     class function Put(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
 
+    {$IF CompilerVersion <> 27.0}
     class function Patch(APath: string; ACallback: THorseCallback): THorseCore; overload;
     class function Patch(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore; overload;
     class function Patch(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Patch(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
+    {$IFEND}
 
     class function Head(APath: string; ACallback: THorseCallback): THorseCore; overload;
     class function Head(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore; overload;
@@ -86,10 +88,12 @@ type
     class function Post(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
 
+    {$IF CompilerVersion <> 27.0}
     class function Delete(APath: string; ACallback: THorseCallback): THorseCore; overload;
     class function Delete(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore; overload;
     class function Delete(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Delete(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
+    {$IFEND}
 
     class property Routes: THorseRouterTree read GetRoutes write SetRoutes;
 
@@ -192,6 +196,7 @@ begin
     FreeAndNil(FRoutes);
 end;
 
+{$IF CompilerVersion <> 27.0}
 class function THorseCore.Delete(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;
@@ -220,6 +225,7 @@ class function THorseCore.Delete(APath: string; ACallback: THorseCallback): THor
 begin
   Result := RegisterRoute(mtDelete, APath, ACallback);
 end;
+{$IFEND}
 
 class function THorseCore.Head(APath: string; ACallback: THorseCallback): THorseCore;
 begin
@@ -264,10 +270,12 @@ begin
   Result := RegisterRoute(mtPost, APath, ACallback);
 end;
 
+{$IF CompilerVersion <> 27.0}
 class function THorseCore.Patch(APath: string; ACallback: THorseCallback): THorseCore;
 begin
   Result := RegisterRoute(mtPatch, APath, ACallback);
 end;
+{$IFEND}
 
 class function THorseCore.Put(APath: string; ACallback: THorseCallback): THorseCore;
 begin
@@ -319,16 +327,19 @@ begin
   Result := Post(APath, [AMiddleware, ACallback]);
 end;
 
+{$IF CompilerVersion <> 27.0}
 class function THorseCore.Patch(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore;
 begin
   Result := Patch(APath, [AMiddleware, ACallback]);
 end;
+{$IFEND}
 
 class function THorseCore.Put(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore;
 begin
   Result := Put(APath, [AMiddleware, ACallback]);
 end;
 
+{$IF CompilerVersion <> 27.0}
 class function THorseCore.Patch(APath: string; ACallbacks: array of THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;
@@ -337,6 +348,7 @@ begin
   for LCallback in ACallbacks do
     Patch(APath, LCallback);
 end;
+{$IFEND}
 
 class function THorseCore.Put(APath: string; ACallbacks: array of THorseCallback): THorseCore;
 var
@@ -377,6 +389,7 @@ begin
   Post(APath, ACallback);
 end;
 
+{$IF CompilerVersion <> 27.0}
 class function THorseCore.Patch(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;
@@ -386,6 +399,7 @@ begin
     Patch(APath, LCallback);
   Patch(APath, ACallback);
 end;
+{$IFEND}
 
 class function THorseCore.Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore;
 var

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -71,7 +71,7 @@ type
     class function Put(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     class function Patch(APath: string; ACallback: THorseCallback): THorseCore; overload;
     class function Patch(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore; overload;
     class function Patch(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
@@ -88,7 +88,7 @@ type
     class function Post(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
     class function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore; overload;
 
-    {$IF CompilerVersion <> 27.0}
+    {$IF CompilerVersion > 27.0}
     class function Delete(APath: string; ACallback: THorseCallback): THorseCore; overload;
     class function Delete(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore; overload;
     class function Delete(APath: string; ACallbacks: array of THorseCallback): THorseCore; overload;
@@ -196,7 +196,7 @@ begin
     FreeAndNil(FRoutes);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 class function THorseCore.Delete(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;
@@ -270,7 +270,7 @@ begin
   Result := RegisterRoute(mtPost, APath, ACallback);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 class function THorseCore.Patch(APath: string; ACallback: THorseCallback): THorseCore;
 begin
   Result := RegisterRoute(mtPatch, APath, ACallback);
@@ -327,7 +327,7 @@ begin
   Result := Post(APath, [AMiddleware, ACallback]);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 class function THorseCore.Patch(APath: string; AMiddleware, ACallback: THorseCallback): THorseCore;
 begin
   Result := Patch(APath, [AMiddleware, ACallback]);
@@ -339,7 +339,7 @@ begin
   Result := Put(APath, [AMiddleware, ACallback]);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 class function THorseCore.Patch(APath: string; ACallbacks: array of THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;
@@ -389,7 +389,7 @@ begin
   Post(APath, ACallback);
 end;
 
-{$IF CompilerVersion <> 27.0}
+{$IF CompilerVersion > 27.0}
 class function THorseCore.Patch(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): THorseCore;
 var
   LCallback: THorseCallback;

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -35,7 +35,6 @@ type
 
   THorse = class;
 
-
 {$IF DEFINED(HORSE_ISAPI)}
   THorseProvider = Horse.Provider.ISAPI.THorseProvider<THorse>;
 {$ELSEIF DEFINED(HORSE_APACHE)}

--- a/src/Web.WebConst.pas
+++ b/src/Web.WebConst.pas
@@ -46,7 +46,7 @@ resourcestring
   sWebDirectoryExclude = 'Exclude';
   sWebDirectoryItemDisplayName = 'Action: %0:s, Mask: ''%1:s''';
 
-  {$IF CompilerVersion = 27.0}
+  {$IF CompilerVersion <= 27.0}
     sErrorDecodingURLText = 'Error decoding URL text';
     sInvalidURLEncodedChar = 'Invalid URL encoded char';
     sInvalidHTMLEncodedChar = 'Invalid HTML encoded char';

--- a/src/Web.WebConst.pas
+++ b/src/Web.WebConst.pas
@@ -46,6 +46,14 @@ resourcestring
   sWebDirectoryExclude = 'Exclude';
   sWebDirectoryItemDisplayName = 'Action: %0:s, Mask: ''%1:s''';
 
+  {$IF CompilerVersion = 27.0}
+    sErrorDecodingURLText = 'Error decoding URL text';
+    sInvalidURLEncodedChar = 'Invalid URL encoded char';
+    sInvalidHTMLEncodedChar = 'Invalid HTML encoded char';
+    sFactoryAlreadyRegistered = 'Factory already registered';
+    sAppFactoryAlreadyRegistered = 'App factory already registered';
+  {$IFEND}
+
 implementation
 
 end.


### PR DESCRIPTION
I made some adjustments to allow the compilation and use of Horse in Delphi XE6.

As in the XE6 version Delphi does not have TMethodType, mtDelete and mtPath, I used a compilation directive verifying that if the compilation version is XE6, the Delete and Path methods will not be included in the compilation.

I performed tests on Delphi XE6 and 10.3.3 Rio