### PR TITLE
Limpeza e reorganização de units

### DIFF
--- a/src/Horse.Callback.pas
+++ b/src/Horse.Callback.pas
@@ -19,7 +19,8 @@ uses
 {$ENDIF}
   Horse.Request,
   Horse.Response,
-  Horse.Proc;
+  Horse.Proc,
+  Horse.Commons;
 
 type
 {$IF DEFINED(FPC)}

--- a/src/Horse.Callback.pas
+++ b/src/Horse.Callback.pas
@@ -19,8 +19,7 @@ uses
 {$ENDIF}
   Horse.Request,
   Horse.Response,
-  Horse.Proc,
-  Horse.Commons;
+  Horse.Proc;
 
 type
 {$IF DEFINED(FPC)}

--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -14,7 +14,6 @@ uses
   StrUtils,
   RegExpr;
 {$ELSE}
-  System.Classes,
   System.SysUtils,
   System.RegularExpressions;
 {$ENDIF}

--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -9,10 +9,8 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  Classes,
   SysUtils,
-  StrUtils,
-  RegExpr;
+  StrUtils;
 {$ELSE}
   System.SysUtils;
 {$ENDIF}
@@ -135,8 +133,12 @@ function MatchRoute(const AText: string; const AValues: array of string): Boolea
 
 implementation
 
-uses
-  System.RegularExpressions;
+uses  
+{$IF DEFINED(FPC)}
+  RegExpr;
+{$ELSE}
+  System.RegularExpressions;    
+{$ENDIF}
 
 {$IF DEFINED(FPC)}
 function StringCommandToMethodType(const ACommand: string): TMethodType;

--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -14,8 +14,7 @@ uses
   StrUtils,
   RegExpr;
 {$ELSE}
-  System.SysUtils,
-  System.RegularExpressions;
+  System.SysUtils;
 {$ENDIF}
 
 type
@@ -135,6 +134,9 @@ function StringCommandToMethodType(const ACommand: string): TMethodType;
 function MatchRoute(const AText: string; const AValues: array of string): Boolean;
 
 implementation
+
+uses
+  System.RegularExpressions;
 
 {$IF DEFINED(FPC)}
 function StringCommandToMethodType(const ACommand: string): TMethodType;

--- a/src/Horse.Core.Files.pas
+++ b/src/Horse.Core.Files.pas
@@ -11,7 +11,6 @@ uses
   SysUtils,
   Classes;
 {$ELSE}
-  System.SysUtils,
   System.Classes;
 {$ENDIF}
 
@@ -36,6 +35,7 @@ type
 implementation
 
 uses
+  System.SysUtils,
   Horse.Mime;
 
 constructor THorseCoreFile.Create(const AFileName: string);

--- a/src/Horse.Core.Files.pas
+++ b/src/Horse.Core.Files.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes;
 {$ELSE}
   System.Classes;
@@ -35,7 +34,11 @@ type
 implementation
 
 uses
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   System.SysUtils,
+{$ENDIF}
   Horse.Mime;
 
 constructor THorseCoreFile.Create(const AFileName: string);

--- a/src/Horse.Core.Files.pas
+++ b/src/Horse.Core.Files.pas
@@ -12,8 +12,7 @@ uses
   Classes;
 {$ELSE}
   System.SysUtils,
-  System.Classes,
-  System.Generics.Collections;
+  System.Classes;
 {$ENDIF}
 
 type

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -7,9 +7,6 @@ unit Horse.Core.Group;
 interface
 
 uses
-{$IF DEFINED(FPC)}
-  SysUtils,
-{$ENDIF}
   Horse.Core.Group.Contract,
   Horse.Core.Route.Contract,
   Horse.Callback;
@@ -80,9 +77,13 @@ type
 implementation
 
 uses
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
+  System.SysUtils,
+{$ENDIF}
   Horse.Core,
-  Horse,
-  System.SysUtils;
+  Horse;
 
 function THorseCoreGroup<T>.&End: T;
 begin

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -9,8 +9,6 @@ interface
 uses
 {$IF DEFINED(FPC)}
   SysUtils,
