### PR TITLE
Melhorias na classe Horse.Session.THorseSessions

### DIFF
--- a/src/Horse.Session.pas
+++ b/src/Horse.Session.pas
@@ -25,6 +25,8 @@ type
     function GetSession(const ASessionClass: TSessionClass): TSession; overload;
     function GetObject(const ASessionClass: TSessionClass): TObject; overload;
   public
+    function TryGetSession<T: class>(out ASession: T): Boolean;
+    function Contains(const ASessionClass: TSessionClass): Boolean;
     function SetSession(const ASessionClass: TSessionClass; const AInstance: TSession): THorseSessions;
     property Session[const ASessionClass: TSessionClass]: TSession read GetSession;
     property &Object[const ASessionClass: TSessionClass]: TObject read GetObject;
@@ -61,6 +63,16 @@ begin
   if not ASessionClass.InheritsFrom(AInstance.ClassType) then
     raise Exception.CreateFmt('SessionClass differs from of instance[%s].', [AInstance.ClassType.ClassName]);
   FSessions.AddOrSetValue(ASessionClass, AInstance);
+end;
+
+function THorseSessions.Contains(const ASessionClass: TSessionClass): Boolean;
+begin
+  Result := FSessions.ContainsKey(ASessionClass);
+end;
+
+function THorseSessions.TryGetSession<T>(out ASession: T): Boolean;
+begin
+  Result := FSessions.TryGetValue(TSessionClass(T), TSession(ASession));
 end;
 
 end.


### PR DESCRIPTION
Novas funcionalidades na classe THorseSessions:

- **TryGetSession:** Retorna verdadeiro ou falso se existe um objeto do tipo **TSessionClass** na lista de sessões, caso verdadeiro retorna a instância desse objeto. Função não gera exceção caso não exista a instância desse obejto.
- **Contains:** Retorna verdadeiro ou falso se existe um objeto do tipo **TSessionClass** na lista de sessões.