### PR TITLE
Add form-data file params in Req.ContentFields

### DIFF
--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -148,6 +148,7 @@ begin
   if ACommand = 'PUT' then
     Result := TMethodType.mtPut;
 end;
+{$ENDIF}
 
 { TLhsBracketsTypeHelper }
 
@@ -172,8 +173,6 @@ begin
       Result := '[like]';
   end;
 end;
-
-{$ENDIF}
 
 { THTTPStatusHelper }
 

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -12,7 +12,8 @@ uses
 {$ELSE}
   System.SysUtils, System.Classes, System.DateUtils, System.Generics.Collections,
 {$ENDIF}
-  Horse.Exception, Horse.Commons, Horse.Core.Param.Field.Brackets;
+  Horse.Exception, Horse.Commons, Horse.Core.Param.Field.Brackets,
+  Horse.Core.Param.Config;
 
 type
   { THorseCoreParamField }
@@ -29,12 +30,16 @@ type
     FReturnUTC: Boolean;
     FTrueValue: string;
     FValue: string;
+    FStream: TStream;
     FLhsBrackets: THorseCoreParamFieldLhsBrackets;
 
     function GetFormatSettings: TFormatSettings;
     procedure RaiseHorseException(const AMessage: string); overload;
     procedure RaiseHorseException(const AMessage: string; const Args: array of const); overload;
     function TryISO8601ToDate(const AValue: string; out Value: TDateTime): Boolean;
+
+    procedure InitializeLhsBrackets(const AParams: TDictionary<string, string>; const AFieldName: string);
+
   public
     function DateFormat(const AValue: string): THorseCoreParamField;
     function InvalidFormatMessage(const AValue: string): THorseCoreParamField;
@@ -45,6 +50,8 @@ type
     function TimeFormat(const AValue: string): THorseCoreParamField;
     function TrueValue(const AValue: string): THorseCoreParamField;
 
+    procedure SaveToFile(const AFileName: String);
+
     function AsBoolean: Boolean;
     function AsCurrency: Currency;
     function AsDate: TDateTime;
@@ -54,12 +61,14 @@ type
     function AsInteger: Integer;
     function AsInt64: Int64;
     function AsISO8601DateTime: TDateTime;
-    function Asstring: string;
+    function AsStream: TStream;
+    function AsString: string;
     function AsTime: TTime;
 
     property LhsBrackets:THorseCoreParamFieldLhsBrackets read FLhsBrackets;
 
-    constructor Create(const AParams: TDictionary<string, string>; const AFieldName: string; const ACheckLhsBrackets: Boolean);
+    constructor Create(const AParams: TDictionary<string, string>; const AFieldName: string); overload;
+    constructor Create(const AStream: TStream; const AFieldName: string); overload;
     destructor Destroy; override;
   end;
 
@@ -72,7 +81,7 @@ var
   LStrParam: string;
 begin
   Result := False;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   if LStrParam <> EmptyStr then
     Result := LowerCase(LStrParam) = LowerCase(FTrueValue);
 end;
@@ -88,7 +97,7 @@ var
   LFormat: TFormatSettings;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
     begin
@@ -107,7 +116,7 @@ var
   LFormat: TFormatSettings;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
     begin
@@ -130,7 +139,7 @@ var
   LStrParam: string;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
     begin
@@ -148,7 +157,7 @@ var
   LStrParam: string;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
       Result := StrToInt64(LStrParam);
@@ -163,7 +172,7 @@ var
   LStrParam: string;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
       Result := StrToInt(LStrParam);
@@ -178,7 +187,7 @@ var
   LStrParam: string;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   if LStrParam <> EmptyStr then
   begin
     if not TryISO8601ToDate(LStrParam, Result) then
@@ -186,7 +195,21 @@ begin
   end;
 end;
 
-function THorseCoreParamField.Asstring: string;
+function THorseCoreParamField.AsStream: TStream;
+begin
+  Result := nil;
+  if FContains then
+  begin
+    Result := FStream;
+    if Assigned(Result) then
+      Result.Position := 0;
+  end
+  else
+  if FRequired then
+    RaiseHorseException(FRequiredMessage, [FFieldName]);
+end;
+
+function THorseCoreParamField.AsString: string;
 begin
   Result := EmptyStr;
   if FContains then
@@ -202,7 +225,7 @@ var
   LFormat: TFormatSettings;
 begin
   Result := 0;
-  LStrParam := Asstring;
+  LStrParam := AsString;
   try
     if LStrParam <> EmptyStr then
     begin
