### PR TITLE
Add form-data file params in Req.ContentFields

### DIFF
--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -187,12 +187,12 @@ end;
 
 function THorseCoreParamField.AsStream: TStream;
 begin
-  result := nil;
+  Result := nil;
   if FContains then
   begin
-    result := FStream;
-    if Assigned(result) then
-      result.Position := 0;
+    Result := FStream;
+    if Assigned(Result) then
+      Result.Position := 0;
   end
   else
   if FRequired then

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -43,6 +43,8 @@ type
     function TimeFormat(const AValue: string): THorseCoreParamField;
     function TrueValue(const AValue: string): THorseCoreParamField;
 
+    procedure SaveToFile(const AFileName: String);
+
     function AsBoolean: Boolean;
     function AsCurrency: Currency;
     function AsDate: TDateTime;
@@ -318,6 +320,23 @@ function THorseCoreParamField.ReturnUTC(const AValue: Boolean): THorseCoreParamF
 begin
   Result := Self;
   FReturnUTC := AValue;
+end;
+
+procedure THorseCoreParamField.SaveToFile(const AFileName: String);
+var
+  LMemoryStream: TMemoryStream;
+begin
+  if AsStream = nil then
+    Exit;
+
+  LMemoryStream := TMemoryStream.Create;
+  try
+    LMemoryStream.LoadFromStream(AsStream);
+    LMemoryStream.Position := 0;
+    LMemoryStream.SaveToFile(AFileName);
+  finally
+    LMemoryStream.Free;
+  end;
 end;
 
 function THorseCoreParamField.TimeFormat(const AValue: string): THorseCoreParamField;

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -117,7 +117,7 @@ end;
 
 function THorseCoreParam.AddStream(const AKey: string; const AContent: TStream): THorseCoreParam;
 begin
-  result := Self;
+  Result := Self;
   if not Assigned(FFiles) then
     FFiles := TDictionary<String, TStream>.Create;
 
@@ -189,13 +189,13 @@ begin
     begin
       if AnsiSameText(LKey, AKey) then
       begin
-        result := THorseCoreParamField.Create(FFiles.Items[LKey], AKey);
+        Result := THorseCoreParamField.Create(FFiles.Items[LKey], AKey);
         Exit;
       end;
     end;
   end;
 
-  result := THorseCoreParamField.create(FParams, AKey);
+  Result := THorseCoreParamField.create(FParams, AKey);
 end;
 
 function THorseCoreParam.Required(const AValue: Boolean): THorseCoreParam;

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -132,7 +132,7 @@ procedure THorseRequest.InitializeContentFields;
 var
   I: Integer;
 begin
-  FContentFields := THorseCoreParam.Create(THorseList.Create).Required(False);
+  FContentFields := THorseCoreParam.Create(THorseList.Create, FWebRequest.Files).Required(False);
   if (not CanLoadContentFields) then
     Exit;
   for I := 0 to Pred(FWebRequest.ContentFields.Count) do

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -132,9 +132,13 @@ procedure THorseRequest.InitializeContentFields;
 var
   I: Integer;
 begin
-  FContentFields := THorseCoreParam.Create(THorseList.Create, FWebRequest.Files).Required(False);
+  FContentFields := THorseCoreParam.Create(THorseList.Create).Required(False);
   if (not CanLoadContentFields) then
     Exit;
+
+  for I := 0 to Pred(FWebRequest.Files.Count) do
+    FContentFields.AddStream(FWebRequest.Files[I].FieldName, FWebRequest.Files[I].Stream);
+
   for I := 0 to Pred(FWebRequest.ContentFields.Count) do
     FContentFields.Dictionary.AddOrSetValue(FWebRequest.ContentFields.Names[I], FWebRequest.ContentFields.ValueFromIndex[I]);
 end;

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -13,7 +13,6 @@ uses
   Horse.Core.Route in '..\..\src\Horse.Core.Route.pas',
   Horse.Core.RouterTree in '..\..\src\Horse.Core.RouterTree.pas',
   Horse.Exception in '..\..\src\Horse.Exception.pas',
-  Horse.HTTP in '..\..\src\Horse.HTTP.pas',
   Horse in '..\..\src\Horse.pas',
   Horse.Provider.Abstract in '..\..\src\Horse.Provider.Abstract.pas',
   Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
@@ -39,10 +38,18 @@ uses
   Tests.Commons in 'tests\Tests.Commons.pas',
   Horse.Core.Param in '..\..\src\Horse.Core.Param.pas',
   Horse.Core.Param.Header in '..\..\src\Horse.Core.Param.Header.pas',
-  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
   Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
   Tests.Horse.Core.Param in 'tests\Tests.Horse.Core.Param.pas',
