### PR TITLE
XE7 until 10.1 Compatibility which does not accept pointer references…

### DIFF
--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -224,7 +224,11 @@ begin
         Read(LAttach);
       end
       else
+      {$IF CompilerVersion >= 32.0}
         raise AcquireExceptionObject;
+      {$ELSE}
+        raise;
+      {$ENDIF}
     end;
   end;
 end;


### PR DESCRIPTION
XE7 until 10.1 Compatibility which does not accept pointer references. 
with the raise. This call is only supported from version 10.2