@@ -215,17 +238,23 @@ begin
   end;
 end;
 
-constructor THorseCoreParamField.Create(const AParams: TDictionary<string,
-  string>; const AFieldName: string; const ACheckLhsBrackets: Boolean);
+constructor THorseCoreParamField.Create(const AStream: TStream; const AFieldName: string);
+begin
+  FContains := True;
+  FFieldName := AFieldName;
+  FValue := EmptyStr;
+  FRequired := False;
+  FStream := AStream;
+end;
+
+constructor THorseCoreParamField.Create(const AParams: TDictionary<string, string>; const AFieldName: string);
 var
   LKey: string;
-  LLhsBracketType: TLhsBracketsType;
 begin
   FContains := False;
   FFieldName := AFieldName;
   FValue := EmptyStr;
   FRequired := False;
-  FLhsBrackets := THorseCoreParamFieldLhsBrackets.Create;
 
   for LKey in AParams.Keys do
   begin
@@ -239,17 +268,7 @@ begin
   if FContains then
     FValue := AParams.Items[LKey];
 
-  if ACheckLhsBrackets then
-  begin
-    for LLhsBracketType in TLhsBracketsType do
-    begin
-      if AParams.ContainsKey(FFieldName+LLhsBracketType.ToString) then
-      begin
-        FLhsBrackets.SetValue(LLhsBracketType, AParams.Items[FFieldName+LLhsBracketType.ToString]);
-        FLhsBrackets.Types := FLhsBrackets.Types + [LLhsBracketType];
-      end;
-    end;
-  end;
+  InitializeLhsBrackets(AParams, AFieldName);
 end;
 
 destructor THorseCoreParamField.Destroy;
@@ -275,6 +294,25 @@ begin
     Result.DateSeparator := '-';
   Result.ShortDateFormat := FDateFormat;
   Result.ShortTimeFormat := FTimeFormat;
+end;
+
+procedure THorseCoreParamField.InitializeLhsBrackets(const AParams: TDictionary<string, string>; const AFieldName: string);
+var
+  LLhsBracketType: TLhsBracketsType;
+begin
+  FLhsBrackets := THorseCoreParamFieldLhsBrackets.Create;
+
+  if THorseCoreParamConfig.GetInstance.CheckLhsBrackets then
+  begin
+    for LLhsBracketType := Low(TLhsBracketsType) to High(TLhsBracketsType) do
+    begin
+      if AParams.ContainsKey(FFieldName + LLhsBracketType.ToString) then
+      begin
+        FLhsBrackets.SetValue(LLhsBracketType, AParams.Items[FFieldName+LLhsBracketType.ToString]);
+        FLhsBrackets.Types := FLhsBrackets.Types + [LLhsBracketType];
+      end;
+    end;
+  end;
 end;
 
 function THorseCoreParamField.InvalidFormatMessage(const AValue: string): THorseCoreParamField;
@@ -319,6 +357,23 @@ function THorseCoreParamField.ReturnUTC(const AValue: Boolean): THorseCoreParamF
 begin
   Result := Self;
   FReturnUTC := AValue;
+end;
+
+procedure THorseCoreParamField.SaveToFile(const AFileName: String);
+var
+  LMemoryStream: TMemoryStream;
+begin
+  if AsStream = nil then
+    Exit;
+
+  LMemoryStream := TMemoryStream.Create;
+  try
+    LMemoryStream.LoadFromStream(AsStream);
+    LMemoryStream.Position := 0;
+    LMemoryStream.SaveToFile(AFileName);
+  finally
+    LMemoryStream.Free;
+  end;
 end;
 
 function THorseCoreParamField.TimeFormat(const AValue: string): THorseCoreParamField;

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -20,6 +20,7 @@ type
   THorseCoreParam = class
   private
     FParams: THorseList;
+    FFiles: TDictionary<String, TStream>;
     FFields: TDictionary<string, THorseCoreParamField>;
     FContent: TStrings;
     FRequired: Boolean;
@@ -29,6 +30,8 @@ type
     function GetContent: TStrings;
     function AsString(const AKey: string): string;
     procedure ClearFields;
+
+    function NewField(const AKey: String): THorseCoreParamField;
   public
     function Required(const AValue: Boolean): THorseCoreParam;
     function Field(const AKey: string): THorseCoreParamField;
@@ -40,6 +43,8 @@ type
     property Count: Integer read GetCount;
     property Items[const AKey: string]: string read GetItem; default;
     property Dictionary: THorseList read GetDictionary;
