### PR TITLE
Created a overload constructor with string parameter

### DIFF
--- a/src/Horse.Exception.Interrupted.pas
+++ b/src/Horse.Exception.Interrupted.pas
@@ -15,7 +15,8 @@ uses
 
 type
   EHorseCallbackInterrupted = class(Exception)
-    constructor Create; reintroduce;
+    constructor Create; reintroduce; overload;
+    constructor Create(AMessage: string); reintroduce; overload;
   end;
 
 implementation
@@ -23,6 +24,11 @@ implementation
 constructor EHorseCallbackInterrupted.Create;
 begin
   inherited Create(EmptyStr);
+end;
+
+constructor EHorseCallbackInterrupted.Create(AMessage: string);
+begin
+  inherited Create(AMessage);
 end;
 
 end.


### PR DESCRIPTION
When exception of this type is dispared in middleware JWT, don't show a message with a reason the exception. 