-{$ELSE}
-  System.SysUtils,
 {$ENDIF}
   Horse.Core.Group.Contract,
   Horse.Core.Route.Contract,
@@ -83,7 +81,8 @@ implementation
 
 uses
   Horse.Core,
-  Horse;
+  Horse,
+  System.SysUtils;
 
 function THorseCoreGroup<T>.&End: T;
 begin

--- a/src/Horse.Core.Param.Field.Brackets.pas
+++ b/src/Horse.Core.Param.Field.Brackets.pas
@@ -10,9 +10,6 @@ uses
 {$IF DEFINED(FPC)}
   SysUtils,
   Classes,
-{$ELSE}
-  System.SysUtils,
-  System.Classes,
 {$ENDIF}
   Horse.Commons;
 

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -10,7 +10,6 @@ uses
 {$IF DEFINED(FPC)}
   SysUtils,
   Classes,
-  DateUtils,
   Generics.Collections,
 {$ELSE}
   System.SysUtils,
@@ -79,8 +78,12 @@ uses
   Horse.Exception,
   Horse.Commons,
   Horse.Core.Param.Config,
+{$IF DEFINED(FPC)}  
+  DateUtils;
+{$ELSE}
   System.DateUtils,
   System.Rtti;
+{$ENDIF}
 
 function THorseCoreParamField.AsBoolean: Boolean;
 var

--- a/src/Horse.Core.Param.Field.pas
+++ b/src/Horse.Core.Param.Field.pas
@@ -15,14 +15,9 @@ uses
 {$ELSE}
   System.SysUtils,
   System.Classes,
-  System.DateUtils,
   System.Generics.Collections,
-  System.Rtti,
 {$ENDIF}
-  Horse.Exception,
-  Horse.Commons,
-  Horse.Core.Param.Field.Brackets,
-  Horse.Core.Param.Config;
+  Horse.Core.Param.Field.Brackets;
 
 type
 
@@ -79,6 +74,13 @@ type
   end;
 
 implementation
+
+uses
+  Horse.Exception,
+  Horse.Commons,
+  Horse.Core.Param.Config,
+  System.DateUtils,
+  System.Rtti;
 
 function THorseCoreParamField.AsBoolean: Boolean;
 var

--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -16,11 +16,8 @@ uses
   HTTPDefs,
 {$ELSE}
   System.Classes,
-  System.SysUtils,
   System.Generics.Collections,
   Web.HTTPApp,
-  IdCustomHTTPServer,
-  Horse.Rtti,
   Horse.Rtti.Helper,
   {$IF DEFINED(HORSE_APACHE)}
     Web.ApacheHTTP,
@@ -48,6 +45,11 @@ type
   end;
 
 implementation
+
+uses
+  IdCustomHTTPServer,
+  Horse.Rtti,
+  System.SysUtils;
 
 class function THorseCoreParamHeader.GetHeaders(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF}): THorseList;
 var

--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -20,9 +20,7 @@ uses
   System.Generics.Collections,
   Web.HTTPApp,
   IdCustomHTTPServer,
-  IdHeaderList,
   Horse.Rtti,
-  Horse.Commons,
   Horse.Rtti.Helper,
   {$IF DEFINED(HORSE_APACHE)}
     Web.ApacheHTTP,

--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes,
   fpHTTP,
   fphttpserver,
@@ -46,10 +45,14 @@ type
 
 implementation
 
-uses
+uses    
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   IdCustomHTTPServer,
-  Horse.Rtti,
-  System.SysUtils;
+  System.SysUtils,
+{$ENDIF}
+  Horse.Rtti;
 
 class function THorseCoreParamHeader.GetHeaders(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF}): THorseList;
 var

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes,
   DateUtils,
   Generics.Collections,
@@ -56,9 +55,13 @@ type
 
 implementation
 
-uses
-  Horse.Core.Param.Config,
-  System.SysUtils;
+uses       
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
+  System.SysUtils,
+{$ENDIF}
+  Horse.Core.Param.Config;
 
 function THorseCoreParam.ContainsKey(const AKey: string): Boolean;
 var

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -17,10 +17,7 @@ uses
 {$ELSE}
   System.SysUtils,
   System.Classes,
