### PR TITLE
Implement RedirectTo method for THorseResponse

### DIFF
--- a/src/Horse.HTTP.pas
+++ b/src/Horse.HTTP.pas
@@ -336,7 +336,6 @@ begin
   Result := Status(AStatus);
 end;
 
-
 function THorseResponse.Status(AStatus: THTTPStatus): THorseResponse;
 begin
   {$IF DEFINED(FPC)}FWebResponse.Code{$ELSE}FWebResponse.StatusCode{$ENDIF} := AStatus.ToInteger;

--- a/src/Horse.HTTP.pas
+++ b/src/Horse.HTTP.pas
@@ -84,6 +84,8 @@ type
   public
     function Send(AContent: string): THorseResponse; overload;
     function Send<T: class>(AContent: T): THorseResponse; overload;
+    function RedirectTo(ALocation: string): THorseResponse; overload;
+    function RedirectTo(ALocation: string; AStatus: THTTPStatus): THorseResponse; overload;
     function Status(AStatus: Integer): THorseResponse; overload;
     function Status(AStatus: THTTPStatus): THorseResponse; overload;
     function Status: Integer; overload;
@@ -321,6 +323,19 @@ begin
   FContent := AContent;
   Result := Self;
 end;
+
+function THorseResponse.RedirectTo(ALocation: string): THorseResponse;
+begin
+  FWebResponse.SetCustomHeader('Location', ALocation);
+  Result := Status(THTTPStatus.SeeOther);
+end;
+
+function THorseResponse.RedirectTo(ALocation: string; AStatus: THTTPStatus): THorseResponse;
+begin
+  FWebResponse.SetCustomHeader('Location', ALocation);
+  Result := Status(AStatus);
+end;
+
 
 function THorseResponse.Status(AStatus: THTTPStatus): THorseResponse;
 begin


### PR DESCRIPTION
Implements a `RedirectTo` method for `THorseResponse`. It can be used when the developer wants the handler to send a redirection response. While it may not seem to be much useful at constructing APIs it's useful when constructing applications where the view layer is processed at backend and a full HTML response is commonly sent to client. With `RedirectTo` we can use a handler to process a POST request and then send the user to another page with the result of processing with a GET, a common standard for MVC or similar web frameworks.