-  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas';
+  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas',
+  Horse.Request in '..\..\src\Horse.Request.pas',
+  Horse.Response in '..\..\src\Horse.Response.pas',
+  Horse.Core.Param.Config in '..\..\src\Horse.Core.Param.Config.pas',
+  Horse.Rtti.Helper in '..\..\src\Horse.Rtti.Helper.pas',
+  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
+  Horse.Callback in '..\..\src\Horse.Callback.pas',
+  Horse.Core.RouterTree.NextCaller in '..\..\src\Horse.Core.RouterTree.NextCaller.pas',
+  Horse.Exception.Interrupted in '..\..\src\Horse.Exception.Interrupted.pas',
+  Horse.Session in '..\..\src\Horse.Session.pas';
 
 var
   Runner: ITestRunner;

--- a/tests/src/Console.dproj
+++ b/tests/src/Console.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{A4A352F5-2896-4539-AE34-A7DF0D94AF4D}</ProjectGuid>
-        <ProjectVersion>19.3</ProjectVersion>
+        <ProjectVersion>19.4</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <MainSource>Console.dpr</MainSource>
         <Base>True</Base>
@@ -67,7 +67,7 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>$(DCC_UnitSearchPath);modules\.dcp;modules\.dcu;modules;modules\dataset-serialize\src\core;modules\dataset-serialize\src\helpers;modules\dataset-serialize\src\providers;modules\dataset-serialize\src\singletons;modules\dataset-serialize\src\types;modules\horse\src;modules\jhonson\src;modules\restrequest4delphi\src\core;modules\restrequest4delphi\src\interfaces</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>modules\.dcp;modules\.dcu;modules;modules\dataset-serialize\src\core;modules\dataset-serialize\src\helpers;modules\dataset-serialize\src\providers;modules\dataset-serialize\src\singletons;modules\dataset-serialize\src\types;modules\horse\src;modules\jhonson\src;modules\restrequest4delphi\src\core;modules\restrequest4delphi\src\interfaces;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <SanitizedProjectName>Console</SanitizedProjectName>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
@@ -129,7 +129,6 @@
         <DCCReference Include="..\..\src\Horse.Core.Route.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.RouterTree.pas"/>
         <DCCReference Include="..\..\src\Horse.Exception.pas"/>
-        <DCCReference Include="..\..\src\Horse.HTTP.pas"/>
         <DCCReference Include="..\..\src\Horse.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Abstract.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
@@ -150,10 +149,18 @@
         <DCCReference Include="tests\Tests.Commons.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Header.pas"/>
-        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
         <DCCReference Include="tests\Tests.Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Field.pas"/>
+        <DCCReference Include="..\..\src\Horse.Request.pas"/>
+        <DCCReference Include="..\..\src\Horse.Response.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Config.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.Helper.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
+        <DCCReference Include="..\..\src\Horse.Callback.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.RouterTree.NextCaller.pas"/>
+        <DCCReference Include="..\..\src\Horse.Exception.Interrupted.pas"/>
+        <DCCReference Include="..\..\src\Horse.Session.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -184,15 +191,8 @@
                 </Excluded_Packages>
             </Delphi.Personality>
             <Deployment Version="3">
-                <DeployFile LocalName="..\Console.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>Console.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="..\Console.exe" Configuration="CI" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>Console.exe</RemoteName>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -206,8 +206,15 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
+                <DeployFile LocalName="..\Console.exe" Configuration="CI" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Console.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="..\Console.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Console.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -1190,17 +1197,17 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
             </Deployment>
             <Platforms>
                 <Platform value="Linux64">False</Platform>

--- a/tests/src/VCL.dpr
+++ b/tests/src/VCL.dpr
@@ -4,11 +4,7 @@ program VCL;
 {$APPTYPE CONSOLE}
 {$ENDIF}{$STRONGLINKTYPES ON}
 uses
-  Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
-  Horse.Provider.CGI in '..\..\src\Horse.Provider.CGI.pas',
   Horse.Provider.Console in '..\..\src\Horse.Provider.Console.pas',
-  Horse.Provider.Daemon in '..\..\src\Horse.Provider.Daemon.pas',
-  Horse.Provider.ISAPI in '..\..\src\Horse.Provider.ISAPI.pas',
   System.Classes,
   System.SysUtils,
   {$IFDEF TESTINSIGHT}
@@ -31,17 +27,29 @@ uses
   Horse.Core.Route in '..\..\src\Horse.Core.Route.pas',
   Horse.Core.RouterTree in '..\..\src\Horse.Core.RouterTree.pas',
   Horse.Exception in '..\..\src\Horse.Exception.pas',
