### PR TITLE
Nova funcionalidade para envio de stream na classe THorseResponse

### DIFF
--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -29,6 +29,7 @@ type
     function RedirectTo(const ALocation: string; const AStatus: THTTPStatus): THorseResponse; overload;
     function Status(const AStatus: Integer): THorseResponse; overload;
     function Status(const AStatus: THTTPStatus): THorseResponse; overload;
+    function SendFile(const AFileStream: TStream; const AFileName: string; const AContentType: string): THorseResponse; overload;
     function SendFile(const AFileName: string; const AContentType: string = ''): THorseResponse; overload;
     function Download(const AFileName: string): THorseResponse; overload;
     function Render(const AFileName: string): THorseResponse; overload;
@@ -117,6 +118,28 @@ function THorseResponse.Status(const AStatus: THTTPStatus): THorseResponse;
 begin
   {$IF DEFINED(FPC)}FWebResponse.Code{$ELSE}FWebResponse.StatusCode{$ENDIF} := AStatus.ToInteger;
   Result := Self;
+end;
+
+function THorseResponse.SendFile(const AFileStream: TStream; const AFileName: string; const AContentType: string): THorseResponse;
+var
+  LFileName: string;
+begin
+  Result := Self;
+
+  LFileName := ExtractFileName(AFileName);
+  FWebResponse.FreeContentStream := False;
+  FWebResponse.ContentLength := AFileStream.Size;
+  FWebResponse.ContentStream := AFileStream;
+  FWebResponse.SetCustomHeader('Content-Disposition', Format('inline; filename="%s"', [LFileName]));
+  if (AContentType <> EmptyStr) then
+    FWebResponse.ContentType := AContentType
+  else
+    FWebResponse.ContentType := 'application/octet-stream';
+  {$IF DEFINED(FPC)}
+  FWebResponse.SendContent;
+  {$ELSE}
+  FWebResponse.SendResponse;
+  {$ENDIF}
 end;
 
 function THorseResponse.SendFile(const AFileName: string; const AContentType: string): THorseResponse;

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -31,6 +31,7 @@ type
     function Status(const AStatus: THTTPStatus): THorseResponse; overload;
     function SendFile(const AFileStream: TStream; const AFileName: string; const AContentType: string): THorseResponse; overload;
     function SendFile(const AFileName: string; const AContentType: string = ''): THorseResponse; overload;
+    function Download(const AFileStream: TStream; const AFileName: string; const AContentType: string): THorseResponse; overload;
     function Download(const AFileName: string): THorseResponse; overload;
     function Render(const AFileName: string): THorseResponse; overload;
     function Status: Integer; overload;
@@ -164,6 +165,28 @@ begin
   finally
     LFile.Free;
   end;
+end;
+
+function THorseResponse.Download(const AFileStream: TStream;
+  const AFileName: string; const AContentType: string): THorseResponse;
+var
+  LFileName: string;
+begin
+  Result := Self;
+  LFileName := ExtractFileName(AFileName);
+  FWebResponse.FreeContentStream := False;
+  FWebResponse.ContentLength := AFileStream.Size;
+  FWebResponse.ContentStream := AFileStream;
+  FWebResponse.SetCustomHeader('Content-Disposition', Format('attachment; filename="%s"', [LFileName]));
+  if (AContentType <> EmptyStr) then
+    FWebResponse.ContentType := AContentType
+  else
+    FWebResponse.ContentType := 'application/octet-stream';
+  {$IF DEFINED(FPC)}
+  FWebResponse.SendContent;
+  {$ELSE}
+  FWebResponse.SendResponse;
+  {$ENDIF}
 end;
 
 function THorseResponse.Download(const AFileName: string): THorseResponse;


### PR DESCRIPTION
Criado uma nova funcionalidade na classe THorseResponse igual a SendFile que passa um arquivo, nesse nova rotina SendFile é possível passar um Stream de um arquivo.

THorse.Get('export',
procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
var
lFileStream: TFileStream;
begin
lFileStream := TFileStream.Create('C:\horse\samples\delphi\vcl\Horse-SendFile.pdf', fmOpenRead);
try
Res.SendFile(lFileStream, 'Horse-SendFile.pdf', 'application/pdf');
finally
lFileStream.Free;
end;
end);

Testado

* Delphi
* Lazarus