-  System.DateUtils,
   System.Generics.Collections,
-  Horse.Exception,
-  Horse.Commons,
 {$ENDIF}
   Horse.Core.Param.Field;
 

--- a/src/Horse.Core.Param.pas
+++ b/src/Horse.Core.Param.pas
@@ -15,7 +15,6 @@ uses
   fpHTTP,
   HTTPDefs,
 {$ELSE}
-  System.SysUtils,
   System.Classes,
   System.Generics.Collections,
 {$ENDIF}
@@ -58,7 +57,8 @@ type
 implementation
 
 uses
-  Horse.Core.Param.Config;
+  Horse.Core.Param.Config,
+  System.SysUtils;
 
 function THorseCoreParam.ContainsKey(const AKey: string): Boolean;
 var

--- a/src/Horse.Core.Route.pas
+++ b/src/Horse.Core.Route.pas
@@ -9,8 +9,6 @@ interface
 uses
 {$IF DEFINED(FPC)}
   SysUtils,
-{$ELSE}
-  System.SysUtils,
 {$ENDIF}
   Horse.Core.Route.Contract,
   Horse.Callback;

--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Generics.Collections,
   fpHTTP,
   httpprotocol,
@@ -18,7 +17,8 @@ uses
 {$ENDIF}
   Horse.Request,
   Horse.Response,
-  Horse.Callback;
+  Horse.Callback,
+  Horse.Commons;
 
 type
   TNextCaller = class
@@ -55,11 +55,14 @@ type
 implementation
 
 uses
-  Horse.Exception,
-  Horse.Exception.Interrupted,
-  System.NetEncoding,
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   System.SysUtils,
-  Horse.Commons;
+  System.NetEncoding,
+{$ENDIF}
+  Horse.Exception,
+  Horse.Exception.Interrupted;
 
 function TNextCaller.Init: TNextCaller;
 var

--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -13,12 +13,9 @@ uses
   fpHTTP,
   httpprotocol,
 {$ELSE}
-  System.NetEncoding,
-  System.SysUtils,
   Web.HTTPApp,
   System.Generics.Collections,
 {$ENDIF}
-  Horse.Commons,
   Horse.Request,
   Horse.Response,
   Horse.Callback;
@@ -59,7 +56,10 @@ implementation
 
 uses
   Horse.Exception,
-  Horse.Exception.Interrupted;
+  Horse.Exception.Interrupted,
+  System.NetEncoding,
+  System.SysUtils,
+  Horse.Commons;
 
 function TNextCaller.Init: TNextCaller;
 var

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Generics.Collections,
   fpHTTP,
   httpprotocol,
@@ -19,7 +18,8 @@ uses
 {$ENDIF}
   Horse.Request,
   Horse.Response,
-  Horse.Callback;
+  Horse.Callback,
+  Horse.Commons;
 
 type
   PHorseRouterTree = ^THorseRouterTree;
@@ -60,10 +60,13 @@ type
 implementation
 
 uses
-  Horse.Core.RouterTree.NextCaller,
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   System.SysUtils,
   System.RegularExpressions,
-  Horse.Commons;
+{$ENDIF}
+  Horse.Core.RouterTree.NextCaller;
 
 procedure THorseRouterTree.RegisterRoute(const AHTTPType: TMethodType; const APath: string; const ACallback: THorseCallback);
 var

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -15,7 +15,6 @@ uses
   RegExpr,
 {$ELSE}
   System.SysUtils,
-  System.NetEncoding,
   Web.HTTPApp,
   System.Generics.Collections,
   System.RegularExpressions,

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -14,14 +14,11 @@ uses
   httpprotocol,
   RegExpr,
 {$ELSE}
-  System.SysUtils,
   Web.HTTPApp,
   System.Generics.Collections,
-  System.RegularExpressions,
 {$ENDIF}
   Horse.Request,
   Horse.Response,
-  Horse.Commons,
   Horse.Callback;
 
 type