+
+    function AddStream(const AKey: string; const AContent: TStream): THorseCoreParam;
     constructor Create(const AParams: THorseList);
     destructor Destroy; override;
   end;
@@ -76,6 +81,8 @@ begin
   FParams.Free;
   FContent.Free;
   ClearFields;
+  if Assigned(FFiles) then
+    FFiles.Free;
   inherited;
 end;
 
@@ -90,7 +97,7 @@ begin
   if FFields.ContainsKey(LFieldName) then
     Exit(FFields.Items[LFieldName]);
 
-  Result := THorseCoreParamField.create(FParams, AKey, THorseCoreParamConfig.GetInstance.CheckLhsBrackets);
+  Result := NewField(AKey);
   try
     Result
       .Required(FRequired)
@@ -106,6 +113,15 @@ begin
     Result.Free;
     raise;
   end;
+end;
+
+function THorseCoreParam.AddStream(const AKey: string; const AContent: TStream): THorseCoreParam;
+begin
+  Result := Self;
+  if not Assigned(FFiles) then
+    FFiles := TDictionary<String, TStream>.Create;
+
+  FFiles.AddOrSetValue(AKey, AContent);
 end;
 
 function THorseCoreParam.AsString(const AKey: string): string;
@@ -161,6 +177,25 @@ begin
       Exit(FParams[LKey]);
   end;
   Result := EmptyStr;
+end;
+
+function THorseCoreParam.NewField(const AKey: String): THorseCoreParamField;
+var
+  LKey: String;
+begin
+  if Assigned(FFiles) then
+  begin
+    for LKey in FFiles.Keys do
+    begin
+      if AnsiSameText(LKey, AKey) then
+      begin
+        Result := THorseCoreParamField.Create(FFiles.Items[LKey], AKey);
+        Exit;
+      end;
+    end;
+  end;
+
+  Result := THorseCoreParamField.create(FParams, AKey);
 end;
 
 function THorseCoreParam.Required(const AValue: Boolean): THorseCoreParam;

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -135,6 +135,10 @@ begin
   FContentFields := THorseCoreParam.Create(THorseList.Create).Required(False);
   if (not CanLoadContentFields) then
     Exit;
+
+  for I := 0 to Pred(FWebRequest.Files.Count) do
+    FContentFields.AddStream(FWebRequest.Files[I].FieldName, FWebRequest.Files[I].Stream);
+
   for I := 0 to Pred(FWebRequest.ContentFields.Count) do
     FContentFields.Dictionary.AddOrSetValue(FWebRequest.ContentFields.Names[I], FWebRequest.ContentFields.ValueFromIndex[I]);
 end;

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -13,7 +13,6 @@ uses
   Horse.Core.Route in '..\..\src\Horse.Core.Route.pas',
   Horse.Core.RouterTree in '..\..\src\Horse.Core.RouterTree.pas',
   Horse.Exception in '..\..\src\Horse.Exception.pas',
-  Horse.HTTP in '..\..\src\Horse.HTTP.pas',
   Horse in '..\..\src\Horse.pas',
   Horse.Provider.Abstract in '..\..\src\Horse.Provider.Abstract.pas',
   Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
@@ -39,10 +38,19 @@ uses
   Tests.Commons in 'tests\Tests.Commons.pas',
   Horse.Core.Param in '..\..\src\Horse.Core.Param.pas',
   Horse.Core.Param.Header in '..\..\src\Horse.Core.Param.Header.pas',
-  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
   Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
   Tests.Horse.Core.Param in 'tests\Tests.Horse.Core.Param.pas',
-  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas';
+  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas',
+  Horse.Request in '..\..\src\Horse.Request.pas',
+  Horse.Response in '..\..\src\Horse.Response.pas',
+  Horse.Core.Param.Config in '..\..\src\Horse.Core.Param.Config.pas',
+  Horse.Rtti.Helper in '..\..\src\Horse.Rtti.Helper.pas',
+  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
+  Horse.Callback in '..\..\src\Horse.Callback.pas',
+  Horse.Core.RouterTree.NextCaller in '..\..\src\Horse.Core.RouterTree.NextCaller.pas',
+  Horse.Exception.Interrupted in '..\..\src\Horse.Exception.Interrupted.pas',
+  Horse.Session in '..\..\src\Horse.Session.pas',
+  Horse.Core.Param.Field.Brackets in '..\..\src\Horse.Core.Param.Field.Brackets.pas';
 
 var
   Runner: ITestRunner;

