### PR TITLE
Update Horse.Core.Param.pas

### DIFF
--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -77,7 +77,12 @@ end;
 
 function THorseCoreParam.ContainsValue(const AValue: string): Boolean;
 begin
-  Result := FParams.ContainsValue(AValue);
+  Result := False;
+  for var LPair in FParams do
+    if (SameText(LPair.Key, AValue)) and (not LPair.Value.Trim.IsEmpty) then
+      Exit(True);
+
+  //Result := FParams.ContainsValue(AValue);
 end;
 
 constructor THorseCoreParam.Create(const AParams: THorseList);


### PR DESCRIPTION
Foi identificado um comportamento inesperado no método ContainsValue, que sempre retornava False, mesmo quando a chave estava claramente presente na coleção.

Após análise, verificou-se que o problema estava relacionado ao formato ou à comparação da chave, resultando em uma verificação incorreta de  inexistência.

O método foi revisado para garantir que a comparação do valor seja realizada de forma consistente, respeitando sensibilidade de maiúsculas/minúsculas, espaços e outros possíveis desvios que poderiam comprometer a acurácia da verificação na chave.

Com o ajuste aplicado, o ContainsValue agora retorna True corretamente sempre que a chave estiver presente.