@@ -63,7 +60,10 @@ type
 implementation
 
 uses
-  Horse.Core.RouterTree.NextCaller;
+  Horse.Core.RouterTree.NextCaller,
+  System.SysUtils,
+  System.RegularExpressions,
+  Horse.Commons;
 
 procedure THorseRouterTree.RegisterRoute(const AHTTPType: TMethodType; const APath: string; const ACallback: THorseCallback);
 var

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Generics.Collections,
 {$ELSE}
   System.Generics.Collections,
@@ -17,7 +16,8 @@ uses
   Horse.Core.RouterTree,
   Horse.Callback,
   Horse.Core.Group.Contract,
-  Horse.Core.Route.Contract;
+  Horse.Core.Route.Contract,
+  Horse.Commons;
 
 type
   THorseCore = class;
@@ -129,13 +129,16 @@ type
 implementation
 
 uses
-  Horse.Core.Route,
-  Horse.Core.Group,
-  Horse.Commons,
-  Horse.Constants,
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
+  System.SysUtils, 
   Horse.Request,
   Horse.Response,
-  System.SysUtils;
+{$ENDIF}
+  Horse.Core.Route,
+  Horse.Core.Group,
+  Horse.Constants;
 
 class function THorseCore.AddCallback(const ACallback: THorseCallback): THorseCore;
 begin

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -11,15 +11,10 @@ uses
   SysUtils,
   Generics.Collections,
 {$ELSE}
-  System.SysUtils,
   System.Generics.Collections,
   Web.HTTPApp,
-  Horse.Request,
-  Horse.Response,
 {$ENDIF}
   Horse.Core.RouterTree,
-  Horse.Commons,
-  Horse.Constants,
   Horse.Callback,
   Horse.Core.Group.Contract,
   Horse.Core.Route.Contract;
@@ -135,7 +130,12 @@ implementation
 
 uses
   Horse.Core.Route,
-  Horse.Core.Group;
+  Horse.Core.Group,
+  Horse.Commons,
+  Horse.Constants,
+  Horse.Request,
+  Horse.Response,
+  System.SysUtils;
 
 class function THorseCore.AddCallback(const ACallback: THorseCallback): THorseCore;
 begin

--- a/src/Horse.Exception.pas
+++ b/src/Horse.Exception.pas
@@ -11,7 +11,6 @@ uses
   SysUtils,
   fpjson,
   jsonparser,
-  TypInfo,
 {$ELSE}
   System.SysUtils,
   System.JSON,
@@ -54,8 +53,12 @@ type
 
 implementation
 
-uses
-  System.TypInfo;
+uses   
+{$IF DEFINED(FPC)} 
+  TypInfo;
+{$ELSE}
+  System.TypInfo; 
+{$ENDIF}
 
 constructor EHorseException.Create;
 begin

--- a/src/Horse.Exception.pas
+++ b/src/Horse.Exception.pas
@@ -15,7 +15,6 @@ uses
 {$ELSE}
   System.SysUtils,
   System.JSON,
-  System.TypInfo,
 {$ENDIF}
   Horse.Commons;
 
@@ -54,6 +53,9 @@ type
   end;
 
 implementation
+
+uses
+  System.TypInfo;
 
 constructor EHorseException.Create;
 begin

--- a/src/Horse.Mime.pas
+++ b/src/Horse.Mime.pas
@@ -17,9 +17,7 @@ uses
   Generics.Collections,
   SyncObjs;
 {$ELSE}
-  System.SysUtils,
-  System.Generics.Collections,
-  SyncObjs;
+  System.Generics.Collections;
 {$ENDIF}
 
 type
@@ -31,10 +29,12 @@ type
 
 implementation
 
-{$IFNDEF UseTHorseMimeTypesExt}
 uses
-  System.Net.Mime;
+{$IFNDEF UseTHorseMimeTypesExt}
+  System.Net.Mime,
 {$ENDIF}
+  System.SysUtils,
+  SyncObjs;
 
 type
 