--- a/tests/src/Console.dproj
+++ b/tests/src/Console.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{A4A352F5-2896-4539-AE34-A7DF0D94AF4D}</ProjectGuid>
-        <ProjectVersion>19.3</ProjectVersion>
+        <ProjectVersion>19.4</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <MainSource>Console.dpr</MainSource>
         <Base>True</Base>
@@ -129,7 +129,6 @@
         <DCCReference Include="..\..\src\Horse.Core.Route.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.RouterTree.pas"/>
         <DCCReference Include="..\..\src\Horse.Exception.pas"/>
-        <DCCReference Include="..\..\src\Horse.HTTP.pas"/>
         <DCCReference Include="..\..\src\Horse.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Abstract.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
@@ -150,10 +149,19 @@
         <DCCReference Include="tests\Tests.Commons.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Header.pas"/>
-        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
         <DCCReference Include="tests\Tests.Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Field.pas"/>
+        <DCCReference Include="..\..\src\Horse.Request.pas"/>
+        <DCCReference Include="..\..\src\Horse.Response.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Config.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.Helper.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
+        <DCCReference Include="..\..\src\Horse.Callback.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.RouterTree.NextCaller.pas"/>
+        <DCCReference Include="..\..\src\Horse.Exception.Interrupted.pas"/>
+        <DCCReference Include="..\..\src\Horse.Session.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Field.Brackets.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -184,15 +192,8 @@
                 </Excluded_Packages>
             </Delphi.Personality>
             <Deployment Version="3">
-                <DeployFile LocalName="..\Console.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>Console.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="..\Console.exe" Configuration="CI" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>Console.exe</RemoteName>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -206,8 +207,15 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
+                <DeployFile LocalName="..\Console.exe" Configuration="CI" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Console.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="..\Console.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>Console.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -1190,17 +1198,17 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
             </Deployment>
             <Platforms>
                 <Platform value="Linux64">False</Platform>

--- a/tests/src/VCL.dpr
+++ b/tests/src/VCL.dpr
@@ -4,11 +4,7 @@ program VCL;
 {$APPTYPE CONSOLE}
 {$ENDIF}{$STRONGLINKTYPES ON}
 uses
-  Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
-  Horse.Provider.CGI in '..\..\src\Horse.Provider.CGI.pas',
   Horse.Provider.Console in '..\..\src\Horse.Provider.Console.pas',
-  Horse.Provider.Daemon in '..\..\src\Horse.Provider.Daemon.pas',
-  Horse.Provider.ISAPI in '..\..\src\Horse.Provider.ISAPI.pas',
   System.Classes,
   System.SysUtils,
   {$IFDEF TESTINSIGHT}
@@ -31,17 +27,30 @@ uses
   Horse.Core.Route in '..\..\src\Horse.Core.Route.pas',
   Horse.Core.RouterTree in '..\..\src\Horse.Core.RouterTree.pas',
   Horse.Exception in '..\..\src\Horse.Exception.pas',
-  Horse.HTTP in '..\..\src\Horse.HTTP.pas',
   Horse in '..\..\src\Horse.pas',
   Horse.Proc in '..\..\src\Horse.Proc.pas',
   Horse.Provider.Abstract in '..\..\src\Horse.Provider.Abstract.pas',
-  Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
-  Horse.Provider.VCL in '..\..\src\Horse.Provider.VCL.pas',
-  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
   ThirdParty.Posix.Syslog in '..\..\src\ThirdParty.Posix.Syslog.pas',
   Web.WebConst in '..\..\src\Web.WebConst.pas',
   Tests.Horse.Core.Param in 'tests\Tests.Horse.Core.Param.pas',
