### PR TITLE
Na versão Seattle o Body do Request não esta reconhecendo caracteres especiais

### DIFF
--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -69,7 +69,11 @@ implementation
 
 function THorseRequest.Body: string;
 begin
+{$IF CompilerVersion <= 31.0}
+  Result := TEncoding.UTF8.GetString(BytesOf(FWebRequest.RawContent));
+{$ELSE}
   Result := FWebRequest.Content;
+{$ENDIF}
 end;
 
 function THorseRequest.Body(const ABody: TObject): THorseRequest;


### PR DESCRIPTION
Utilizando o windows, postman e Delphi Seattle.
Conteúdo do Body:
`{
    "nome": "TIPOSEPARACAO",
    "descricao": "Tipo de separação"
}`

Na api, na chegada do Request.Body:
`{ "nome": "TIPOSEPARACAO",'#$D#$A'    "descricao": "Tipo de separaÃ§Ã£o"'}`

Sugestão de correção no metodo Body do Horse.Request
`function THorseRequest.Body: string;
begin
{$IF CompilerVersion <= 31.0}
  Result := TEncoding.UTF8.GetString(BytesOf(FWebRequest.RawContent));
{$ELSE}
  Result := FWebRequest.Content;
{$ENDIF}
end;`