--- a/src/Horse.Mime.pas
+++ b/src/Horse.Mime.pas
@@ -12,10 +12,8 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes,
-  Generics.Collections,
-  SyncObjs;
+  Generics.Collections;
 {$ELSE}
   System.Generics.Collections;
 {$ENDIF}
@@ -33,7 +31,12 @@ uses
 {$IFNDEF UseTHorseMimeTypesExt}
   System.Net.Mime,
 {$ENDIF}
+
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   System.SysUtils,
+{$ENDIF}
   SyncObjs;
 
 type

--- a/src/Horse.Mime.pas
+++ b/src/Horse.Mime.pas
@@ -18,7 +18,6 @@ uses
   SyncObjs;
 {$ELSE}
   System.SysUtils,
-  System.Classes,
   System.Generics.Collections,
   SyncObjs;
 {$ENDIF}

--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -10,9 +10,7 @@ uses
   Horse.Provider.IOHandleSSL,
   IdHTTPWebBrokerBridge,
   IdSSLOpenSSL,
-  IdSSL,
   IdContext,
-  System.Classes,
   System.SyncObjs,
   System.SysUtils;
 

--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -5,11 +5,8 @@ interface
 {$IF NOT DEFINED(FPC)}
 uses
   Horse.Provider.Abstract,
-  Horse.Constants,
   Horse.Provider.IOHandleSSL.Contract,
-  Horse.Provider.IOHandleSSL,
   IdHTTPWebBrokerBridge,
-  IdSSLOpenSSL,
   IdContext,
   System.SyncObjs,
   System.SysUtils;
@@ -73,7 +70,10 @@ implementation
 uses
   Web.WebReq,
   Horse.WebModule,
-  IdCustomTCPServer;
+  IdCustomTCPServer,
+  Horse.Constants,
+  Horse.Provider.IOHandleSSL,
+  IdSSLOpenSSL;
 
 class function THorseProvider.GetDefaultHTTPWebBroker: TIdHTTPWebBrokerBridge;
 begin

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -14,15 +14,12 @@ uses
   HTTPDefs,
 {$ELSE}
   System.SysUtils,
-  System.Classes,
   Web.HTTPApp,
 {$IF CompilerVersion > 32.0}
   Web.ReqMulti,
 {$ENDIF}
 {$ENDIF}
   Horse.Core.Param,
-  Horse.Core.Param.Header,
-  Horse.Commons,
   Horse.Session;
 
 type
@@ -67,6 +64,11 @@ type
   end;
 
 implementation
+
+uses
+  System.Classes,
+  Horse.Core.Param.Header,
+  Horse.Commons;
 
 function THorseRequest.Body: string;
 begin

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -9,7 +9,6 @@ interface
 uses
 {$IF DEFINED(FPC)}
   SysUtils,
-  Classes,
   fpHTTP,
   HTTPDefs,
 {$ELSE}
@@ -20,7 +19,8 @@ uses
 {$ENDIF}
 {$ENDIF}
   Horse.Core.Param,
-  Horse.Session;
+  Horse.Session,
+  Horse.Commons;
 
 type
   THorseRequest = class
@@ -65,10 +65,13 @@ type
 
 implementation
 
-uses
+uses      
+{$IF DEFINED(FPC)}
+  Classes,
+{$ELSE}
   System.Classes,
-  Horse.Core.Param.Header,
-  Horse.Commons;
+{$ENDIF}
+  Horse.Core.Param.Header;
 
 function THorseRequest.Body: string;
 begin

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes,
   fpHTTP,
   HTTPDefs,
@@ -52,8 +51,12 @@ type
 
 implementation
 
-uses
+uses        
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
   System.SysUtils,
+{$ENDIF}
   Horse.Core.Files,
   Horse.Mime;
 

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -13,16 +13,13 @@ uses
   fpHTTP,
   HTTPDefs,
 {$ELSE}
-  System.SysUtils,
   System.Classes,
   Web.HTTPApp,
 {$IF CompilerVersion > 32.0}
   Web.ReqMulti,
 {$ENDIF}
 {$ENDIF}
-  Horse.Commons,
-  Horse.Core.Files,
-  Horse.Mime;
+  Horse.Commons;
 
 type
   THorseResponse = class
