### PR TITLE
{$IF CompilerVersion > 27.0} incompatible with lazarus

### DIFF
--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -40,7 +40,7 @@ type
     function Put(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Put(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion > 27.0}
+    {$IF (defined(fpc) or (CompilerVersion > 27.0))}
     function Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Patch(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
@@ -57,7 +57,7 @@ type
     function Post(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
     function Post(APath: string; ACallbacks: array of THorseCallback; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
 
-    {$IF CompilerVersion > 27.0}
+    {$IF (defined(fpc) or (CompilerVersion > 27.0))}
     function Delete(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>; overload;
     function Delete(APath: string; ACallbacks: array of THorseCallback): IHorseCoreGroup<T>; overload;
@@ -168,7 +168,7 @@ begin
   THorseCore(FHorseCore).Put(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
-{$IF CompilerVersion > 27.0}
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
 function THorseCoreGroup<T>.Patch(APath: string; ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;
@@ -247,7 +247,7 @@ begin
   THorseCore(FHorseCore).Post(NormalizePath(APath), ACallbacks, ACallback);
 end;
 
-{$IF CompilerVersion > 27.0}
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
 function THorseCoreGroup<T>.Delete(APath: string; AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
   Result := Self;


### PR DESCRIPTION
Replace {$IF CompilerVersion > 27.0} with {$IF (defined(fpc) or (CompilerVersion > 27.0))}