### PR TITLE
Add support to LHS Brackets

### DIFF
--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -7,14 +7,20 @@ unit Horse.Commons;
 
 interface
 
+uses
 {$IF DEFINED(FPC)}
-uses Classes, SysUtils;
+  Classes, SysUtils
+{$ELSE}
+  System.Classes, System.SysUtils
 {$ENDIF}
+ ;
 
 type
 {$IF DEFINED(FPC)}
   TMethodType = (mtAny, mtGet, mtPut, mtPost, mtHead, mtDelete, mtPatch);
 {$ENDIF}
+  TLhsBracketsType = (lbteq, lbtne, lbtlt, lbtlte, lbtgt, lbtgte, lbtrange, lbtlike);
+  TLhsBrackets = set of TLhsBracketsType;
 
 {$SCOPEDENUMS ON}
   THTTPStatus = (
@@ -112,6 +118,11 @@ type
     function ToString: string;
   end;
 
+  TLhsBracketsTypeHelper  = {$IF DEFINED(FPC)} type {$ELSE} record {$ENDIF} helper
+  for TLhsBracketsType
+    function ToString: string;
+  end;
+
 {$IF DEFINED(FPC)}
 function StringCommandToMethodType(const ACommand: string): TMethodType;
 {$ENDIF}
@@ -136,6 +147,31 @@ begin
   if ACommand = 'PUT' then
     Result := TMethodType.mtPut;
 end;
+
+{ TLhsBracketsTypeHelper }
+
+function TLhsBracketsTypeHelper.ToString: string;
+begin
+  case Self of
+    TLhsBracketsType.lbteq:
+      Result := '[eq]';
+    TLhsBracketsType.lbtne:
+      Result := '[ne]';
+    TLhsBracketsType.lbtlt:
+      Result := '[lt]';
+    TLhsBracketsType.lbtlte:
+      Result := '[lte]';
+    TLhsBracketsType.lbtgt:
+      Result := '[gt]';
+    TLhsBracketsType.lbtgte:
+      Result := '[gte]';
+    TLhsBracketsType.lbtrange:
+      Result := '[range]';
+    TLhsBracketsType.lbtlike:
+      Result := '[like]';
+  end;
+end;
+
 {$ENDIF}
 
 { THTTPStatusHelper }

--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -19,8 +19,6 @@ type
 {$IF DEFINED(FPC)}
   TMethodType = (mtAny, mtGet, mtPut, mtPost, mtHead, mtDelete, mtPatch);
 {$ENDIF}
-  TLhsBracketsType = (lbteq, lbtne, lbtlt, lbtlte, lbtgt, lbtgte, lbtrange, lbtlike);
-  TLhsBrackets = set of TLhsBracketsType;
 
 {$SCOPEDENUMS ON}
   THTTPStatus = (
@@ -107,7 +105,10 @@ type
     ImageGIF);
 
   TMessageType = (Default, Error, Warning, Information);
+
+  TLhsBracketsType = (Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, Range, Like);
 {$SCOPEDENUMS OFF}
+  TLhsBrackets = set of TLhsBracketsType;
 
   THTTPStatusHelper = {$IF DEFINED(FPC)} type {$ELSE} record {$ENDIF} helper for THTTPStatus
     function ToInteger: Integer;
@@ -153,21 +154,21 @@ end;
 function TLhsBracketsTypeHelper.ToString: string;
 begin
   case Self of
-    TLhsBracketsType.lbteq:
+    TLhsBracketsType.Equal:
       Result := '[eq]';
-    TLhsBracketsType.lbtne:
+    TLhsBracketsType.NotEqual:
       Result := '[ne]';
-    TLhsBracketsType.lbtlt:
+    TLhsBracketsType.LessThan:
       Result := '[lt]';
-    TLhsBracketsType.lbtlte:
+    TLhsBracketsType.LessThanOrEqual:
       Result := '[lte]';
-    TLhsBracketsType.lbtgt:
+    TLhsBracketsType.GreaterThan:
       Result := '[gt]';
-    TLhsBracketsType.lbtgte:
+    TLhsBracketsType.GreaterThanOrEqual:
       Result := '[gte]';
-    TLhsBracketsType.lbtrange:
+    TLhsBracketsType.Range:
       Result := '[range]';
-    TLhsBracketsType.lbtlike:
+    TLhsBracketsType.Like:
       Result := '[like]';
   end;
 end;

--- a/src/Horse.Core.Param.Config.pas
+++ b/src/Horse.Core.Param.Config.pas
@@ -7,6 +7,9 @@ unit Horse.Core.Param.Config;
 interface
 
 type
+
+  { THorseCoreParamConfig }
+
   THorseCoreParamConfig = class
   private
     class var FInstance: THorseCoreParamConfig;
@@ -16,6 +19,7 @@ type
     FTimeFormat: string;
     FReturnUTC: Boolean;
     FTrueValue: string;
+    FCheckLhsBrackets: Boolean;
     constructor Create;
   public
     function RequiredMessage(const AValue: string): THorseCoreParamConfig; overload;
@@ -30,6 +34,8 @@ type
     function ReturnUTC: Boolean; overload;
     function TrueValue(const AValue: string): THorseCoreParamConfig; overload;
     function TrueValue: string; overload;
+    function CheckLhsBrackets(const AValue: Boolean): THorseCoreParamConfig; overload;
+    function CheckLhsBrackets: Boolean; overload;
     class function GetInstance: THorseCoreParamConfig;
     class destructor UnInitialize;
   end;
@@ -51,6 +57,7 @@ begin
   FTrueValue := 'true';
   FRequiredMessage := 'The %s param is required.';
   FInvalidFormatMessage := 'The %0:s param ''%1:s'' is not valid a %2:s type.';
+  FCheckLhsBrackets := False;
 end;
 
 function THorseCoreParamConfig.DateFormat(const AValue: string): THorseCoreParamConfig;
@@ -124,6 +131,18 @@ end;
 function THorseCoreParamConfig.TrueValue: string;
 begin
   Result := FTrueValue;
+end;
+
+function THorseCoreParamConfig.CheckLhsBrackets(const AValue: Boolean
+  ): THorseCoreParamConfig;
+begin
+  Result := Self;
+  FCheckLhsBrackets := AValue;
+end;
+
+function THorseCoreParamConfig.CheckLhsBrackets: Boolean;
+begin
+  Result := FCheckLhsBrackets;
 end;
 
 class destructor THorseCoreParamConfig.UnInitialize;

--- a/src/Horse.Core.Param.Field.Brackets.pas
+++ b/src/Horse.Core.Param.Field.Brackets.pas
@@ -1,0 +1,97 @@
+unit Horse.Core.Param.Field.Brackets;
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+uses
+  {$IF DEFINED(FPC)}
+    SysUtils, Classes,
+  {$ELSE}
+    System.SysUtils, System.Classes,
+  {$ENDIF}
+    Horse.Commons;
+
+type
+  { THorseCoreParamFieldLhsBrackets }
+
+  THorseCoreParamFieldLhsBrackets = class
+  private
+    FEq: string;
+    FNe: string;
+    FLt: string;
+    FLte: string;
+    FGt: string;
+    FGte: string;
+    FRange: string;
+    FLike: string;
+    FTypes: TLhsBrackets;
+  public
+    property Eq: string read Feq;
+    property Ne: string read Fne;
+    property Lt: string read Flt;
+    property Lte: string read Flte;
+    property Gt: string read Fgt;
+    property Gte: string read Fgte;
+    property Range: string read Frange;
+    property Like: string read Flike;
+    property Types: TLhsBrackets read FTypes write FTypes;
+
+    procedure SetValue(const AType: TLhsBracketsType; const AValue: string);
+    function GetValue(const AType: TLhsBracketsType): string;
+  end;
+
+implementation
+
+{ THorseCoreParamFieldLhsBrackets }
+
+procedure THorseCoreParamFieldLhsBrackets.SetValue(
+  const AType: TLhsBracketsType; const AValue: string);
+begin
+  case AType of
+    TLhsBracketsType.Equal:
+      FEq := AValue;
+    TLhsBracketsType.NotEqual:
+      FNe := AValue;
+    TLhsBracketsType.LessThan:
+      FLt := AValue;
+    TLhsBracketsType.LessThanOrEqual:
+      FLte := AValue;
+    TLhsBracketsType.GreaterThan:
+      FGt := AValue;
+    TLhsBracketsType.GreaterThanOrEqual:
+      FGte := AValue;
+    TLhsBracketsType.Range:
+      FRange := AValue;
+    TLhsBracketsType.Like:
+      FLike := AValue;
+  end;
+end;
+
+function THorseCoreParamFieldLhsBrackets.GetValue(const AType: TLhsBracketsType
+  ): string;
+begin
+  case AType of
+    TLhsBracketsType.Equal:
+      Result := FEq;
+    TLhsBracketsType.NotEqual:
+      Result := FNe;
+    TLhsBracketsType.LessThan:
+      Result := FLt;
+    TLhsBracketsType.LessThanOrEqual:
+      Result := FLte;
+    TLhsBracketsType.GreaterThan:
+      Result := FGt;
+    TLhsBracketsType.GreaterThanOrEqual:
+      Result := FGte;
+    TLhsBracketsType.Range:
+      Result := FRange;
+    TLhsBracketsType.Like:
+      Result := FLike;
+  end;
+end;
+
+end.
+

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -12,38 +12,9 @@ uses
 {$ELSE}
   System.SysUtils, System.Classes, System.DateUtils, System.Generics.Collections,
 {$ENDIF}
-  Horse.Exception, Horse.Commons;
+  Horse.Exception, Horse.Commons, Horse.Core.Param.Field.Brackets;
 
 type
-
-  { THorseCoreParamFieldLhsBrackets }
-
-  THorseCoreParamFieldLhsBrackets = class
-  private
-    Feq: string; //Equal
-    Fne: string; //NotEqual
-    Flt: string; //LessThan
-    Flte: string; //LessThanOrEqual
-    Fgt: string; //GreaterThan
-    Fgte: string; //GreaterThanOrEqual
-    Frange: string; //Range
-    Flike: string; //Like
-    FTypes: TLhsBrackets;
-  public
-    property eq: string read Feq;
-    property ne: string read Fne;
-    property lt: string read Flt;
-    property lte: string read Flte;
-    property gt: string read Fgt;
-    property gte: string read Fgte;
-    property range: string read Frange;
-    property like: string read Flike;
-    property Types: TLhsBrackets read FTypes write FTypes;
-
-    procedure SetValue(AType: TLhsBracketsType; AValue: string);
-    function GetValue(AType: TLhsBracketsType): string;
-  end;
-
   { THorseCoreParamField }
 
   THorseCoreParamField = class
@@ -88,59 +59,11 @@ type
 
     property LhsBrackets:THorseCoreParamFieldLhsBrackets read FLhsBrackets;
 
-    constructor Create(const AParams: TDictionary<string, string>; const AFieldName: string; ACheckLhsBrackets: Boolean);
+    constructor Create(const AParams: TDictionary<string, string>; const AFieldName: string; const ACheckLhsBrackets: Boolean);
     destructor Destroy; override;
   end;
 
 implementation
-
-{ THorseCoreParamFieldLhsBrackets }
-
-procedure THorseCoreParamFieldLhsBrackets.SetValue(AType: TLhsBracketsType;
-  AValue: string);
-begin
-  case AType of
-    lbteq:
-      Feq := AValue;
-    lbtne:
-      Fne := AValue;
-    lbtlt:
-      Flt := AValue;
-    lbtlte:
-      Flte := AValue;
-    lbtgt:
-      Fgt := AValue;
-    lbtgte:
-      Fgte := AValue;
-    lbtrange:
-      Frange := AValue;
-    lbtlike:
-      Flike := AValue;
-  end;
-end;
-
-function THorseCoreParamFieldLhsBrackets.GetValue(AType: TLhsBracketsType
-  ): string;
-begin
-  case AType of
-    lbteq:
-      Result := Feq;
-    lbtne:
-      Result := Fne;
-    lbtlt:
-      Result := Flt;
-    lbtlte:
-      Result := Flte;
-    lbtgt:
-      Result := Fgt;
-    lbtgte:
-      Result := Fgte;
-    lbtrange:
-      Result := Frange;
-    lbtlike:
-      Result := Flike;
-  end;
-end;
 
 { THorseCoreParamField }
 
@@ -293,7 +216,7 @@ begin
 end;
 
 constructor THorseCoreParamField.Create(const AParams: TDictionary<string,
-  string>; const AFieldName: string; ACheckLhsBrackets: Boolean);
+  string>; const AFieldName: string; const ACheckLhsBrackets: Boolean);
 var
   LKey: string;
   LLhsBracketType: TLhsBracketsType;

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -314,10 +314,7 @@ begin
   end;
 
   if FContains then
