### PR TITLE
Report memory leaks

### DIFF
--- a/samples/delphi/console/Console.dpr
+++ b/samples/delphi/console/Console.dpr
@@ -17,5 +17,16 @@ begin
     procedure(Horse: THorse)
     begin
       Writeln(Format('Server is runing on %s:%d', [Horse.Host, Horse.Port]));
+      {$IFDEF DEBUG}
+      ReportMemoryLeaksOnShutdown := True;
+      System.IsConsole := False;
+      while THorse.IsRunning do
+      begin
+        Writeln('Type "stop" to terminate the server');
+        Readln(LReadLn);
+        if LReadLn = 'stop' then
+          THorse.StopListen;
+      end;
+      {$ENDIF}
     end);
 end.


### PR DESCRIPTION
Pequeno ajuste no sample console para capturar os vazamentos de memória sem a necessidade de executar a aplicação via terminal