### PR TITLE
Fix uses clause of Horse.Exception when FPC is defined

### DIFF
--- a/src/Horse.Exception.pas
+++ b/src/Horse.Exception.pas
@@ -11,7 +11,7 @@ uses
   SysUtils,
   fpjson,
   jsonparser,
-  TypInfo;
+  TypInfo,
 {$ELSE}
   System.SysUtils,
   System.JSON,


### PR DESCRIPTION
Compilation of `samples/lazarus/console/Console.lpr` with FPC fails at `Horse.Exception` unit, due to a semicolon before `Horse.Commons` in the uses clause, from the point of view of FPC.