### PR TITLE
Remove alterações PR (#364)

### DIFF
--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -45,7 +45,6 @@ type
     function Body: string; overload; virtual;
     function Body<T: class>: T; overload;
     function Body(const ABody: TObject): THorseRequest; overload; virtual;
-    function Body(const Encoding: TEncoding): string; overload; virtual;
     function Session<T: class>: T; overload;
     function Session(const ASession: TObject): THorseRequest; overload; virtual;
     function Headers: THorseCoreParam; virtual;

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -86,28 +86,6 @@ begin
   FBody := ABody;
 end;
 
-function THorseRequest.Body(const Encoding: TEncoding): string;
-{$IF DEFINED(FPC)}
-var
-  lContent: TStringStream;
-{$ENDIF}
-begin
-  {$IF DEFINED(FPC)}
-  try
-    lContent := TStringStream.Create(FWebRequest.Content, Encoding);
-    Result   := lContent.DataString;
-  finally
-    lContent.Free;
-  end;
-  {$ELSE}
-  {$IF CompilerVersion <= 31.0}
-  Result := Encoding.GetString(BytesOf(FWebRequest.RawContent));
-  {$ELSE}
-  Result := Encoding.GetString(FWebRequest.RawContent);
-  {$ENDIF}
-  {$ENDIF}
-end;
-
 function THorseRequest.Body<T>: T;
 begin
   Result := T(FBody);


### PR DESCRIPTION
As alterações implementadas via PR (#364), quebra a compilação do Horse na versão 10.1 do Delphi (#433) e é uma forma ineficiente de corrigir o problema de encoding relatado.

No Delphi 10.0 (Seattle), a unit Web.HTTPApp.pas por padrão codifica o corpo das requisições em ANSI, a menos que um charset seja especificado no cabeçalho Content-Type, como é mostrado no print retirado do PR.

<img width="964" height="429" alt="image" src="https://github.com/user-attachments/assets/42be4b43-ea40-4f1d-ac14-2658f87684ef" />

Para resolver isso de forma eficaz e garantir a compatibilidade, a solução mais simples é adicionar charset=utf-8 ao cabeçalho Content-Type. Dessa forma, a própria unit Web.HTTPApp do Delphi reconhecerá e aplicará a codificação UTF-8 corretamente, sem a necessidade de modificações no framework.

Há também uma RFC que ampara o uso de charset no content-type, [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-charset)