### PR TITLE
The HORSE_NOPROVIDER define has been included. It allows packages to …

### DIFF
--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -21,6 +21,9 @@ uses
   {$ELSEIF DEFINED(HORSE_LCL)}
   Horse.Provider.FPC.LCL,
   {$ENDIF}
+{$ELSEIF DEFINED(HORSE_NOPROVIDER)}
+  System.SysUtils,
+  Horse.Provider.Abstract,
 {$ELSE}
   System.SysUtils,
   Horse.Provider.Console,
@@ -99,6 +102,8 @@ type
   THorseProvider =
   {$IF DEFINED(FPC)}
     Horse.Provider.FPC.HTTPApplication.THorseProvider;
+  {$ELSEIF DEFINED(HORSE_NOPROVIDER)}
+    Horse.Provider.Abstract.THorseProviderAbstract;
   {$ELSE}
     Horse.Provider.Console.THorseProvider;
   {$ENDIF}


### PR DESCRIPTION
I'm including the HORSE_NOPROVIDER define because we're working on a modular web server architecture, where each module is a package that provides specific APIs. These packages need to use THorseRequest and THorseResponse without requiring a provider, since the main application responsible for loading the BPLs will supply the provider.