### PR TITLE
Ajuste para evitar o erro E2003 Undeclared identifier: 'TMimeTypes' para Delphi Tokyo

### DIFF
--- a/src/Horse.Mime.pas
+++ b/src/Horse.Mime.pas
@@ -4,7 +4,7 @@ unit Horse.Mime;
   {$MODE DELPHI}{$H+}
 {$ENDIF}
 
-{$IF DEFINED(FPC) OR (CompilerVersion < 32.0)}
+{$IF DEFINED(FPC) OR (CompilerVersion <= 32.0)}
   {$DEFINE UseTHorseMimeTypesExt}
 {$ENDIF}
 


### PR DESCRIPTION
Ajuste na classe Horse.Mime.pas para evitar o erro **E2003 Undeclared identifier: 'TMimeTypes'** para Delphi Tokyo.

A classe TMimeTypes foi lançada na versão Delphi Tokyo 10.2.3 conforme o link: [10.2 Tokyo - Release 3](https://docwiki.embarcadero.com/RADStudio/Tokyo/en/10.2_Tokyo_-_Release_3), versões anteriores gera erro.

* Essa alteração não afeta outras versões ou Lazarus.

Origem do pull request:

![image](https://github.com/HashLoad/horse/assets/20980984/8115a944-01a5-4689-8692-3c1383f73796)