-  begin
     FValue := AParams.Items[LKey];
-    Exit;
-  end;
 
   if ACheckLhsBrackets then
   begin

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -30,9 +30,9 @@ type
     Flike: string; //Like
     FTypes: TLhsBrackets;
   public
-    property eq: string read Feq write Feq ;
-    property ne: string read Fne write Fne;
-    property lt: string read Flt write Flt;
+    property eq: string read Feq;
+    property ne: string read Fne;
+    property lt: string read Flt;
     property lte: string read Flte;
     property gt: string read Fgt;
     property gte: string read Fgte;

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -90,7 +90,7 @@ begin
   if FFields.ContainsKey(LFieldName) then
     Exit(FFields.Items[LFieldName]);
 
-  Result := THorseCoreParamField.create(FParams, AKey);
+  Result := THorseCoreParamField.create(FParams, AKey, THorseCoreParamConfig.GetInstance.CheckLhsBrackets);
   try
     Result
       .Required(FRequired)


### PR DESCRIPTION
Example:

http://localhost:9000/ping?test[eq]=1234&test[lt]=321&test[ne]=111


```
procedure GetPing(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
var
  LLhsBracketType: TLhsBracketsType;
  LPong: TJSONArray;
  LJson: TJSONObject;
begin
  THorseCoreParamConfig.GetInstance.CheckLhsBrackets(True);

  LPong := TJSONArray.Create;
  for LLhsBracketType in Req.Query.Field('test').LhsBrackets.Types do
  begin
    LJson := TJSONObject.Create;
    LJson.Add(Format('test %s =',
             [LLhsBracketType.ToString]) ,
             Req.Query.Field('test').LhsBrackets.GetValue(LLhsBracketType));
    LPong.Add(LJson);
  end;

  Res.Send(LPong.AsJSON);
end;
```