### PR TITLE
Fixed header reading in Apache for Delphi

### DIFF
--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -11,14 +11,22 @@ uses
   SysUtils, Classes, Generics.Collections, fpHTTP, fphttpserver, httpprotocol, HTTPDefs,
 {$ELSE}
   System.Classes, System.SysUtils, System.Generics.Collections,
-  Web.HTTPApp, IdCustomHTTPServer, IdHeaderList, Horse.Rtti,
+  Web.HTTPApp, IdCustomHTTPServer, IdHeaderList,
+  Horse.Rtti,
+{$IF DEFINED(HORSE_APACHE)}
+  Web.ApacheHTTP, Web.HTTPD24,
+{$ENDIF}
 {$ENDIF}
   Horse.Core.Param, Horse.Commons, Horse.Rtti.Helper;
 
 type
   THorseCoreParamHeader = class
   private
-    class function GetHeadersList(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF}): TStrings;
+{$IF DEFINED(FPC)}
+    class function GetHeadersList(const AWebRequest: TRequest): TStrings;
+{$ELSE}
+    class function GetHeadersList(const AWebRequest: TWebRequest): TStrings;
+{$ENDIF}
   public
     class function GetHeaders(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF}): THorseList;
   end;
@@ -41,7 +49,7 @@ begin
         LValue := LHeaders.Values[LName];
         Result.AddOrSetValue(LName, Trim(LValue));
       end;
-      {$IF DEFINED(FPC)}
+{$IF DEFINED(FPC)}
       for I := Integer(Low(THeader)) to Integer(High(THeader)) do
       begin
         LName := HTTPHeaderNames[THeader(I)];
@@ -49,7 +57,7 @@ begin
         if not LValue.Trim.IsEmpty then
           Result.AddOrSetValue(LName, LValue);
       end;
-      {$ENDIF}
+{$ENDIF}
     finally
       LHeaders.Free;
     end;
@@ -59,39 +67,68 @@ begin
   end;
 end;
 
-class function THorseCoreParamHeader.GetHeadersList(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF}): TStrings;
-{$IF NOT DEFINED(HORSE_ISAPI)}
+{$IF DEFINED(FPC)}
+class function THorseCoreParamHeader.GetHeadersList(const AWebRequest: TRequest): TStrings;
 var
-  LRequest: {$IF DEFINED(FPC)} TFPHTTPConnectionRequest {$ELSE} TIdHTTPRequestInfo {$ENDIF};
-  {$IF NOT DEFINED(FPC)}
-  LObject: TObject;
-  {$ENDIF}
-{$ENDIF}
+  LRequest: TFPHTTPConnectionRequest;
 begin
-  Result := TStringList.Create;
+  Result := TStringList.create;
   try
-    Result.NameValueSeparator := ':';
-    {$IF DEFINED(FPC)}
-      if AWebRequest is TFPHTTPConnectionRequest then
-      begin
-        LRequest := TFPHTTPConnectionRequest(AWebRequest);
-        Result.NameValueSeparator := '=';
-        Result.Text := LRequest.CustomHeaders.Text;
-      end;
-    {$ELSEIF DEFINED(HORSE_ISAPI)}
-      Result.Text := AWebRequest.GetFieldByName('ALL_RAW');
-    {$ELSE}
-      LObject := THorseRtti.GetInstance.GetType(AWebRequest.ClassType).FieldValueAsObject(AWebRequest, 'FRequestInfo');
-      if (Assigned(LObject)) and (LObject is TIdHTTPRequestInfo) then
-      begin
-        LRequest := TIdHTTPRequestInfo(LObject);
-        Result.Text := LRequest.RawHeaders.Text;
-      end;
-    {$ENDIF}
+    if AWebRequest is TFPHTTPConnectionRequest then
+    begin
+      LRequest := TFPHTTPConnectionRequest(AWebRequest);
+      Result.NameValueSeparator := '=';
+      Result.Text := LRequest.CustomHeaders.Text;
+    end;
   except
     Result.Free;
     raise;
   end;
 end;
+{$ELSE}
+class function THorseCoreParamHeader.GetHeadersList(const AWebRequest: TWebRequest): TStrings;
+{$IF DEFINED(HORSE_APACHE)}
+type
+  Papr_table_entry_t = ^apr_table_entry_t;
+
+var
+  LHeadersArray: papr_array_header_t;
+  LHeadersEntry: Papr_table_entry_t;
+  I: Integer;
+{$ELSEIF NOT DEFINED(HORSE_ISAPI)}
+var
+  LRequest: TIdHTTPRequestInfo;
+  LObject: TObject;
+{$ENDIF}
+begin
+  Result := TStringList.create;
+  try
+    Result.NameValueSeparator := ':';
+
+{$IF DEFINED(HORSE_ISAPI)}
+    Result.Text := AWebRequest.GetFieldByName('ALL_RAW');
+{$ELSEIF DEFINED(HORSE_APACHE)}
+    LHeadersArray := papr_array_header_t(Prequest_rec(TApacheRequest(AWebRequest).HTTPDRequest)^.headers_in);
+    LHeadersEntry := Papr_table_entry_t(LHeadersArray^.elts);
+
+    for I := 0 to Pred(LHeadersArray^.nelts) do
+    begin
+      Result.Add(string(LHeadersEntry^.key) + Result.NameValueSeparator + string(LHeadersEntry^.val));
+      Inc(LHeadersEntry);
+    end;
+{$ELSE}
+    LObject := THorseRtti.GetInstance.GetType(AWebRequest.ClassType).FieldValueAsObject(AWebRequest, 'FRequestInfo');
+    if (Assigned(LObject)) and (LObject is TIdHTTPRequestInfo) then
+    begin
+      LRequest := TIdHTTPRequestInfo(LObject);
+      Result.Text := LRequest.RawHeaders.Text;
+    end
+{$ENDIF}
+  except
+    Result.Free;
+    raise;
+  end;
+end;
+{$ENDIF}
 
 end.


### PR DESCRIPTION
```delphi
uses Horse, Web.HTTPD24Impl;

var
  ApacheModuleData: TApacheModuleData;

exports
  ApacheModuleData name 'apache_horse_module';

begin
  THorse.DefaultModule := @ApacheModuleData;
  THorse.HandlerName := 'apache_horse_module-handle';

  THorse.Get('/ping',
    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
    begin
      Res.Send('pong: ' + Req.Headers.Field('CONNECTION').AsString);
    end);

  THorse.Listen;
end.
```