@@ -54,6 +51,11 @@ type
   end;
 
 implementation
+
+uses
+  System.SysUtils,
+  Horse.Core.Files,
+  Horse.Mime;
 
 function THorseResponse.AddHeader(const AName, AValue: string): THorseResponse;
 begin

--- a/src/Horse.Rtti.pas
+++ b/src/Horse.Rtti.pas
@@ -10,7 +10,6 @@ uses
 {$IF DEFINED(FPC)}
   SysUtils, RTTI;
 {$ELSE}
-  System.SysUtils,
   System.Rtti;
 {$ENDIF}
 type
@@ -28,6 +27,9 @@ type
   end;
 
 implementation
+
+uses
+  System.SysUtils;
 
 constructor THorseRtti.Create;
 begin

--- a/src/Horse.Rtti.pas
+++ b/src/Horse.Rtti.pas
@@ -8,13 +8,11 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils, RTTI,
+  SysUtils, RTTI;
 {$ELSE}
   System.SysUtils,
-  System.Rtti,
+  System.Rtti;
 {$ENDIF}
-  Horse.Commons;
-
 type
   THorseRtti = class
   private

--- a/src/Horse.Rtti.pas
+++ b/src/Horse.Rtti.pas
@@ -8,7 +8,7 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils, RTTI;
+  RTTI;
 {$ELSE}
   System.Rtti;
 {$ENDIF}
@@ -28,8 +28,12 @@ type
 
 implementation
 
-uses
+uses 
+{$IF DEFINED(FPC)}
+  SysUtils;
+{$ELSE}
   System.SysUtils;
+{$ENDIF}
 
 constructor THorseRtti.Create;
 begin

--- a/src/Horse.Session.pas
+++ b/src/Horse.Session.pas
@@ -11,7 +11,6 @@ uses
   SysUtils,
   Generics.Collections;
 {$ELSE}
-  System.SysUtils,
   System.Generics.Collections;
 {$ENDIF}
 
@@ -37,6 +36,9 @@ type
   end;
 
 implementation
+
+uses
+  System.SysUtils;
 
 constructor THorseSessions.Create;
 begin

--- a/src/Horse.Session.pas
+++ b/src/Horse.Session.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Generics.Collections;
 {$ELSE}
   System.Generics.Collections;
@@ -37,8 +36,12 @@ type
 
 implementation
 
-uses
+uses   
+{$IF DEFINED(FPC)}
+  SysUtils;
+{$ELSE}
   System.SysUtils;
+{$ENDIF}
 
 constructor THorseSessions.Create;
 begin

--- a/src/Horse.WebModule.pas
+++ b/src/Horse.WebModule.pas
@@ -14,7 +14,6 @@ uses
   fpHTTP,
   fpWeb,
 {$ELSE}
-  System.SysUtils,
   System.Classes,
   Web.HTTPApp,
 {$ENDIF}
@@ -49,7 +48,8 @@ implementation
 uses
   Horse.Request,
   Horse.Response,
-  Horse.Exception.Interrupted;
+  Horse.Exception.Interrupted,
+  System.SysUtils;
 
 {$IF DEFINED(FPC)}
   {$R Horse.WebModule.lfm}

--- a/src/Horse.WebModule.pas
+++ b/src/Horse.WebModule.pas
@@ -8,7 +8,6 @@ interface
 
 uses
 {$IF DEFINED(FPC)}
-  SysUtils,
   Classes,
   httpdefs,
   fpHTTP,
@@ -46,10 +45,15 @@ var
 implementation
 
 uses
+
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
+  System.SysUtils,
+{$ENDIF}        
   Horse.Request,
   Horse.Response,
-  Horse.Exception.Interrupted,
-  System.SysUtils;
+  Horse.Exception.Interrupted;
 
 {$IF DEFINED(FPC)}
   {$R Horse.WebModule.lfm}


### PR DESCRIPTION
A limpeza e reorganização de units se trata de boas práticas. Trás muitas vantagens, como diminuição no tempo de compilação e no tamanho do arquivo final.