### PR TITLE
Middleware nomeados para identifica-lo no método

### DIFF
--- a/src/Horse.Callback.pas
+++ b/src/Horse.Callback.pas
@@ -4,6 +4,8 @@ unit Horse.Callback;
   {$MODE DELPHI}{$H+}
 {$ENDIF}
 
+{$DEFINE CALLBACKNAMED}
+
 interface
 
 uses
@@ -18,16 +20,27 @@ type
 {$IF DEFINED(FPC)}
   THorseCallbackRequest = procedure(AReq: THorseRequest);
   THorseCallbackResponse = procedure(ARes: THorseResponse);
-  THorseCallbackRequestResponse = procedure(AReq: THorseRequest; ARes: THorseResponse);
-  THorseCallback = procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
   TCallNextPath = function(var APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean of object;
+  {$IFDEF CALLBACKNAMED}
+    THorseCallbackRequestResponse = procedure(AReq: THorseRequest; ARes: THorseResponse; ACallbackName: String);
+    THorseCallback = procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc; ACallbackName: String);
+  {$ELSE}
+    THorseCallbackRequestResponse = procedure(AReq: THorseRequest; ARes: THorseResponse);
+    THorseCallback = procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
+  {$ENDIF}
 {$ELSE}
   THorseCallbackRequest = reference to procedure(AReq: THorseRequest);
   THorseCallbackResponse = reference to procedure(ARes: THorseResponse);
-  THorseCallbackRequestResponse = reference to procedure(AReq: THorseRequest; ARes: THorseResponse);
-  THorseCallback = reference to procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
   TCallNextPath = reference to function(var APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean;
+  {$IFDEF CALLBACKNAMED}
+    THorseCallbackRequestResponse = reference to procedure(AReq: THorseRequest; ARes: THorseResponse; ACallbackName: String);
+    THorseCallback = reference to procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc; ACallbackName: String);
+  {$ELSE}
+    THorseCallbackRequestResponse = reference to procedure(AReq: THorseRequest; ARes: THorseResponse);
+    THorseCallback = reference to procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
+  {$ENDIF}
 {$ENDIF}
+ TMiddlewares = TObjectDictionary<string, THorseCallback>;
 
 implementation
 


### PR DESCRIPTION
Recurso para nomear os middleware ao coloca-lo em uso, possibilitado assim a identificação na chamada do método e validar que é o middleware correspondente.
Recurso não quebra código anterior as modificações, se a diretiva CALLBACKNAMED na unit Horse.Callback.pas não for definida.