### PR TITLE
Implementacoes para tratamento de QueryParams como List

### DIFF
--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -247,6 +247,10 @@ begin
     LKey := Copy(LItem, 1, LEqualFirstPos - 1);
     LValue := Copy(LItem, LEqualFirstPos + 1, Length(LItem));
     FQuery.Dictionary.AddOrSetValue(LKey, LValue);
+    if not FQuery.Dictionary.ContainsKey(LKey) then
+      FQuery.Dictionary.AddOrSetValue(LKey, LValue)
+    else
+      FQuery.Dictionary[LKey] := FQuery.Dictionary[LKey] +','+ LValue;
   end;
 end;
 


### PR DESCRIPTION
Implementado o método AsList<T> na classe THorseCoreParamField para converter automaticamente os valores separados por vírgula do parâmetro de consulta em uma lista do tipo especificado. Adicionei suporte para os tipos Integer, Int64, Double, String, Variant, DateTime, Date e Time. Utilizei TValue para conversão de tipo e tratamento de exceções para tipos não suportados.

Atualizado o método InitializeQuery na classe THorseRequest para incluir a condição que permite concatenar os valores separados por vírgula quando houver repetição de QueryParam.