### PR TITLE
Verify Delphi Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ This is a list of middlewares that are created by the Horse community, please cr
 |  [claudneysessa/Horse-CSResponsePagination](https://github.com/claudneysessa/Horse-CSResponsePagination) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [claudneysessa/Horse-XSuperObjects](https://github.com/claudneysessa/Horse-XSuperObjects)               | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 
+## ⚠️ Delphi Versions
+`Horse` works with Delphi 11 Alexandria, Delphi 10.4 Sydney, Delphi 10.3 Rio, Delphi 10.2 Tokyo, Delphi 10.1 Berlin, Delphi 10 Seattle, Delphi XE8 and Delphi XE7.
+
 ## ⚠️ License
 
 `Horse` is free and open-source software licensed under the [MIT License](https://github.com/HashLoad/horse/blob/master/LICENSE). 


### PR DESCRIPTION
Verified versions: XE7, XE8, 10 Seattle, 10.1 Berlin and 10.2 Tokyo.
Tested Console, VCL and Apache Samples.
Build CGI and ISAPI Samples.
XE5 showed compilation error.