### PR TITLE
Add compatibility with horse-manipulate-request middleware

### DIFF
--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -74,7 +74,7 @@ begin
   FIndex := -1;
   FIndexCallback := -1;
   if FIsParamsKey then
-    FRequest.Params.Dictionary.Add(FTag, {$IF DEFINED(FPC)}HTTPDecode(LCurrent){$ELSE}TNetEncoding.URL.Decode(LCurrent){$ENDIF});
+    FRequest.Params.Dictionary.AddOrSetValue(FTag, {$IF DEFINED(FPC)}HTTPDecode(LCurrent){$ELSE}TNetEncoding.URL.Decode(LCurrent){$ENDIF});
 end;
 
 procedure TNextCaller.Next;

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -55,6 +55,8 @@ type
     function Execute(const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean;
     constructor Create;
     destructor Destroy; override;
+
+    property Route: TObjectDictionary<string, THorseRouterTree> read FRoute;
   end;
 
 implementation


### PR DESCRIPTION
Add compatibility with horse-manipulate-request middleware

The horse-manipulate-request middleware performs URL parameter extraction before Horse processes route parameters, requiring access to the original RouteTree values.

As this middleware is executed prior to Horse's internal URL parameter handling, this change introduces an early extraction of parameter names and values to ensure compatibility.

### Notes
- This change does not affect the default behavior when the middleware is not in use.
- Designed to be minimally invasive and maintain backward compatibility.