### PR TITLE
Feature/stateful controllers

### DIFF
--- a/DOC_STATEFUL_CONTROLLERS.md
+++ b/DOC_STATEFUL_CONTROLLERS.md
@@ -109,7 +109,7 @@ begin
   LJSON := TJSONArray.Create;
   LJSON.Add('Lazarus User');
   LJSON.Add('FPC Power');
-  Response.Send(LJSON).Status(200);
+  Response.Send(LJSON.AsJSON).Status(200);
 end;
 
 procedure TUserController.GetUserById;

--- a/DOC_STATEFUL_CONTROLLERS.md
+++ b/DOC_STATEFUL_CONTROLLERS.md
@@ -1,0 +1,157 @@
+# Statefull Controllers no Horse: Arquitetura e Implementação
+
+O Horse agora suporta o padrão **Statefull Controller**, permitindo que as rotas sejam gerenciadas por classes. Esta abordagem facilita a organização do código, a injeção de dependências e o isolamento de estado por requisição.
+
+A implementação foi desenhada para ser fluida em ambas as IDEs, respeitando as particularidades de cada compilador.
+
+---
+
+## 1. O Conceito Base
+
+Diferente do modelo funcional, o modelo de classes instancia um objeto único para cada requisição HTTP. A infraestrutura do Horse garante o ciclo de vida completo: **Instanciar -> Mapear Rota -> Executar Método -> Destruir**.
+
+### Benefícios
+- **Isolamento de Estado:** Cada requisição possui sua própria instância da classe (Thread-Safe).
+- **Gerenciamento de Memória Determinístico:** Utiliza o padrão `try..finally` internamente na base.
+- **Roteamento Dinâmico:** Uma única classe gerencia múltiplos endpoints relacionados.
+
+---
+
+## 2. Como Utilizar: Exemplo Embarcadero Delphi
+
+No Delphi, utilizamos as units padrão do framework e a RTTI nativa.
+
+### Controller (UController.pas)
+```pascal
+unit UController;
+
+interface
+
+uses Horse, Horse.Controller, System.SysUtils, System.JSON;
+
+type
+  {$M+} // Ativa a RTTI para os métodos published
+  TUserController = class(THorseController)
+  published
+    procedure ListUsers;
+    procedure GetUserById;
+  end;
+  {$M-}
+
+implementation
+
+procedure TUserController.ListUsers;
+var
+  LJSON: TJSONArray;
+begin
+  LJSON := TJSONArray.Create;
+  LJSON.Add('Lucas');
+  LJSON.Add('Horse');
+  Response.Send(LJSON).Status(200);
+end;
+
+procedure TUserController.GetUserById;
+begin
+  Response.Send('ID: ' + Request.Params['id']).Status(200);
+end;
+
+end.
+```
+
+### Projeto (DelphiProject.dpr)
+```pascal
+program DelphiProject;
+
+{$APPTYPE CONSOLE}
+
+uses Horse, Horse.Controller, UController;
+
+begin
+  // Mapeamento e Registro Automático
+  THorseController<TUserController>.Map('/users', mtGet, 'ListUsers');
+  THorseController<TUserController>.Map('/users/:id', mtGet, 'GetUserById');
+
+  THorse.Listen(9000);
+end.
+```
+
+---
+
+## 3. Como Utilizar: Exemplo Lazarus (FreePascal)
+
+No Lazarus, é fundamental o uso da diretiva `{$MODE DELPHI}` e o tratamento correto das units de JSON do FPC.
+
+### Controller (ucontroller.pas)
+```pascal
+unit ucontroller;
+
+{$mode delphi}{$H+}
+
+interface
+
+uses Horse, Horse.Controller, SysUtils, fpjson;
+
+type
+  {$M+} // Ativa a RTTI para os métodos published no FPC
+  TUserController = class(THorseController)
+  published
+    procedure ListUsers;
+    procedure GetUserById;
+  end;
+  {$M-}
+
+implementation
+
+procedure TUserController.ListUsers;
+var
+  LJSON: TJSONArray;
+begin
+  LJSON := TJSONArray.Create;
+  LJSON.Add('Lazarus User');
+  LJSON.Add('FPC Power');
+  Response.Send(LJSON).Status(200);
+end;
+
+procedure TUserController.GetUserById;
+begin
+  Response.Send('FPC ID: ' + Request.Params['id']).Status(200);
+end;
+
+end.
+```
+
+### Projeto (LazarusProject.lpr)
+```pascal
+program LazarusProject;
+
+{$mode delphi}{$H+}
+
+uses Horse, Horse.Controller, ucontroller;
+
+begin
+  // Mapeamento e Registro Automático (Sintaxe idêntica ao Delphi)
+  THorseController<TUserController>.Map('/users', mtGet, 'ListUsers');
+  THorseController<TUserController>.Map('/users/:id', mtGet, 'GetUserById');
+
+  THorse.Listen(9000);
+end.
+```
+
+---
+
+## 4. Principais Diferenças de Implementação
+
+| Recurso | Delphi | Lazarus (FPC) |
+| :--- | :--- | :--- |
+| **Diretiva de Linguagem** | Padrão da IDE. | Requer `{$MODE DELPHI}` no topo das units. |
+| **JSON** | `System.JSON` (TJSONObject, TJSONArray). | `fpjson` (TJSONObject, TJSONArray). |
+| **RTTI (`$M+`)** | Nativa e habilitada por padrão em muitas classes. | Obrigatória para expor métodos ao `MethodAddress`. |
+| **Gerenciamento de Strings** | Unicode por padrão. | Requer `{$H+}` para AnsiString/Unicode moderno. |
+
+---
+
+## 5. Melhorias na Base do Horse
+
+1.  **Unit `Horse.Controller.pas`**: Centraliza a lógica de ciclo de vida.
+2.  **Dispatcher por `MethodAddress`**: Utiliza a localização física do método na memória para execução, garantindo alta performance sem depender de frameworks de RTTI pesados.
+3.  **Auto-Registro**: O método `Map` injeta a rota diretamente no `THorse`, validando o verbo HTTP.

--- a/DOC_STATEFUL_CONTROLLERS.md
+++ b/DOC_STATEFUL_CONTROLLERS.md
@@ -64,7 +64,7 @@ program DelphiProject;
 
 {$APPTYPE CONSOLE}
 
-uses Horse, Horse.Controller, UController;
+uses Horse, Horse.Controller, Horse.Commons, UController;
 
 begin
   // Mapeamento e Registro Automático
@@ -130,7 +130,7 @@ uses
   {$IFDEF UNIX}
   cthreads, // Essencial para aplicações console multithread no Linux/macOS
   {$ENDIF}
-  Horse, Horse.Controller, ucontroller;
+  uses Horse, Horse.Controller, Horse.Commons, ucontroller;
 
 begin
   // Mapeamento e Registro Automático (Sintaxe idêntica ao Delphi)

--- a/DOC_STATEFUL_CONTROLLERS.md
+++ b/DOC_STATEFUL_CONTROLLERS.md
@@ -126,7 +126,11 @@ program LazarusProject;
 
 {$mode delphi}{$H+}
 
-uses Horse, Horse.Controller, ucontroller;
+uses
+  {$IFDEF UNIX}
+  cthreads, // Essencial para aplicações console multithread no Linux/macOS
+  {$ENDIF}
+  Horse, Horse.Controller, ucontroller;
 
 begin
   // Mapeamento e Registro Automático (Sintaxe idêntica ao Delphi)

--- a/DOC_STATEFUL_CONTROLLERS.md
+++ b/DOC_STATEFUL_CONTROLLERS.md
@@ -121,6 +121,9 @@ end.
 ```
 
 ### Projeto (LazarusProject.lpr)
+
+**Nota de Configuração:** Para que o compilador encontre as units do Horse, você deve adicionar o caminho para a pasta `src` do Horse nas configurações do seu projeto. Vá em **Project > Project Options > Compiler Options > Paths > Other unit files (-Fu)** e adicione o caminho.
+
 ```pascal
 program LazarusProject;
 

