### PR TITLE
Add new LHS Brackets: Contains, StartsWith and EndsWith

### DIFF
--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -110,7 +110,8 @@ type
     Download);
 
   TMessageType = (Default, Error, Warning, Information);
-  TLhsBracketsType = (Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, Range, Like);
+  TLhsBracketsType = (Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, Range, Like,
+    Contains, StartsWith, EndsWith);
 {$SCOPEDENUMS OFF}
 
   TLhsBrackets = set of TLhsBracketsType;
@@ -233,6 +234,12 @@ begin
       Result := '[range]';
     TLhsBracketsType.Like:
       Result := '[like]';
+    TLhsBracketsType.Contains:
+      Result := '[contains]';
+    TLhsBracketsType.StartsWith:
+      Result := '[startsWith]';
+    TLhsBracketsType.EndsWith:
+      Result := '[endsWith]';
   end;
 end;
 

--- a/src/Horse.Core.Param.Field.Brackets.pas
+++ b/src/Horse.Core.Param.Field.Brackets.pas
@@ -28,6 +28,9 @@ type
     FRange: string;
     FLike: string;
     FTypes: TLhsBrackets;
+    FContains: string;
+    FStartsWith: string;
+    FEndsWith: string;
   public
     property Eq: string read FEq;
     property Ne: string read FNe;
@@ -37,6 +40,9 @@ type
     property Gte: string read FGte;
     property Range: string read FRange;
     property Like: string read FLike;
+    property Contains: string read FContains;
+    property StartsWith: string read FStartsWith;
+    property EndsWith: string read FEndsWith;
     property Types: TLhsBrackets read FTypes write FTypes;
     procedure SetValue(const AType: TLhsBracketsType; const AValue: string);
     function GetValue(const AType: TLhsBracketsType): string;
@@ -63,6 +69,12 @@ begin
       FRange := AValue;
     TLhsBracketsType.Like:
       FLike := AValue;
+    TLhsBracketsType.Contains:
+      FContains := AValue;
+    TLhsBracketsType.StartsWith:
+      FStartsWith := AValue;
+    TLhsBracketsType.EndsWith:
+      FEndsWith := AValue;
   end;
 end;
 
@@ -83,6 +95,12 @@ begin
       Result := FRange;
     TLhsBracketsType.Like:
       Result := FLike;
+    TLhsBracketsType.Contains:
+      Result := FContains;
+    TLhsBracketsType.StartsWith:
+      Result := FStartsWith;
+    TLhsBracketsType.EndsWith:
+      Result := FEndsWith;
   else
     Result := FEq;
   end;


### PR DESCRIPTION
Add new LHS bracket options for working with strings:

- Contains: %example%
- StartsWith: example%
- EndsWith: %example


`http://localhost:9000/ping?test[contains]=abc&test[startsWith]=def&test[endsWith]=ghi`

Based on: https://subscription.packtpub.com/book/web-development/9781800560635/8/ch08lvl1sec40/filtering-api-content