-  Horse.HTTP in '..\..\src\Horse.HTTP.pas',
   Horse in '..\..\src\Horse.pas',
   Horse.Proc in '..\..\src\Horse.Proc.pas',
   Horse.Provider.Abstract in '..\..\src\Horse.Provider.Abstract.pas',
-  Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
-  Horse.Provider.VCL in '..\..\src\Horse.Provider.VCL.pas',
-  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
   ThirdParty.Posix.Syslog in '..\..\src\ThirdParty.Posix.Syslog.pas',
   Web.WebConst in '..\..\src\Web.WebConst.pas',
   Tests.Horse.Core.Param in 'tests\Tests.Horse.Core.Param.pas',
-  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas';
+  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas',
+  Horse.Request in '..\..\src\Horse.Request.pas',
+  Horse.Response in '..\..\src\Horse.Response.pas',
+  Horse.Callback in '..\..\src\Horse.Callback.pas',
+  Horse.Core.Param.Config in '..\..\src\Horse.Core.Param.Config.pas',
+  Horse.Core.RouterTree.NextCaller in '..\..\src\Horse.Core.RouterTree.NextCaller.pas',
+  Horse.Exception.Interrupted in '..\..\src\Horse.Exception.Interrupted.pas',
+  Horse.Rtti.Helper in '..\..\src\Horse.Rtti.Helper.pas',
+  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
+  Horse.Session in '..\..\src\Horse.Session.pas',
+  Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
+  Horse.Provider.CGI in '..\..\src\Horse.Provider.CGI.pas',
+  Horse.Provider.Daemon in '..\..\src\Horse.Provider.Daemon.pas',
+  Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
+  Horse.Provider.ISAPI in '..\..\src\Horse.Provider.ISAPI.pas',
+  Horse.Provider.VCL in '..\..\src\Horse.Provider.VCL.pas',
+  Horse.WebModule in '..\..\src\Horse.WebModule.pas' {HorseWebModule: TWebModule};
 
 var
   runner: ITestRunner;

--- a/tests/src/VCL.dproj
+++ b/tests/src/VCL.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{090D8F0A-88C5-4ED1-BF6B-7D62B658AA0C}</ProjectGuid>
-        <ProjectVersion>19.3</ProjectVersion>
+        <ProjectVersion>19.4</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <MainSource>VCL.dpr</MainSource>
         <Base>True</Base>
@@ -119,11 +119,7 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.CGI.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Console.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.Daemon.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.ISAPI.pas"/>
         <DCCReference Include="tests\Tests.Api.Vcl.pas"/>
         <DCCReference Include="controllers\Controllers.Api.pas"/>
         <DCCReference Include="tests\Tests.Commons.pas"/>
@@ -138,17 +134,33 @@
         <DCCReference Include="..\..\src\Horse.Core.Route.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.RouterTree.pas"/>
         <DCCReference Include="..\..\src\Horse.Exception.pas"/>
-        <DCCReference Include="..\..\src\Horse.HTTP.pas"/>
         <DCCReference Include="..\..\src\Horse.pas"/>
         <DCCReference Include="..\..\src\Horse.Proc.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Abstract.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.VCL.pas"/>
-        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
         <DCCReference Include="..\..\src\ThirdParty.Posix.Syslog.pas"/>
         <DCCReference Include="..\..\src\Web.WebConst.pas"/>
         <DCCReference Include="tests\Tests.Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Field.pas"/>
+        <DCCReference Include="..\..\src\Horse.Request.pas"/>
+        <DCCReference Include="..\..\src\Horse.Response.pas"/>
+        <DCCReference Include="..\..\src\Horse.Callback.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Config.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.RouterTree.NextCaller.pas"/>
+        <DCCReference Include="..\..\src\Horse.Exception.Interrupted.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.Helper.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
+        <DCCReference Include="..\..\src\Horse.Session.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.CGI.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.Daemon.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.ISAPI.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.VCL.pas"/>
+        <DCCReference Include="..\..\src\Horse.WebModule.pas">
+            <Form>HorseWebModule</Form>
+            <FormType>dfm</FormType>
+            <DesignClass>TWebModule</DesignClass>
+        </DCCReference>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -180,14 +192,13 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="..\VCL.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>VCL.exe</RemoteName>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -197,8 +208,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="OSX32">
+                <DeployFile LocalName="..\VCL.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>VCL.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -1181,17 +1193,17 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
             </Deployment>
             <Platforms>
                 <Platform value="Linux64">False</Platform>


### PR DESCRIPTION
In Parameters Form-data to fetch the passed files we would have to make a loop in the property FWebRequest.Files. This implementation assigns the files passed in the form-data inside the ContentFields property and can be accessed as follows:

``` delphi
Req.ContentFields.Field('paramName').AsStream;
// or
Req.ContentFields.Field('paramName').SaveToFile('file.txt');
```