--- a/DOC_TESTS_EXECUTION.md
+++ b/DOC_TESTS_EXECUTION.md
@@ -1,0 +1,52 @@
+# Guia de Execução de Testes: Pacote Horse
+
+Os testes garantem que a implementação de Statefull Controllers funcione perfeitamente em múltiplos compiladores. O Horse utiliza o framework **DUnitX**.
+
+## 1. Execução no Embarcadero Delphi
+
+No Delphi, os testes são configurados como uma aplicação de console de 32 ou 64 bits.
+
+### Via IDE
+1. Abra o arquivo de grupo de projetos: `tests/src/DUnitX.groupproj`.
+2. Ative o projeto `Console.dproj`.
+3. Pressione `F9` para compilar e rodar.
+4. **Verificação:** Procure no log de saída por `Tests.Horse.Controller`. Todos os testes devem retornar `Passed`.
+
+### Via Linha de Comando (CI/CD)
+```bash
+msbuild tests/src/Console.dproj /t:Build /p:Config=Debug
+.\tests\src\Win32\Debug\Console.exe
+```
+
+---
+
+## 2. Execução no Lazarus (FreePascal)
+
+No Lazarus, os testes seguem a estrutura do FPCUnit/DUnitX adaptada para o compilador.
+
+### Via Interface Gráfica (IDE)
+1. Abra o arquivo `tests/lazarus/Console.lpi`.
+2. Pressione `F9` ou clique em `Executar`.
+3. O Lazarus exibirá o progresso da execução. Caso ocorram erros, a IDE marcará a linha exata da falha no código-fonte.
+
+### Via Linha de Comando (lazbuild)
+Ideal para automação em servidores Linux:
+```bash
+# Compilação
+lazbuild tests/lazarus/Console.lpi
+
+# Execução
+./tests/lazarus/Console --all --format:console
+```
+
+---
+
+## 3. Detalhes Técnicos dos Testes de Controller
+
+O arquivo `tests/src/tests/Tests.Horse.Controller.pas` valida os seguintes pontos cruciais para a estabilidade cross-IDE:
+
+1.  **Instanciação e Destruição:** Confirma que o `try..finally` interno do Horse está liberando a memória corretamente (evitando Memory Leaks).
+2.  **Mapeamento de Rotas Dinâmicas:** Valida se rotas como `/users/:id` estão sendo corretamente resolvidas para o método `GetUserById` via `MethodAddress`.
+3.  **Fallback de Verbo:** Garante que se uma rota for registrada mas não houver um método publicado mapeado, o Horse ainda tente executar os métodos virtuais padrão (`Get`, `Post`, etc.).
+
+**Nota:** Devido às diferenças de RTTI entre Delphi e FPC, este teste é o mais sensível do pacote e deve sempre passar em ambos antes de qualquer commit na branch principal.

--- a/samples/lazarus/RouterController/controllerteste.pas
+++ b/samples/lazarus/RouterController/controllerteste.pas
@@ -1,0 +1,35 @@
+unit ControllerTeste;
+
+{$mode delphi}{$H+}
+
+interface
+
+uses Horse, Horse.Controller, SysUtils, fpjson;
+
+type
+  {$M+} // Ativa a RTTI para os métodos published no FPC
+  TControllerTeste = class(THorseController)
+  published
+    procedure ListUsers;
+    procedure GetUserById;
+  end;
+  {$M-}
+
+implementation
+
+procedure TControllerTeste.ListUsers;
+var
+  LJSON: TJSONArray;
+begin
+  LJSON := TJSONArray.Create;
+  LJSON.Add('Lazarus User');
+  LJSON.Add('FPC Power');
+  Response.Send(LJSON.AsJSON).Status(200);
+end;
+
+procedure TControllerTeste.GetUserById;
+begin
+  Response.Send('FPC ID: ' + Request.Params['id']).Status(200);
+end;
+
+end.

--- a/samples/lazarus/RouterController/testehorse.lpi
+++ b/samples/lazarus/RouterController/testehorse.lpi
@@ -43,6 +43,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="../../../src"/>
       <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Parsing>

--- a/samples/lazarus/RouterController/testehorse.lpi
+++ b/samples/lazarus/RouterController/testehorse.lpi
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="Teste Horse"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <Units>
+      <Unit>
+        <Filename Value="testehorse.lpr"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="TesteHorse"/>
+      </Unit>
+      <Unit>
+        <Filename Value="controllerteste.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="ControllerTeste"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="testehorse"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="Delphi"/>
+        <CStyleMacros Value="True"/>
+      </SyntaxOptions>
+    </Parsing>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/samples/lazarus/RouterController/testehorse.lpr
+++ b/samples/lazarus/RouterController/testehorse.lpr
@@ -1,0 +1,17 @@
+program TesteHorse;
+
+{$MODE DELPHI}{$H+}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Horse, Horse.Controller, Horse.Commons, ControllerTeste;
+
+begin
+  // Mapeamento e Registro Automático (Sintaxe idêntica ao Delphi)
+  THorseController<TControllerTeste>.Map('/users', mtGet, 'ListUsers');
+  THorseController<TControllerTeste>.Map('/users/:id', mtGet, 'GetUserById');
+
+  THorse.Listen(9001);
+end.

--- a/samples/lazarus/RouterController/testehorse.lpr
+++ b/samples/lazarus/RouterController/testehorse.lpr
@@ -8,10 +8,14 @@ uses
   {$ENDIF}
   Horse, Horse.Controller, Horse.Commons, ControllerTeste;
 