-  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas';
+  Horse.Core.Param.Field in '..\..\src\Horse.Core.Param.Field.pas',
+  Horse.Request in '..\..\src\Horse.Request.pas',
+  Horse.Response in '..\..\src\Horse.Response.pas',
+  Horse.Callback in '..\..\src\Horse.Callback.pas',
+  Horse.Core.Param.Config in '..\..\src\Horse.Core.Param.Config.pas',
+  Horse.Core.RouterTree.NextCaller in '..\..\src\Horse.Core.RouterTree.NextCaller.pas',
+  Horse.Exception.Interrupted in '..\..\src\Horse.Exception.Interrupted.pas',
+  Horse.Rtti.Helper in '..\..\src\Horse.Rtti.Helper.pas',
+  Horse.Rtti in '..\..\src\Horse.Rtti.pas',
+  Horse.Session in '..\..\src\Horse.Session.pas',
+  Horse.Provider.Apache in '..\..\src\Horse.Provider.Apache.pas',
+  Horse.Provider.CGI in '..\..\src\Horse.Provider.CGI.pas',
+  Horse.Provider.Daemon in '..\..\src\Horse.Provider.Daemon.pas',
+  Horse.Provider.IOHandleSSL in '..\..\src\Horse.Provider.IOHandleSSL.pas',
+  Horse.Provider.ISAPI in '..\..\src\Horse.Provider.ISAPI.pas',
+  Horse.Provider.VCL in '..\..\src\Horse.Provider.VCL.pas',
+  Horse.WebModule in '..\..\src\Horse.WebModule.pas' {HorseWebModule: TWebModule},
+  Horse.Core.Param.Field.Brackets in '..\..\src\Horse.Core.Param.Field.Brackets.pas';
 
 var
   runner: ITestRunner;

--- a/tests/src/VCL.dproj
+++ b/tests/src/VCL.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{090D8F0A-88C5-4ED1-BF6B-7D62B658AA0C}</ProjectGuid>
-        <ProjectVersion>19.3</ProjectVersion>
+        <ProjectVersion>19.4</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <MainSource>VCL.dpr</MainSource>
         <Base>True</Base>
@@ -119,11 +119,7 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.CGI.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Console.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.Daemon.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.ISAPI.pas"/>
         <DCCReference Include="tests\Tests.Api.Vcl.pas"/>
         <DCCReference Include="controllers\Controllers.Api.pas"/>
         <DCCReference Include="tests\Tests.Commons.pas"/>
@@ -138,17 +134,34 @@
         <DCCReference Include="..\..\src\Horse.Core.Route.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.RouterTree.pas"/>
         <DCCReference Include="..\..\src\Horse.Exception.pas"/>
-        <DCCReference Include="..\..\src\Horse.HTTP.pas"/>
         <DCCReference Include="..\..\src\Horse.pas"/>
         <DCCReference Include="..\..\src\Horse.Proc.pas"/>
         <DCCReference Include="..\..\src\Horse.Provider.Abstract.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
-        <DCCReference Include="..\..\src\Horse.Provider.VCL.pas"/>
-        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
         <DCCReference Include="..\..\src\ThirdParty.Posix.Syslog.pas"/>
         <DCCReference Include="..\..\src\Web.WebConst.pas"/>
         <DCCReference Include="tests\Tests.Horse.Core.Param.pas"/>
         <DCCReference Include="..\..\src\Horse.Core.Param.Field.pas"/>
+        <DCCReference Include="..\..\src\Horse.Request.pas"/>
+        <DCCReference Include="..\..\src\Horse.Response.pas"/>
+        <DCCReference Include="..\..\src\Horse.Callback.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Config.pas"/>
+        <DCCReference Include="..\..\src\Horse.Core.RouterTree.NextCaller.pas"/>
+        <DCCReference Include="..\..\src\Horse.Exception.Interrupted.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.Helper.pas"/>
+        <DCCReference Include="..\..\src\Horse.Rtti.pas"/>
+        <DCCReference Include="..\..\src\Horse.Session.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.Apache.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.CGI.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.Daemon.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.IOHandleSSL.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.ISAPI.pas"/>
+        <DCCReference Include="..\..\src\Horse.Provider.VCL.pas"/>
+        <DCCReference Include="..\..\src\Horse.WebModule.pas">
+            <Form>HorseWebModule</Form>
+            <FormType>dfm</FormType>
+            <DesignClass>TWebModule</DesignClass>
+        </DCCReference>
+        <DCCReference Include="..\..\src\Horse.Core.Param.Field.Brackets.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -180,14 +193,13 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="..\VCL.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>VCL.exe</RemoteName>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -197,8 +209,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="OSX32">
+                <DeployFile LocalName="..\VCL.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>VCL.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -1181,17 +1194,17 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
             </Deployment>
             <Platforms>
                 <Platform value="Linux64">False</Platform>


### PR DESCRIPTION
In Parameters Form-data to fetch the passed files we would have to make a loop in the property FWebRequest.Files. This implementation assigns the files passed in the form-data inside the ContentFields property and can be accessed as follows:

``` delphi
Req.ContentFields.Field('paramName').AsStream;
// or
Req.ContentFields.Field('paramName').SaveToFile('file.txt');
```