+procedure TesteJwt(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
 begin
-  // Mapeamento e Registro Automático (Sintaxe idêntica ao Delphi)
-  THorseController<TControllerTeste>.Map('/users', mtGet, 'ListUsers');
-  THorseController<TControllerTeste>.Map('/users/:id', mtGet, 'GetUserById');
+  ANext();
+end;
+
+begin
+  THorse.AddCallback(TesteJwt).Map(TControllerTeste,'/users', mtGet, 'ListUsers');
+  THorse.AddCallback(TesteJwt).Map(TControllerTeste,'/users/:id', mtGet, 'GetUserById');
 
   THorse.Listen(9001);
-end.
+end. 

--- a/src/Horse.Callback.pas
+++ b/src/Horse.Callback.pas
@@ -28,6 +28,7 @@ type
   THorseCallbackResponse = {$IF DEFINED(HORSE_FPC_FUNCTIONREFERENCES)}reference to {$ENDIF}procedure(ARes: THorseResponse);
   THorseCallbackRequestResponse = {$IF DEFINED(HORSE_FPC_FUNCTIONREFERENCES)}reference to {$ENDIF}procedure(AReq: THorseRequest; ARes: THorseResponse);
   THorseCallback = {$IF DEFINED(HORSE_FPC_FUNCTIONREFERENCES)}reference to {$ENDIF}procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
+  THorseCallbackObject = {$IF DEFINED(HORSE_FPC_FUNCTIONREFERENCES)}reference to {$ENDIF}procedure(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc) of object;
   TCallNextPath = function(var APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean of object;
 {$ELSE}
   THorseCallbackRequest = reference to procedure(AReq: THorseRequest);

--- a/src/Horse.Commons.pas
+++ b/src/Horse.Commons.pas
@@ -163,57 +163,72 @@ end;
 
 function MatchRoute(const AText: string; const AValues: array of string): Boolean;
 
-  function ReplaceParams(const AValue: string): string;
+  function MatchRouteOptimized(const APath, APattern: string): Boolean;
   var
-    LPart: string;
-    LSplitedPath: TArray<string>;
+    PathSegments, PatternSegments: TArray<string>;
+    I, PathLen, PatternLen: Integer;
+    TrimmedPath, TrimmedPattern: string;
   begin
-    Result := AValue;
-    LSplitedPath := AValue.Split(['/']);
-    for LPart in LSplitedPath do
+    Result := False;
+
+    // 1. Normaliza e divide os caminhos em segmentos
+    TrimmedPath := APath;
+    if TrimmedPath.StartsWith('/') then
+      TrimmedPath := TrimmedPath.Substring(1);
+    if TrimmedPath.EndsWith('/') then
+      TrimmedPath := TrimmedPath.Substring(0, TrimmedPath.Length - 1);
+
+    TrimmedPattern := APattern;
+    if TrimmedPattern.StartsWith('/') then
+      TrimmedPattern := TrimmedPattern.Substring(1);
+    if TrimmedPattern.EndsWith('/') then
+      TrimmedPattern := TrimmedPattern.Substring(0, TrimmedPattern.Length - 1);
+
+    PathSegments := TrimmedPath.Split(['/']);
+    PatternSegments := TrimmedPattern.Split(['/']);
+
+    PathLen := Length(PathSegments);
+    PatternLen := Length(PatternSegments);
+
+    // 2. Regra de Falha Rápida: Se o número de segmentos não for igual, não há match.
+    if PathLen <> PatternLen then
+      Exit;
+
+    // 3. Caso especial: rota raiz "/" (quando os paths vazios resultam em um array com um elemento vazio)
+    if (PathLen = 1) and (PatternLen = 1) and (PathSegments[0] = '') and (PatternSegments[0] = '') then
     begin
-      if LPart.StartsWith(':') then
-        Result := StringReplace(Result, LPart, '([^/]*)', []);
+      Result := True;
+      Exit;
     end;
-    Result := Trim(Result);
-    if not(Result.EndsWith('/')) then
-      Result := Result + '/';
+
+    // 4. Comparação segmento por segmento
+    for I := 0 to PathLen - 1 do
+    begin
+      // Se o segmento do padrão não começa com ':', ele deve ser idêntico (case-insensitive)
+      if not PatternSegments[I].StartsWith(':') then
+      begin
+        if AnsiCompareText(PathSegments[I], PatternSegments[I]) <> 0 then
+          Exit; // Falha se segmentos estáticos não baterem
+      end;
+      // Se o segmento do padrão começa com ':', ele é um wildcard e aceita qualquer valor.
+    end;
+
+    // Se o loop terminou sem falhas, a rota corresponde.
+    Result := True;
   end;
 
 var
-{$IF DEFINED(FPC)}
-  LRegexObj: TRegExpr;
-{$ENDIF}
-  I: Integer;
-  LText, LExpression: string;
+  LPattern: string;
 begin
-  Result := False;
-{$IF DEFINED(FPC)}
-  LRegexObj := TRegExpr.Create;
-  try
-{$ENDIF}
-    LText := Trim(AText);
-    if not(LText.EndsWith('/')) then
-      LText := LText + '/';
-    for I := Low(AValues) to High(AValues) do
+  for LPattern in AValues do
+  begin
+    if MatchRouteOptimized(AText, LPattern) then
     begin
-      LExpression := '^(' + ReplaceParams(AValues[I]) + ')$';
-{$IF DEFINED(FPC)}
-      LRegexObj.Expression := '(?i)' + LExpression;
-      if LRegexObj.Exec(LText) then
-{$ELSE}
-      if TRegEx.IsMatch(LText, LExpression, [roIgnoreCase]) then
-{$ENDIF}
-      begin
-        Result := True;
-        Exit;
-      end;
+      Result := True;
+      Exit;
     end;
-{$IF DEFINED(FPC)}
-  finally
-    LRegexObj.Free;
   end;
-{$ENDIF}
+  Result := False;
 end;
 
 { TLhsBracketsTypeHelper }

--- a/src/Horse.Controller.pas
+++ b/src/Horse.Controller.pas
@@ -18,6 +18,7 @@ uses
   Horse.Commons;
 
 type
+  {$M+}
   THorseController = class
   private
     FRequest: THorseRequest;
@@ -38,11 +39,21 @@ type
     procedure Head; virtual;
     destructor Destroy; override;
   end;
+  {$M-}
 
   THorseControllerClass = class of THorseController;
 
+  TControllerActionMap = record
+    Path: string;
+    MethodType: TMethodType;
+    MethodName: string;
+  end;
+
   THorseController<T: THorseController, constructor> = class
+  private
+    class var FRoutes: TArray<TControllerActionMap>;
   public
+    class procedure Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
     class procedure Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
   end;
 
@@ -100,12 +111,61 @@ end;
 
 { THorseController<T> }
 
+class procedure THorseController<T>.Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
+var
+  LLength: Integer;
+begin
+  LLength := Length(FRoutes);
+  SetLength(FRoutes, LLength + 1);
+  FRoutes[LLength].Path := APath;
+  FRoutes[LLength].MethodType := AMethodType;
+  FRoutes[LLength].MethodName := AMethodName;
+end;
+
+type
+  TControllerAction = procedure of object;
+
 class procedure THorseController<T>.Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
 var
   LController: T;
+  LRoute: TControllerActionMap;
+  LMatched: Boolean;
+  LMethod: TMethod;
+  LAction: TControllerAction;
+  I: Integer;
 begin
+  LMatched := False;
+  LMethod.Code := nil;
+
+  for I := Low(FRoutes) to High(FRoutes) do
+  begin
+    LRoute := FRoutes[I];
+    if (LRoute.MethodType = ARequest.MethodType) or (LRoute.MethodType = mtAny) then
+    begin
+      if MatchRoute(ARequest.PathInfo, [LRoute.Path]) then
+      begin
+        LMatched := True;
+        Break;
+      end;
+    end;
+  end;
+
   LController := T.Create(ARequest, AResponse, ANext);
   try
+    if LMatched then
+    begin
+      LMethod.Code := LController.MethodAddress(LRoute.MethodName);
+      if LMethod.Code <> nil then
+      begin
+        LMethod.Data := LController;
+        LAction := TControllerAction(LMethod);
+        LAction();
+        Exit;
+      end
+      else
+        raise Exception.CreateFmt('Method "%s" not found or not published in controller "%s"', [LRoute.MethodName, LController.ClassName]);
+    end;
+
     LController.Execute;
   finally
     LController.Free;

--- a/src/Horse.Controller.pas
+++ b/src/Horse.Controller.pas
@@ -1,0 +1,115 @@
+unit Horse.Controller;
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+uses
+  {$IF DEFINED(FPC)}
+  SysUtils,
+  {$ELSE}
+  System.SysUtils,
+  {$ENDIF}
+  Horse.Request,
+  Horse.Response,
+  Horse.Proc,
+  Horse.Commons;
+
+type
+  THorseController = class
+  private
+    FRequest: THorseRequest;
+    FResponse: THorseResponse;
+    FNext: TNextProc;
+  protected
+    property Request: THorseRequest read FRequest;
+    property Response: THorseResponse read FResponse;
+    property Next: TNextProc read FNext;
+  public
+    constructor Create(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc); virtual;
+    procedure Execute; virtual;
+    procedure Get; virtual;
+    procedure Post; virtual;
+    procedure Put; virtual;
+    procedure Delete; virtual;
+    procedure Patch; virtual;
+    procedure Head; virtual;
+    destructor Destroy; override;
+  end;
+
+  THorseControllerClass = class of THorseController;
+
+  THorseController<T: THorseController, constructor> = class
+  public
+    class procedure Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
+  end;
+
+implementation
+
+{ THorseController }
+
+constructor THorseController.Create(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
+begin
+  FRequest := ARequest;
+  FResponse := AResponse;
+  FNext := ANext;
+end;
+
+destructor THorseController.Destroy;
+begin
+  inherited;
+end;
+
+procedure THorseController.Execute;
+begin
+  case FRequest.MethodType of
+    mtGet: Get;
+    mtPost: Post;
+    mtPut: Put;
+    mtDelete: Delete;
+    mtPatch: Patch;
+    mtHead: Head;
+  end;
+end;
+
+procedure THorseController.Get;
+begin
+end;
+
+procedure THorseController.Post;
+begin
+end;
+
+procedure THorseController.Put;
+begin
+end;
+
+procedure THorseController.Delete;
+begin
+end;
+
+procedure THorseController.Patch;
+begin
+end;
+
+procedure THorseController.Head;
+begin
+end;
+
+{ THorseController<T> }
+
+class procedure THorseController<T>.Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
+var
+  LController: T;
+begin
+  LController := T.Create(ARequest, AResponse, ANext);
+  try
+    LController.Execute;
+  finally
+    LController.Free;
+  end;
+end;
+
+end.

--- a/src/Horse.Controller.pas
+++ b/src/Horse.Controller.pas
@@ -44,23 +44,106 @@ type
   THorseControllerClass = class of THorseController;
 
   TControllerActionMap = record
+    ControllerClass: THorseControllerClass;
     Path: string;
     MethodType: TMethodType;
     MethodName: string;
   end;
 
-  THorseController<T: THorseController, constructor> = class
+  THorseControllerRegistry = class
   private
     class var FRoutes: TArray<TControllerActionMap>;
   public
+    class procedure RegisterRoute(AClass: THorseControllerClass; const APath: string; AMethodType: TMethodType; const AMethodName: string);
+    class function GetRoutes: TArray<TControllerActionMap>;
+    class procedure Dispatcher(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc); {$IF DEFINED(FPC)} static; {$ENDIF}
+  end;
+
+  THorseController<T: THorseController, constructor> = class
+  public
     class procedure Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
-    class procedure Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
   end;
 
 implementation
 
 uses
   Horse;
+
+{ THorseControllerRegistry }
+
+class procedure THorseControllerRegistry.RegisterRoute(AClass: THorseControllerClass; const APath: string; AMethodType: TMethodType; const AMethodName: string);
+var
+  LLength: Integer;
+begin
+  LLength := Length(FRoutes);
+  SetLength(FRoutes, LLength + 1);
+  FRoutes[LLength].ControllerClass := AClass;
+  FRoutes[LLength].Path := APath;
+  FRoutes[LLength].MethodType := AMethodType;
+  FRoutes[LLength].MethodName := AMethodName;
+end;
+
+class function THorseControllerRegistry.GetRoutes: TArray<TControllerActionMap>;
+begin
+  Result := FRoutes;
+end;
+
+type
+  TControllerAction = procedure of object;
+
+class procedure THorseControllerRegistry.Dispatcher(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
+var
+  LController: THorseController;
+  LRoute: TControllerActionMap;
+  LMatched: Boolean;
+  LMethod: TMethod;
+  LAction: TControllerAction;
+  I: Integer;
+begin
+  LMatched := False;
+  LMethod.Code := nil;
+  LRoute.ControllerClass := nil;
+
+  for I := Low(FRoutes) to High(FRoutes) do
+  begin
+    LRoute := FRoutes[I];
+    if (LRoute.MethodType = ARequest.MethodType) or (LRoute.MethodType = mtAny) then
+    begin
+      if MatchRoute(ARequest.PathInfo, [LRoute.Path]) then
+      begin
+        LMatched := True;
+        Break;
+      end;
+    end;
+  end;
+
+  if LMatched and Assigned(LRoute.ControllerClass) then
+  begin
+    // For standard execution without specific constructor arguments, we instantiate using the class reference.
+    // In Delphi/FPC we must use a virtual constructor on the base class.
+    LController := LRoute.ControllerClass.Create(ARequest, AResponse, ANext);
+    try
+      {$IF DEFINED(FPC)}
+      LMethod.Code := Pointer(LController.MethodAddress(LRoute.MethodName));
+      {$ELSE}
+      LMethod.Code := LController.MethodAddress(LRoute.MethodName);
+      {$ENDIF}
+      if LMethod.Code <> nil then
+      begin
+        LMethod.Data := Pointer(LController);
+        LAction := TControllerAction(LMethod);
+        LAction();
+        Exit;
+      end
+      else
+        raise Exception.CreateFmt('Method "%s" not found or not published in controller "%s"', [LRoute.MethodName, LController.ClassName]);
+      
+      LController.Execute;
+    finally
+      LController.Free;
+    end;
+  end;
+end;
 
 { THorseController }
 
@@ -88,101 +171,34 @@ begin
   end;
 end;
 
-procedure THorseController.Get;
-begin
-end;
-
-procedure THorseController.Post;
-begin
-end;
-
-procedure THorseController.Put;
-begin
-end;
-
-procedure THorseController.Delete;
-begin
-end;
-
-procedure THorseController.Patch;
-begin
-end;
-
-procedure THorseController.Head;
-begin
-end;
+procedure THorseController.Get; begin end;
+procedure THorseController.Post; begin end;
+procedure THorseController.Put; begin end;
+procedure THorseController.Delete; begin end;
+procedure THorseController.Patch; begin end;
+procedure THorseController.Head; begin end;
 
 { THorseController<T> }
 
 class procedure THorseController<T>.Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
 var
-  LLength: Integer;
+  LCallback: THorseCallback;
 begin
-  LLength := Length(FRoutes);
-  SetLength(FRoutes, LLength + 1);
-  FRoutes[LLength].Path := APath;
-  FRoutes[LLength].MethodType := AMethodType;
-  FRoutes[LLength].MethodName := AMethodName;
+  THorseControllerRegistry.RegisterRoute(T, APath, AMethodType, AMethodName);
+
+  LCallback := {$IF DEFINED(FPC)} @THorseControllerRegistry.Dispatcher {$ELSE} THorseControllerRegistry.Dispatcher {$ENDIF};
 
   case AMethodType of
-    mtGet: THorse.Get(APath, Handle);
-    mtPost: THorse.Post(APath, Handle);
-    mtPut: THorse.Put(APath, Handle);
-    mtDelete: THorse.Delete(APath, Handle);
-    mtPatch: THorse.Patch(APath, Handle);
-    mtHead: THorse.Head(APath, Handle);
-    mtAny: THorse.Any(APath, Handle);
+    mtGet: THorse.Get(APath, LCallback);
+    mtPost: THorse.Post(APath, LCallback);
+    mtPut: THorse.Put(APath, LCallback);
+    mtDelete: THorse.Delete(APath, LCallback);
+    mtPatch: THorse.Patch(APath, LCallback);
+    mtHead: THorse.Head(APath, LCallback);
+    mtAny: THorse.All(APath, LCallback);
   end;
 end;
 
-type
-  TControllerAction = procedure of object;
-
-class procedure THorseController<T>.Handle(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
-var
-  LController: T;
-  LRoute: TControllerActionMap;
-  LMatched: Boolean;
-  LMethod: TMethod;
-  LAction: TControllerAction;
-  I: Integer;
-begin
-  LMatched := False;
-  LMethod.Code := nil;
-
-  for I := Low(FRoutes) to High(FRoutes) do
-  begin
-    LRoute := FRoutes[I];
-    if (LRoute.MethodType = ARequest.MethodType) or (LRoute.MethodType = mtAny) then
-    begin
-      if MatchRoute(ARequest.PathInfo, [LRoute.Path]) then
-      begin
-        LMatched := True;
-        Break;
-      end;
-    end;
-  end;
-
-  LController := T.Create(ARequest, AResponse, ANext);
-  try
-    if LMatched then
-    begin
-      LMethod.Code := LController.MethodAddress(LRoute.MethodName);
-      if LMethod.Code <> nil then
-      begin
-        LMethod.Data := LController;
-        LAction := TControllerAction(LMethod);
-        LAction();
-        Exit;
-      end
-      else
-        raise Exception.CreateFmt('Method "%s" not found or not published in controller "%s"', [LRoute.MethodName, LController.ClassName]);
-    end;
-
-    LController.Execute;
-  finally
-    LController.Free;
-  end;
-end;
+end.
 
 end.

--- a/src/Horse.Controller.pas
+++ b/src/Horse.Controller.pas
@@ -59,6 +59,9 @@ type
 
 implementation
 
+uses
+  Horse;
+
 { THorseController }
 
 constructor THorseController.Create(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc);
@@ -120,6 +123,16 @@ begin
   FRoutes[LLength].Path := APath;
   FRoutes[LLength].MethodType := AMethodType;
   FRoutes[LLength].MethodName := AMethodName;
+
+  case AMethodType of
+    mtGet: THorse.Get(APath, Handle);
+    mtPost: THorse.Post(APath, Handle);
+    mtPut: THorse.Put(APath, Handle);
+    mtDelete: THorse.Delete(APath, Handle);
+    mtPatch: THorse.Patch(APath, Handle);
+    mtHead: THorse.Head(APath, Handle);
+    mtAny: THorse.Any(APath, Handle);
+  end;
 end;
 
 type

--- a/src/Horse.Controller.pas
+++ b/src/Horse.Controller.pas
@@ -59,10 +59,6 @@ type
     class procedure Dispatcher(ARequest: THorseRequest; AResponse: THorseResponse; ANext: TNextProc); {$IF DEFINED(FPC)} static; {$ENDIF}
   end;
 
-  THorseController<T: THorseController, constructor> = class
-  public
-    class procedure Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
-  end;
 
 implementation
 
@@ -178,26 +174,6 @@ procedure THorseController.Delete; begin end;
 procedure THorseController.Patch; begin end;
 procedure THorseController.Head; begin end;
 
-{ THorseController<T> }
-
-class procedure THorseController<T>.Map(const APath: string; AMethodType: TMethodType; const AMethodName: string);
-var
-  LCallback: THorseCallback;
-begin
-  THorseControllerRegistry.RegisterRoute(T, APath, AMethodType, AMethodName);
-
-  LCallback := {$IF DEFINED(FPC)} @THorseControllerRegistry.Dispatcher {$ELSE} THorseControllerRegistry.Dispatcher {$ENDIF};
-
-  case AMethodType of
-    mtGet: THorse.Get(APath, LCallback);
-    mtPost: THorse.Post(APath, LCallback);
-    mtPut: THorse.Put(APath, LCallback);
-    mtDelete: THorse.Delete(APath, LCallback);
-    mtPatch: THorse.Patch(APath, LCallback);
-    mtHead: THorse.Head(APath, LCallback);
-    mtAny: THorse.All(APath, LCallback);
-  end;
-end;
 
 end.
 

--- a/src/Horse.Core.Group.Contract.pas
+++ b/src/Horse.Core.Group.Contract.pas
@@ -8,6 +8,7 @@ interface
 
 uses
   Horse.Core.Route.Contract,
+  Horse.Controller,
   Horse.Callback;
 
 type
@@ -65,6 +66,15 @@ type
 {$IFNDEF FPC}
     function Delete(const APath: string; const ACallback: THorseCallbackResponse): IHorseCoreGroup<T>; overload;
 {$IFEND}
+{$IFEND}
+    function All(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Get(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Put(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Head(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Post(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+    function Delete(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Patch(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
 {$IFEND}
     function &End: T;
   end;

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -9,6 +9,7 @@ interface
 uses
   Horse.Core.Group.Contract,
   Horse.Core.Route.Contract,
+  Horse.Controller,
   Horse.Callback;
 
 type
@@ -70,6 +71,15 @@ type
 {$IFNDEF FPC}
     function Delete(const APath: string; const ACallback: THorseCallbackResponse): IHorseCoreGroup<T>; overload;
 {$IFEND}
+{$IFEND}
+    function All(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Get(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Put(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Head(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Post(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+    function Delete(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
+    function Patch(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>; overload;
 {$IFEND}
     function &End: T;
   end;
@@ -334,5 +344,49 @@ begin
   Result := Self;
   THorseCore(FHorseCore).Post(NormalizePath(APath), ACallback);
 end;
+
+function THorseCoreGroup<T>.All(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).All(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+function THorseCoreGroup<T>.Get(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Get(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+function THorseCoreGroup<T>.Put(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Put(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+function THorseCoreGroup<T>.Head(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Head(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+function THorseCoreGroup<T>.Post(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Post(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+function THorseCoreGroup<T>.Delete(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Delete(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+
+function THorseCoreGroup<T>.Patch(const APath: string; AController: THorseControllerClass; const AMethodName: string): IHorseCoreGroup<T>;
+begin
+  THorseCore(FHorseCore).Patch(NormalizePath(APath), AController, AMethodName);
+  Result := Self;
+end;
+{$IFEND}
 
 end.

--- a/src/Horse.Core.Route.Contract.pas
+++ b/src/Horse.Core.Route.Contract.pas
@@ -7,6 +7,7 @@ unit Horse.Core.Route.Contract;
 interface
 
 uses
+  Horse.Controller,
   Horse.Callback;
 
 type
@@ -55,6 +56,15 @@ type
 {$IFNDEF FPC}
     function Delete(const ACallback: THorseCallbackResponse): IHorseCoreRoute<T>; overload;
 {$IFEND}
+{$IFEND}
+    function All(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Get(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Put(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Head(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Post(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+    function Delete(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Patch(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
 {$IFEND}
     function &End: T;
   end;

--- a/src/Horse.Core.Route.pas
+++ b/src/Horse.Core.Route.pas
@@ -11,6 +11,7 @@ uses
   SysUtils,
 {$ENDIF}
   Horse.Core.Route.Contract,
+  Horse.Controller,
   Horse.Callback;
 
 type
@@ -64,6 +65,15 @@ type
 {$IFNDEF FPC}
     function Delete(const ACallback: THorseCallbackResponse): IHorseCoreRoute<T>; overload;
 {$IFEND}
+{$IFEND}
+    function All(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Get(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Put(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Head(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Post(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+    function Delete(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
+    function Patch(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>; overload;
 {$IFEND}
     function &End: T;
   end;
@@ -286,5 +296,49 @@ begin
   THorseCore(FHorseCore).Put(FPath, ACallback);
   Result := Self;
 end;
+
+function THorseCoreRoute<T>.All(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).All(FPath, AController, AMethodName);
+end;
+
+function THorseCoreRoute<T>.Get(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Get(FPath, AController, AMethodName);
+end;
+
+function THorseCoreRoute<T>.Put(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Put(FPath, AController, AMethodName);
+end;
+
+function THorseCoreRoute<T>.Head(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Head(FPath, AController, AMethodName);
+end;
+
+function THorseCoreRoute<T>.Post(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Post(FPath, AController, AMethodName);
+end;
+
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+function THorseCoreRoute<T>.Delete(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Delete(FPath, AController, AMethodName);
+end;
+
+function THorseCoreRoute<T>.Patch(AController: THorseControllerClass; const AMethodName: string): IHorseCoreRoute<T>;
+begin
+  Result := Self;
+  THorseCore(FHorseCore).Patch(FPath, AController, AMethodName);
+end;
+{$IFEND}
 
 end.

--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -18,6 +18,7 @@ uses
   Horse.Request,
   Horse.Response,
   Horse.Callback,
+  Horse.Controller,
   Horse.Commons;
 
 type
@@ -31,13 +32,17 @@ type
     FResponse: THorseResponse;
     FMiddleware: TList<THorseCallback>;
     FCallBack: TObjectDictionary<TMethodType, TList<THorseCallback>>;
+    FControllers: TObjectDictionary<TMethodType, TControllerActionMap>;
+    FControllerExecuted: Boolean;
     FCallNextPath: TCallNextPath;
     FIsGroup: Boolean;
     FTag: string;
     FIsParamsKey: Boolean;
     FFound: ^Boolean;
+    procedure ExecuteController(const AAction: TControllerActionMap);
   public
     function Init: TNextCaller;
+    function SetControllers(const AControllers: TObjectDictionary<TMethodType, TControllerActionMap>): TNextCaller;
     function SetCallback(const ACallback: TObjectDictionary<TMethodType, TList<THorseCallback>>): TNextCaller;
     function SetPath(const APath: TQueue<string>): TNextCaller;
     function SetHTTPType(const AHTTPType: TMethodType): TNextCaller;
@@ -80,6 +85,7 @@ end;
 procedure TNextCaller.Next;
 var
   LCallback: TList<THorseCallback>;
+  LAction: TControllerActionMap;
 begin
   Inc(FIndex);
   if (FMiddleware.Count > FIndex) then
@@ -113,9 +119,29 @@ begin
         Next;
       end;
     end
+    else if Assigned(FControllers) and FControllers.TryGetValue(FHTTPType, LAction) then
+    begin
+      if not FControllerExecuted then
+      begin
+        FControllerExecuted := True;
+        FFound^ := True;
+        ExecuteController(LAction);
+        Next;
+      end;
+    end
+    else if Assigned(FControllers) and FControllers.TryGetValue(mtAny, LAction) then
+    begin
+      if not FControllerExecuted then
+      begin
+        FControllerExecuted := True;
+        FFound^ := True;
+        ExecuteController(LAction);
+        Next;
+      end;
+    end
     else
     begin
-      if FCallBack.Count > 0 then
+      if (FCallBack.Count > 0) or (Assigned(FControllers) and (FControllers.Count > 0)) then
       begin
         FFound^ := True;
         FResponse.Send('Method Not Allowed').Status(THTTPStatus.MethodNotAllowed);
@@ -126,8 +152,70 @@ begin
   end
   else
     FFound^ := FCallNextPath(FPath, FHTTPType, FRequest, FResponse);
+  
   if not FFound^ then
-    FResponse.Send('Not Found').Status(THTTPStatus.NotFound);
+  begin
+    if Assigned(FControllers) and FControllers.TryGetValue(FHTTPType, LAction) then
+    begin
+      if not FControllerExecuted then
+      begin
+        FControllerExecuted := True;
+        FFound^ := True;
+        ExecuteController(LAction);
+        Next;
+      end;
+    end
+    else if Assigned(FControllers) and FControllers.TryGetValue(mtAny, LAction) then
+    begin
+      if not FControllerExecuted then
+      begin
+        FControllerExecuted := True;
+        FFound^ := True;
+        ExecuteController(LAction);
+        Next;
+      end;
+    end
+    else
+      FResponse.Send('Not Found').Status(THTTPStatus.NotFound);
+  end;
+end;
+
+procedure TNextCaller.ExecuteController(const AAction: TControllerActionMap);
+type
+  TControllerAction = procedure of object;
+var
+  LController: THorseController;
+  LMethod: TMethod;
+  LActionProc: TControllerAction;
+begin
+  LController := AAction.ControllerClass.Create(FRequest, FResponse, Next);
+  try
+    {$IF DEFINED(FPC)}
+    LMethod.Code := Pointer(LController.MethodAddress(AAction.MethodName));
+    {$ELSE}
+    LMethod.Code := LController.MethodAddress(AAction.MethodName);
+    {$ENDIF}
+    
+    if LMethod.Code <> nil then
+    begin
+      LMethod.Data := Pointer(LController);
+      LActionProc := TControllerAction(LMethod);
+      LActionProc();
+      Exit;
+    end
+    else
+      raise Exception.CreateFmt('Method "%s" not found in controller "%s"', [AAction.MethodName, LController.ClassName]);
+      
+    LController.Execute;
+  finally
+    LController.Free;
+  end;
+end;
+
+function TNextCaller.SetControllers(const AControllers: TObjectDictionary<TMethodType, TControllerActionMap>): TNextCaller;
+begin
+  FControllers := AControllers;
+  Result := Self;
 end;
 
 function TNextCaller.SetCallback(const ACallback: TObjectDictionary<TMethodType, TList<THorseCallback>>): TNextCaller;

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -19,6 +19,7 @@ uses
   Horse.Request,
   Horse.Response,
   Horse.Callback,
+  Horse.Controller,
   Horse.Commons;
 
 type
@@ -39,8 +40,10 @@ type
     FMiddleware: TList<THorseCallback>;
     FRegexedKeys: TList<string>;
     FCallBack: TObjectDictionary<TMethodType, TList<THorseCallback>>;
+    FControllers: TObjectDictionary<TMethodType, TControllerActionMap>;
     FRoute: TObjectDictionary<string, THorseRouterTree>;
     procedure RegisterInternal(const AHTTPType: TMethodType; var APath: TQueue<string>; const ACallback: THorseCallback);
+    procedure RegisterControllerInternal(const AHTTPType: TMethodType; var APath: TQueue<string>; const AAction: TControllerActionMap);
     procedure RegisterMiddlewareInternal(var APath: TQueue<string>; const AMiddleware: THorseCallback);
     function ExecuteInternal(const APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse; const AIsGroup: Boolean = False): Boolean;
     function CallNextPath(var APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean;
@@ -50,6 +53,7 @@ type
     function GetPrefix: string;
     procedure Prefix(const APrefix: string);
     procedure RegisterRoute(const AHTTPType: TMethodType; const APath: string; const ACallback: THorseCallback);
+    procedure RegisterController(const AHTTPType: TMethodType; const APath: string; AController: THorseControllerClass; const AMethodName: string);
     procedure RegisterMiddleware(const APath: string; const AMiddleware: THorseCallback); overload;
     procedure RegisterMiddleware(const AMiddleware: THorseCallback); overload;
     function Execute(const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean;
@@ -80,6 +84,43 @@ begin
   finally
     LPathChain.Free;
   end;
+end;
+
+procedure THorseRouterTree.RegisterController(const AHTTPType: TMethodType; const APath: string; AController: THorseControllerClass; const AMethodName: string);
+var
+  LQueue: TQueue<string>;
+  LAction: TControllerActionMap;
+begin
+  LQueue := GetQueuePath(APath);
+  try
+    LAction.ControllerClass := AController;
+    LAction.MethodName := AMethodName;
+    LAction.MethodType := AHTTPType;
+    LAction.Path := APath;
+    RegisterControllerInternal(AHTTPType, LQueue, LAction);
+  finally
+    LQueue.Free;
+  end;
+end;
+
+procedure THorseRouterTree.RegisterControllerInternal(const AHTTPType: TMethodType; var APath: TQueue<string>; const AAction: TControllerActionMap);
+var
+  LCurrentPath: string;
+  LNextRoute: THorseRouterTree;
+begin
+  if APath.Count = 0 then
+  begin
+    FControllers.AddOrSetValue(AHTTPType, AAction);
+    Exit;
+  end;
+
+  LCurrentPath := APath.Dequeue;
+  if not FRoute.TryGetValue(LCurrentPath, LNextRoute) then
+  begin
+    LNextRoute := THorseRouterTree.Create;
+    FRoute.Add(LCurrentPath, LNextRoute);
+  end;
+  LNextRoute.RegisterControllerInternal(AHTTPType, APath, AAction);
 end;
 
 function THorseRouterTree.CallNextPath(var APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest;
@@ -124,6 +165,7 @@ begin
   FRoute := TObjectDictionary<string, THorseRouterTree>.Create([doOwnsValues]);
   FRegexedKeys := TList<string>.Create;
   FCallBack := TObjectDictionary < TMethodType, TList < THorseCallback >>.Create([doOwnsValues]);
+  FControllers := TObjectDictionary<TMethodType, TControllerActionMap>.Create;
   FPrefix := '';
   FIsRouterRegex := False;
 end;
@@ -135,6 +177,7 @@ begin
   FRegexedKeys.Clear;
   FRegexedKeys.Free;
   FCallBack.Free;
+  FControllers.Free;
   inherited;
 end;
 
@@ -177,6 +220,7 @@ begin
   LNextCaller := TNextCaller.Create;
   try
     LNextCaller.SetCallback(FCallBack);
+    LNextCaller.SetControllers(FControllers);
     LNextCaller.SetPath(APath);
     LNextCaller.SetHTTPType(AHTTPType);
     LNextCaller.SetRequest(ARequest);

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -122,6 +122,15 @@ type
     class function Delete(const APath: string; const ACallback: THorseCallbackResponse): THorseCore; overload;
 {$IFEND}
 {$IFEND}
+    class function All(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+    class function Get(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+    class function Put(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+    class function Head(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+    class function Post(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+    class function Delete(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+    class function Patch(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore; overload;
+{$IFEND}
     class property Routes: THorseRouterTree read GetRoutes write SetRoutes;
     class function GetInstance: THorseCore;
     class function Version: string;
@@ -383,22 +392,55 @@ begin
   Result := HORSE_VERSION;
 end;
 
+class function THorseCore.All(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtAny, AMethodName);
+end;
+
+class function THorseCore.Get(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtGet, AMethodName);
+end;
+
+class function THorseCore.Put(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtPut, AMethodName);
+end;
+
+class function THorseCore.Head(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtHead, AMethodName);
+end;
+
+class function THorseCore.Post(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtPost, AMethodName);
+end;
+
+{$IF (defined(fpc) or (CompilerVersion > 27.0))}
+class function THorseCore.Delete(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtDelete, AMethodName);
+end;
+
+class function THorseCore.Patch(const APath: string; AController: THorseControllerClass; const AMethodName: string): THorseCore;
+begin
+  Result := Map(AController, APath, mtPatch, AMethodName);
+end;
+{$IFEND}
+
 class function THorseCore.Map(AController: THorseControllerClass; const APath: string; AMethodType: TMethodType; const AMethodName: string): THorseCore;
 var
-  LCallback: THorseCallback;
+  LMethod: TMethodType;
 begin
   Result := GetInstance;
-  THorseControllerRegistry.RegisterRoute(AController, APath, AMethodType, AMethodName);
-  LCallback := {$IF DEFINED(FPC)} @THorseControllerRegistry.Dispatcher {$ELSE} THorseControllerRegistry.Dispatcher {$ENDIF};
-  case AMethodType of
-    mtGet: Get(APath, LCallback);
-    mtPost: Post(APath, LCallback);
-    mtPut: Put(APath, LCallback);
-    mtDelete: Delete(APath, LCallback);
-    mtPatch: Patch(APath, LCallback);
-    mtHead: Head(APath, LCallback);
-    mtAny: All(APath, LCallback);
-  end;
+  if AMethodType = mtAny then
+  begin
+    for LMethod := Low(TMethodType) to High(TMethodType) do
+      Result.GetRoutes.RegisterController(LMethod, TrimPath(APath), AController, AMethodName);
+  end
+  else
+    Result.GetRoutes.RegisterController(AMethodType, TrimPath(APath), AController, AMethodName);
 end;
 
 class function THorseCore.Use(const APath: string; const ACallbacks: array of THorseCallback): THorseCore;

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -17,6 +17,7 @@ uses
   Horse.Callback,
   Horse.Core.Group.Contract,
   Horse.Core.Route.Contract,
+  Horse.Controller,
   Horse.Commons;
 
 type
@@ -124,6 +125,7 @@ type
     class property Routes: THorseRouterTree read GetRoutes write SetRoutes;
     class function GetInstance: THorseCore;
     class function Version: string;
+    class function Map(AController: THorseControllerClass; const APath: string; AMethodType: TMethodType; const AMethodName: string): THorseCore;
   end;
 
 implementation
@@ -379,6 +381,24 @@ end;
 class function THorseCore.Version: string;
 begin
   Result := HORSE_VERSION;
+end;
+
+class function THorseCore.Map(AController: THorseControllerClass; const APath: string; AMethodType: TMethodType; const AMethodName: string): THorseCore;
+var
+  LCallback: THorseCallback;
+begin
+  Result := GetInstance;
+  THorseControllerRegistry.RegisterRoute(AController, APath, AMethodType, AMethodName);
+  LCallback := {$IF DEFINED(FPC)} @THorseControllerRegistry.Dispatcher {$ELSE} THorseControllerRegistry.Dispatcher {$ENDIF};
+  case AMethodType of
+    mtGet: Get(APath, LCallback);
+    mtPost: Post(APath, LCallback);
+    mtPut: Put(APath, LCallback);
+    mtDelete: Delete(APath, LCallback);
+    mtPatch: Patch(APath, LCallback);
+    mtHead: Head(APath, LCallback);
+    mtAny: All(APath, LCallback);
+  end;
 end;
 
 class function THorseCore.Use(const APath: string; const ACallbacks: array of THorseCallback): THorseCore;

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -68,7 +68,6 @@ type
   PHorseRouterTree = Horse.Core.RouterTree.PHorseRouterTree;
   THorseController = Horse.Controller.THorseController;
   THorseControllerClass = Horse.Controller.THorseControllerClass;
-  THorseController<T: THorseController, constructor> = Horse.Controller.THorseController<T>;
 
 {$IF DEFINED(HORSE_ISAPI)}
   THorseProvider = Horse.Provider.ISAPI.THorseProvider;

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -44,7 +44,8 @@ uses
   Horse.Exception,
   Horse.Exception.Interrupted,
   Horse.Core.Param.Config,
-  Horse.Callback;
+  Horse.Callback,
+  Horse.Controller;
 
 type
   EHorseException = Horse.Exception.EHorseException;
@@ -65,6 +66,9 @@ type
   PHorseModule = Horse.Core.PHorseModule;
   PHorseCore = Horse.Core.PHorseCore;
   PHorseRouterTree = Horse.Core.RouterTree.PHorseRouterTree;
+  THorseController = Horse.Controller.THorseController;
+  THorseControllerClass = Horse.Controller.THorseControllerClass;
+  THorseController<T: THorseController, constructor> = Horse.Controller.THorseController<T>;
 
 {$IF DEFINED(HORSE_ISAPI)}
   THorseProvider = Horse.Provider.ISAPI.THorseProvider;

--- a/tests/src/tests/Tests.Horse.Controller.pas
+++ b/tests/src/tests/Tests.Horse.Controller.pas
@@ -1,0 +1,80 @@
+unit Tests.Horse.Controller;
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Horse,
+  {$IF DEFINED(FPC)}
+  SysUtils,
+  fpHTTP
+  {$ELSE}
+  System.SysUtils,
+  Web.HTTPApp
+  {$ENDIF};
+
+type
+  TMyController = class(THorseController)
+  public
+    class var Executed: Boolean;
+    procedure Get; override;
+  end;
+
+  TMyRequestMock = class(THorseRequest)
+  public
+    function MethodType: TMethodType; override;
+  end;
+
+  [TestFixture]
+  TTestHorseController = class
+  public
+    [Setup]
+    procedure Setup;
+    [Test]
+    procedure TestHandle;
+  end;
+
+implementation
+
+{ TMyController }
+
+procedure TMyController.Get;
+begin
+  Executed := True;
+end;
+
+{ TMyRequestMock }
+
+function TMyRequestMock.MethodType: TMethodType;
+begin
+  Result := mtGet;
+end;
+
+{ TTestHorseController }
+
+procedure TTestHorseController.Setup;
+begin
+  TMyController.Executed := False;
+end;
+
+procedure TTestHorseController.TestHandle;
+var
+  LReq: TMyRequestMock;
+begin
+  LReq := TMyRequestMock.Create(nil);
+  try
+    THorseController<TMyController>.Handle(LReq, nil, nil);
+    Assert.IsTrue(TMyController.Executed);
+  finally
+    LReq.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestHorseController);
+
+end.

--- a/tests/src/tests/Tests.Horse.Controller.pas
+++ b/tests/src/tests/Tests.Horse.Controller.pas
@@ -18,15 +18,28 @@ uses
   {$ENDIF};
 
 type
+  {$M+}
   TMyController = class(THorseController)
   public
-    class var Executed: Boolean;
+    class var ExecutedGet: Boolean;
+    class var ExecutedListUsers: Boolean;
+    class var ExecutedGetUserById: Boolean;
+    
     procedure Get; override;
+  published
+    procedure ListUsers;
+    procedure GetUserById;
   end;
+  {$M-}
 
   TMyRequestMock = class(THorseRequest)
+  private
+    FMethodType: TMethodType;
+    FPathInfo: string;
   public
     function MethodType: TMethodType; override;
+    function PathInfo: string; override;
+    constructor Create(AMethod: TMethodType; const APathInfo: string);
   end;
 
   [TestFixture]
@@ -34,8 +47,15 @@ type
   public
     [Setup]
     procedure Setup;
+    
     [Test]
-    procedure TestHandle;
+    procedure TestFallbackToExecute;
+    
+    [Test]
+    procedure TestMappedMethodListUsers;
+    
+    [Test]
+    procedure TestMappedMethodGetUserById;
   end;
 
 implementation
@@ -44,31 +64,89 @@ implementation
 
 procedure TMyController.Get;
 begin
-  Executed := True;
+  ExecutedGet := True;
+end;
+
+procedure TMyController.ListUsers;
+begin
+  ExecutedListUsers := True;
+end;
+
+procedure TMyController.GetUserById;
+begin
+  ExecutedGetUserById := True;
 end;
 
 { TMyRequestMock }
 
+constructor TMyRequestMock.Create(AMethod: TMethodType; const APathInfo: string);
+begin
+  inherited Create(nil);
+  FMethodType := AMethod;
+  FPathInfo := APathInfo;
+end;
+
 function TMyRequestMock.MethodType: TMethodType;
 begin
-  Result := mtGet;
+  Result := FMethodType;
+end;
+
+function TMyRequestMock.PathInfo: string;
+begin
+  Result := FPathInfo;
 end;
 
 { TTestHorseController }
 
 procedure TTestHorseController.Setup;
 begin
-  TMyController.Executed := False;
+  TMyController.ExecutedGet := False;
+  TMyController.ExecutedListUsers := False;
+  TMyController.ExecutedGetUserById := False;
+  
+  // Register routes mapping for testing
+  THorseController<TMyController>.Map('/users', mtGet, 'ListUsers');
+  THorseController<TMyController>.Map('/users/:id', mtGet, 'GetUserById');
 end;
 
-procedure TTestHorseController.TestHandle;
+procedure TTestHorseController.TestFallbackToExecute;
 var
   LReq: TMyRequestMock;
 begin
-  LReq := TMyRequestMock.Create(nil);
+  // A path that is not mapped but falls back to standard execution
+  LReq := TMyRequestMock.Create(mtGet, '/unmapped/path');
   try
     THorseController<TMyController>.Handle(LReq, nil, nil);
-    Assert.IsTrue(TMyController.Executed);
+    Assert.IsTrue(TMyController.ExecutedGet);
+    Assert.IsFalse(TMyController.ExecutedListUsers);
+  finally
+    LReq.Free;
+  end;
+end;
+
+procedure TTestHorseController.TestMappedMethodListUsers;
+var
+  LReq: TMyRequestMock;
+begin
+  LReq := TMyRequestMock.Create(mtGet, '/users');
+  try
+    THorseController<TMyController>.Handle(LReq, nil, nil);
+    Assert.IsTrue(TMyController.ExecutedListUsers);
+    Assert.IsFalse(TMyController.ExecutedGet);
+  finally
+    LReq.Free;
+  end;
+end;
+
+procedure TTestHorseController.TestMappedMethodGetUserById;
+var
+  LReq: TMyRequestMock;
+begin
+  LReq := TMyRequestMock.Create(mtGet, '/users/123');
+  try
+    THorseController<TMyController>.Handle(LReq, nil, nil);
+    Assert.IsTrue(TMyController.ExecutedGetUserById);
+    Assert.IsFalse(TMyController.ExecutedListUsers);
   finally
     LReq.Free;
   end;


### PR DESCRIPTION
# Statefull Controllers no Horse: Arquitetura e Implementação

O Horse agora suporta o padrão **Statefull Controller**, permitindo que as rotas sejam gerenciadas por classes. Esta abordagem facilita a organização do código, a injeção de dependências e o isolamento de estado por requisição.

A implementação foi desenhada para ser fluida em ambas as IDEs, respeitando as particularidades de cada compilador.

---

## 1. O Conceito Base

Diferente do modelo funcional, o modelo de classes instancia um objeto único para cada requisição HTTP. A infraestrutura do Horse garante o ciclo de vida completo: **Instanciar -> Mapear Rota -> Executar Método -> Destruir**.

### Benefícios
- **Isolamento de Estado:** Cada requisição possui sua própria instância da classe (Thread-Safe).
- **Gerenciamento de Memória Determinístico:** Utiliza o padrão `try..finally` internamente na base.
- **Roteamento Dinâmico:** Uma única classe gerencia múltiplos endpoints relacionados.

---

## 2. Como Utilizar: Exemplo Embarcadero Delphi

No Delphi, utilizamos as units padrão do framework e a RTTI nativa.

### Controller (UController.pas)
```pascal
unit UController;

interface

uses Horse, Horse.Controller, System.SysUtils, System.JSON;

type
  {$M+} // Ativa a RTTI para os métodos published
  TUserController = class(THorseController)
  published
    procedure ListUsers;
    procedure GetUserById;
  end;
  {$M-}

implementation

procedure TUserController.ListUsers;
var
  LJSON: TJSONArray;
begin
  LJSON := TJSONArray.Create;
  LJSON.Add('Lucas');
  LJSON.Add('Horse');
  Response.Send(LJSON).Status(200);
end;

procedure TUserController.GetUserById;
begin
  Response.Send('ID: ' + Request.Params['id']).Status(200);
end;

end.
```

### Projeto (DelphiProject.dpr)
```pascal
program DelphiProject;

{$APPTYPE CONSOLE}

uses Horse, Horse.Controller, Horse.Commons, UController;

begin
  THorse.Map(TControllerTeste,'/users', mtGet, 'ListUsers');
  THorse.Map(TControllerTeste,'/users/:id', mtGet, 'GetUserById');

  THorse.Listen(9000);
end.
```

---

## 3. Como Utilizar: Exemplo Lazarus (FreePascal)

No Lazarus, é fundamental o uso da diretiva `{$MODE DELPHI}` e o tratamento correto das units de JSON do FPC.

### Controller (ucontroller.pas)
```pascal
unit ucontroller;

{$mode delphi}{$H+}

interface

uses Horse, Horse.Controller, SysUtils, fpjson;

type
  {$M+} // Ativa a RTTI para os métodos published no FPC
  TUserController = class(THorseController)
  published
    procedure ListUsers;
    procedure GetUserById;
  end;
  {$M-}

implementation

procedure TUserController.ListUsers;
var
  LJSON: TJSONArray;
begin
  LJSON := TJSONArray.Create;
  LJSON.Add('Lazarus User');
  LJSON.Add('FPC Power');
  Response.Send(LJSON.AsJSON).Status(200);
end;

procedure TUserController.GetUserById;
begin
  Response.Send('FPC ID: ' + Request.Params['id']).Status(200);
end;

end.
```

### Projeto (LazarusProject.lpr)

**Nota de Configuração:** Para que o compilador encontre as units do Horse, você deve adicionar o caminho para a pasta `src` do Horse nas configurações do seu projeto. Vá em **Project > Project Options > Compiler Options > Paths > Other unit files (-Fu)** e adicione o caminho.

```pascal
program LazarusProject;

{$mode delphi}{$H+}

uses
  {$IFDEF UNIX}
  cthreads,
  {$ENDIF}
  Horse, Horse.Controller, Horse.Commons, ControllerTeste;

procedure TesteJwt(AReq: THorseRequest; ARes: THorseResponse; ANext: TNextProc);
begin
  ANext();
end;

begin
  // exemplo com e sem middlewares diretamente na chamada
  THorse.AddCallback(TesteJwt).Map(TControllerTeste,'/users', mtGet, 'ListUsers');
  THorse.AddCallback(TesteJwt).Map(TControllerTeste,'/users/:id', mtGet, 'GetUserById');

  THorse.Map(TControllerTeste,'/users', mtGet, 'ListUsers');
  THorse.Map(TControllerTeste,'/users/:id', mtGet, 'GetUserById');

  THorse.Listen(9001);
end. 
```

---

## 4. Principais Diferenças de Implementação

| Recurso | Delphi | Lazarus (FPC) |
| :--- | :--- | :--- |
| **Diretiva de Linguagem** | Padrão da IDE. | Requer `{$MODE DELPHI}` no topo das units. |
| **JSON** | `System.JSON` (TJSONObject, TJSONArray). | `fpjson` (TJSONObject, TJSONArray). |
| **RTTI (`$M+`)** | Nativa e habilitada por padrão em muitas classes. | Obrigatória para expor métodos ao `MethodAddress`. |
| **Gerenciamento de Strings** | Unicode por padrão. | Requer `{$H+}` para AnsiString/Unicode moderno. |

---

## 5. Melhorias na Base do Horse

1.  **Unit `Horse.Controller.pas`**: Centraliza a lógica de ciclo de vida.
2.  **Dispatcher por `MethodAddress`**: Utiliza a localização física do método na memória para execução, garantindo alta performance sem depender de frameworks de RTTI pesados.
3.  **Auto-Registro**: O método `Map` injeta a rota diretamente no `THorse`, validando o verbo HTTP.