### PR TITLE
feat: integrate CrossSocket / mORMot transport providers + PATCH-HORSE-2 three-axis defines + bilingual docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,23 +72,25 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 | `THorseRequest` / `THorseResponse` — body, headers, cookies, sessions, status, streaming | [Request & Response](./doc/request-response.md) |
 | Using middleware, registration order, the `Next` proc | [Middleware](./doc/middleware.md) |
 | **Writing & publishing your own middleware** — skeleton, thread safety, Provider neutrality, Boss packaging | [**Writing a Middleware**](./doc/writing-middleware.md) |
-| **Choosing a transport provider** — Indy (default), CrossSocket, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.md) |
+| **Choosing a transport provider** — Indy (default), CrossSocket, mORMot2, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.md) |
 | **Deploy** as Console / VCL / Daemon / Windows Service / LCL / HTTPApplication — one-page recipe | [**Deployment Cheatsheet**](./doc/deployment.md) |
 | Full middleware catalogue with extended descriptions | [Middleware Ecosystem](./doc/middleware-ecosystem.md) |
 | Supported Delphi / FPC versions and platforms | [Compiler Support](./doc/compiler-support.md) |
 
 ## 🔌 Providers (transport layer)
 
-A _provider_ is the HTTP transport that owns the socket and hands requests to your route handlers. **The same handler code runs under any provider** — you select one at compile time via a Conditional Define. The default Provider depends on the compiler: **Indy** on Delphi (for Console / VCL / Daemon), **`fphttpserver`** on FPC (for Daemon / HTTPApplication / LCL). The optional **CrossSocket** Provider replaces both with async **IOCP / epoll / kqueue** I/O.
+A _provider_ is the HTTP transport that owns the socket and hands requests to your route handlers. **The same handler code runs under any provider** — you select one at compile time via a Conditional Define. The default Provider depends on the compiler: **Indy** on Delphi (for Console / VCL / Daemon), **`fphttpserver`** on FPC (for Daemon / HTTPApplication / LCL). The optional **CrossSocket** and **mORMot2** Providers replace both with async **IOCP / epoll / kqueue** I/O.
 
 | Provider | Compiler define | Delphi | Lazarus |
 | ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
 | **Indy** _(Delphi default for self-hosted)_                                                     | _(none)_                | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
 | **`fphttpserver`** _(FPC default for self-hosted)_                                              | _(none)_                | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| _(planned)_ horse-provider-mormot                                                                | `HORSE_MORMOT`          | &nbsp;&nbsp;&nbsp;—  | &nbsp;&nbsp;&nbsp;&nbsp;—  |
+| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Note** — Apache / ISAPI / CGI / FastCGI Application types (below) do **not** use any of these Providers. The host process (Apache, IIS, the web server) owns the socket; Horse runs in-process. See [Providers & Application types](./doc/providers.md) for the full model.
+
+> **Delphi-Cross-Socket installation** — clone [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) **plus** [`cnpack/cnvcl/.../Crypto`](https://github.com/cnpack/cnvcl/tree/master/Source/Crypto) for the required CnPack/Crypto units, and add search paths to your project. Three previously-fork-only bug fixes have been merged into upstream as of 2026-Q2, so the upstream mainline is correct for general use. For server-side **mutual TLS** (`SSLVerifyPeer = True` + `SSLCACertFile = ...`) use the pre-built release [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) — single clone, CnPack bundled, mTLS APIs (`SetCACertificateFile` + `SetVerifyPeer`) ready to use. See [horse-provider-crosssocket Installation](./doc/providers.md#crosssocket-optional) for the full two-path breakdown.
 
 ## 🎯 Application types
 
@@ -99,7 +101,8 @@ How the binary is packaged and started. **Self-hosted** types run under the chos
 | _**Self-hosted** (uses the selected Provider)_                                                                                                                            |
 | [Console](./doc/providers.md) _(default)_                                    | _(none)_          | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [VCL](./doc/providers.md)                                                    | `HORSE_VCL`       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
-| [Daemon](./doc/providers.md) (Windows service)                               | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| [Daemon — Windows Service](./doc/providers.md)                               | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
+| [Daemon — Linux daemon (systemd)](./doc/providers.md)                        | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [LCL](./doc/providers.md) (Lazarus GUI)                                      | `HORSE_LCL`       | &nbsp;&nbsp;&nbsp;❌ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [HTTPApplication](./doc/providers.md) (FPC)                                  | _(FPC default)_   | &nbsp;&nbsp;&nbsp;❌ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | _**Host-managed** (the web server owns the socket; Provider above is unused)_                                                                                            |
@@ -107,6 +110,13 @@ How the binary is packaged and started. **Self-hosted** types run under the chos
 | [ISAPI](./doc/providers.md) (IIS)                                            | `HORSE_ISAPI`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 | [CGI](./doc/providers.md)                                                    | `HORSE_CGI`       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [FastCGI](./doc/providers.md)                                                | `HORSE_FCGI`      | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+
+> **Note** – `HORSE_DAEMON` is a **platform‑adaptive** application type:  
+> - On **Windows** → compiles as a Windows Service (`Vcl.SvcMgr.TService` + SCM)  
+> - On **Linux** → compiles as a systemd daemon (uses `signal(SIGTERM)` + systemd)  
+>  
+> “Daemon” is the Unix‑native term; Windows has no exact equivalent, so the same define name is used across platforms.
+
 
 See [Providers](./doc/providers.md) for the full compatibility matrix and how to combine Provider × Application type.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -72,23 +72,25 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 | `THorseRequest` / `THorseResponse` — body, headers, cookies, sessions, status, streaming | [Request e Response](./doc/request-response.pt-BR.md) |
 | Usar middleware, ordem de registro, o `Next` proc | [Middleware](./doc/middleware.pt-BR.md) |
 | **Criar e publicar seu próprio middleware** — esqueleto, thread safety, neutralidade a Provider, empacotamento Boss | [**Criando um Middleware**](./doc/writing-middleware.pt-BR.md) |
-| **Escolher um provider de transporte** — Indy (padrão), CrossSocket, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.pt-BR.md) |
+| **Escolher um provider de transporte** — Indy (padrão), CrossSocket, mORMot2, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.pt-BR.md) |
 | **Deploy** como Console / VCL / Daemon / Serviço Windows / LCL / HTTPApplication — receita de uma página | [**Cheatsheet de Deploy**](./doc/deployment.pt-BR.md) |
 | Catálogo completo de middlewares com descrições estendidas | [Ecossistema de Middlewares](./doc/middleware-ecosystem.pt-BR.md) |
 | Versões suportadas de Delphi / FPC e plataformas | [Suporte de Compilador](./doc/compiler-support.pt-BR.md) |
 
 ## 🔌 Providers (camada de transporte)
 
-Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições aos seus handlers de rota. **O mesmo código de handler roda em qualquer provider** — você seleciona um em tempo de compilação via uma Conditional Define. O Provider padrão depende do compilador: **Indy** no Delphi (para Console / VCL / Daemon), **`fphttpserver`** no FPC (para Daemon / HTTPApplication / LCL). O Provider **CrossSocket** opcional substitui ambos por E/S assíncrona **IOCP / epoll / kqueue**.
+Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições aos seus handlers de rota. **O mesmo código de handler roda em qualquer provider** — você seleciona um em tempo de compilação via uma Conditional Define. O Provider padrão depende do compilador: **Indy** no Delphi (para Console / VCL / Daemon), **`fphttpserver`** no FPC (para Daemon / HTTPApplication / LCL). Os Providers opcionais **CrossSocket** e **mORMot2** substituem ambos por E/S assíncrona **IOCP / epoll / kqueue**.
 
 | Provider | Define de compilação | Delphi | Lazarus |
 | ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
 | **Indy** _(padrão Delphi para self-hosted)_                                                     | _(nenhum)_              | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
 | **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| _(planejado)_ horse-provider-mormot                                                              | `HORSE_MORMOT`          | &nbsp;&nbsp;&nbsp;—  | &nbsp;&nbsp;&nbsp;&nbsp;—  |
+| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Nota** — Os tipos de aplicação Apache / ISAPI / CGI / FastCGI (abaixo) **não** usam nenhum desses Providers. O processo host (Apache, IIS, o webserver) é dono do socket; o Horse roda in-process. Veja [Providers e Tipos de aplicação](./doc/providers.pt-BR.md) para o modelo completo.
+
+> **Instalação do Delphi-Cross-Socket** — clone [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) **junto com** [`cnpack/cnvcl/.../Crypto`](https://github.com/cnpack/cnvcl/tree/master/Source/Crypto) para as units CnPack/Crypto exigidas, e adicione os _search paths_ ao seu projeto. Três correções que antes eram exclusivas do fork já foram incorporadas ao upstream desde o 2º trimestre de 2026, então o mainline do upstream é adequado para uso geral. Para **mTLS** do lado servidor (`SSLVerifyPeer = True` + `SSLCACertFile = ...`) use o release pré-empacotado [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) — um único clone, CnPack já incluso, APIs de mTLS (`SetCACertificateFile` + `SetVerifyPeer`) prontas para uso. Veja [Instalação do horse-provider-crosssocket](./doc/providers.pt-BR.md#crosssocket-opcional) para o detalhamento completo dos dois caminhos.
 
 ## 🎯 Tipos de aplicação
 
@@ -99,7 +101,8 @@ Como o binário é empacotado e iniciado. Tipos **self-hosted** rodam sob o Prov
 | _**Self-hosted** (usa o Provider selecionado)_                                                                                                                            |
 | [Console](./doc/providers.pt-BR.md) _(padrão)_                              | _(nenhum)_        | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [VCL](./doc/providers.pt-BR.md)                                              | `HORSE_VCL`       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
-| [Daemon](./doc/providers.pt-BR.md) (serviço Windows)                        | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| [Daemon — Serviço Windows](./doc/providers.pt-BR.md)                        | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
+| [Daemon — daemon Linux (systemd)](./doc/providers.pt-BR.md)                 | `HORSE_DAEMON`    | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [LCL](./doc/providers.pt-BR.md) (GUI Lazarus)                               | `HORSE_LCL`       | &nbsp;&nbsp;&nbsp;❌ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [HTTPApplication](./doc/providers.pt-BR.md) (FPC)                           | _(padrão FPC)_    | &nbsp;&nbsp;&nbsp;❌ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | _**Host-managed** (o webserver é dono do socket; Provider acima não é usado)_                                                                                              |
@@ -107,6 +110,13 @@ Como o binário é empacotado e iniciado. Tipos **self-hosted** rodam sob o Prov
 | [ISAPI](./doc/providers.pt-BR.md) (IIS)                                     | `HORSE_ISAPI`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 | [CGI](./doc/providers.pt-BR.md)                                              | `HORSE_CGI`       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | [FastCGI](./doc/providers.pt-BR.md)                                          | `HORSE_FCGI`      | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+
+> **Nota** – `HORSE_DAEMON` é um tipo de aplicação **adaptável à plataforma**:  
+> - No **Windows** → compila como um **Serviço Windows** (`Vcl.SvcMgr.TService` + SCM)  
+> - No **Linux** → compila como um **daemon systemd** (utiliza `signal(SIGTERM)` + systemd)  
+>  
+> “Daemon” é o termo nativo do Unix; o Windows não possui um equivalente exato, por isso o mesmo nome da definição é usado em ambas as plataformas.
+
 
 Veja [Providers](./doc/providers.pt-BR.md) para a matriz de compatibilidade completa e como combinar Provider × Tipo de aplicação.
 

--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
   "name": "horse",
   "description": "Horse web framework \u2014 CrossSocket-compatible fork",
-  "version": "3.1.98",
+  "version": "3.1.99",
   "homepage": "https://github.com/freitasjca/horse",
   "license": "MIT",
   "mainsrc": "src/",

--- a/doc/compiler-support.md
+++ b/doc/compiler-support.md
@@ -4,7 +4,7 @@
 
 Horse targets a broad range of Delphi and Free Pascal versions. This page lists what's supported, what's tested, and the per-Provider / per-Application-type considerations.
 
-For the two-axis model (Provider — Indy / fphttpserver / CrossSocket — × Application type — Console / VCL / Daemon / Apache / ISAPI / CGI / FCGI / LCL / HTTPApplication), see [Providers & Application types](./providers.md).
+For the two-axis model (Provider — Indy / fphttpserver / CrossSocket / mORMot2 — × Application type — Console / VCL / Daemon / Apache / ISAPI / CGI / FCGI / LCL / HTTPApplication), see [Providers & Application types](./providers.md).
 
 ---
 
@@ -39,15 +39,15 @@ The platform set depends on which Provider is selected and which Application typ
 
 ### Self-hosted Providers × Platform
 
-The Provider that owns the socket. Indy is Delphi-only; `fphttpserver` is FPC-only; CrossSocket spans both.
+The Provider that owns the socket. Indy is Delphi-only; `fphttpserver` is FPC-only; CrossSocket and mORMot2 span both.
 
-| Platform | Indy _(Delphi default)_ | `fphttpserver` _(FPC default)_ | CrossSocket _(`HORSE_PROVIDER_CROSSSOCKET`; legacy alias `HORSE_CROSSSOCKET`)_ |
-|---|:---:|:---:|:---:|
-| Windows x86 / x64 | ✔ | ✔ | ✔ |
-| Linux x64 | ✔ | ✔ | ✔ _(primary target)_ |
-| macOS Intel / ARM64 | ✔ | ✔ | ✔ |
-| FreeBSD | — | ✔ | ✔ _(via kqueue)_ |
-| Android / iOS | — | — | — |
+| Platform | Indy _(Delphi default)_ | `fphttpserver` _(FPC default)_ | CrossSocket _(`HORSE_PROVIDER_CROSSSOCKET`)_ | mORMot2 _(`HORSE_PROVIDER_MORMOT`)_ |
+|---|:---:|:---:|:---:|:---:|
+| Windows x86 / x64 | ✔ | ✔ | ✔ _(IOCP)_ | ✔ _(IOCP; also http.sys via `THttpApiServer`)_ |
+| Linux x64 | ✔ | ✔ | ✔ _(epoll, primary target)_ | ✔ _(epoll)_ |
+| macOS Intel / ARM64 | ✔ | ✔ | ✔ _(kqueue)_ | ✔ |
+| FreeBSD | — | ✔ | ✔ _(kqueue)_ | ✔ _(kqueue)_ |
+| Android / iOS | — | — | — | — |
 
 ### Host-managed Application types × Platform
 
@@ -83,11 +83,24 @@ These don't use a self-hosted Provider — the host process owns the socket. Cov
 - Requires **FPC 3.2.0 or later** for FPC builds.
 - Tested platforms: Windows x64, Linux x64, macOS ARM64.
 - Replaces Indy (Delphi) and `fphttpserver` (FPC) with a single async transport for both compilers.
-- See [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket#readme) for the current per-version test matrix.
+- **Installation is manual** (mirrors the mORMot2 install pattern, not Boss): clone [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) and add its search paths. Upstream does **not** bundle CnPack — also clone [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) and add `Source/Common` + `Source/Crypto` to the search path (Delphi-Cross-Socket's `Utils.Hash.pas` requires `CnMD5`, `CnSHA1`, `CnSHA2`, `CnSM3`, and `CnPemUtils` plus their transitive deps). Three previously-fork-only bug fixes (`PATCH-IOCP-1`, the zero-body response parser hang, and the `_OnBodyEnd` nil-guard) have all been merged into upstream as of 2026-Q2 — no patches needed on upstream for HTTP and one-way HTTPS.
+- **Server-side mutual TLS is still fork-only at the source level.** Upstream `Net.CrossSslSocket.Base.pas` and `Net.CrossSslSocket.OpenSSL.pas` do **not** yet expose the `SetCACertificate(File)` overload chain or the virtual abstract `SetVerifyPeer(Boolean)` that the provider calls when `THorseCrossSocketConfig.SSLVerifyPeer = True`. An upstream PR is in preparation; until it lands, mTLS users must either apply the two `Net.CrossSslSocket.*` patches manually on upstream **or** use the pre-built fork release (next bullet).
+- **Supported alternative — fork release** [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3): single clone, bundles CnPack, **and ships the two `Net.CrossSslSocket.*` mTLS patches pre-applied** — `SetCACertificate(File)` + `SetVerifyPeer(Boolean)` are immediately available. Use this when `SSLVerifyPeer = True` or when you prefer the one-dependency convenience over tracking upstream directly. Trade-off: the fork lags upstream's commit history between syncs (typically <24h via the [automated sync workflow](https://github.com/freitasjca/Delphi-Cross-Socket/actions)).
+- See [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket#readme) for the full three-path install runbook and the current per-version test matrix.
+
+### mORMot2 — optional, cross-compiler
+
+- Compatible with **Delphi 7 through 12.3 Athens** — the broadest compiler range of any Provider thanks to mORMot's own long-standing legacy support. Horse-side adapter units carry `{$IF CompilerVersion >= 32.0}` guards (Delphi 10.2+) on a small number of `Int64`/`Integer` boundaries; XE7+ otherwise.
+- Requires **FPC 3.2.0 or later** for FPC builds.
+- Tested platforms: Windows x86 / x64, Linux x64, macOS ARM64.
+- Replaces Indy (Delphi) and `fphttpserver` (FPC) with [mORMot2](https://github.com/synopse/mORMot2)'s `THttpServer` (IOCP / epoll) — pure Pascal, no compiled C library dependencies for standard HTTP. On Windows, swap `THttpServer` for `THttpApiServer` to get **kernel-mode http.sys HTTP** with zero code change.
+- mORMot2 is **not** available via `boss install` — clone [synopse/mORMot2](https://github.com/synopse/mORMot2) directly and add the search-path entries documented in [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme).
+- On Delphi the build also requires the **precompiled `.obj` blobs** from `mormot2static.7z` ([latest mORMot2 release](https://github.com/synopse/mORMot2/releases/latest)) extracted into `mORMot2\static\delphi\`. Without these the linker fails with `E1026 File not found: '..\..\static\delphi\zlibdeflate.obj'`. The FPC variants use `.o` files under `mORMot2\static\<target>` configured via the project's `-Fl` paths.
+- See [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme) for the current per-version test matrix and configuration record (`THorseMormotConfig`).
 
 ## Host-managed Application types
 
-Apache / ISAPI / CGI / FastCGI **do not use a self-hosted Provider** — neither Indy, `fphttpserver`, nor CrossSocket is involved. The host process (Apache httpd, IIS, the web server) owns the socket and hands the request to Horse via `Web.HTTPApp` (Delphi) or `fpFCGI` / `fpHTTP` (FPC) subclasses.
+Apache / ISAPI / CGI / FastCGI **do not use a self-hosted Provider** — neither Indy, `fphttpserver`, CrossSocket, nor mORMot2 is involved. The host process (Apache httpd, IIS, the web server) owns the socket and hands the request to Horse via `Web.HTTPApp` (Delphi) or `fpFCGI` / `fpHTTP` (FPC) subclasses.
 
 - **Apache module** — Delphi (`Web.HTTPD24Impl`, `Web.ApacheApp`). Build the `.so` / `.dll` matching the Apache architecture.
 - **ISAPI extension** — Delphi only (`Web.Win.ISAPIApp`). Windows + IIS. Match the architecture of the IIS application pool (32-bit pool → Win32 build).
@@ -102,7 +115,7 @@ Horse uses a few defensive guards. If you're contributing patches:
 - `{$IF CompilerVersion >= 32.0}` — Delphi 10.2 Tokyo introduced `Int64` return types on `TWebRequest.GetIntegerVariable` / `TWebResponse.SetIntegerVariable`. Anything that overrides those needs the guard.
 - `{$IF CompilerVersion >= 33.0}` — Delphi 10.3 Rio introduced inline `var`. Horse core avoids inline `var` so it remains compilable on XE7.
 
-For every change, mentally compile against both `dcc32` (Delphi) and `fpc` (FPC). Anonymous procedures, generics, and Web/HTTPApp types are the most common cross-compiler trip points.
+For every change, **test‑compile** against both **Delphi** (e.g., `dcc32`, `dcc64`) and **FPC** (`fpc`). Anonymous procedures, generics, and Web/HTTPApp types are the most common cross-compiler trip points.
 
 ## Reporting a version-specific bug
 

--- a/doc/compiler-support.pt-BR.md
+++ b/doc/compiler-support.pt-BR.md
@@ -2,7 +2,7 @@
 
 *Leia em [English](./compiler-support.md) ou [Português (BR)](./compiler-support.pt-BR.md).*
 
-O Horse mira uma faixa ampla de versões de Delphi e Free Pascal. Esta página lista o que é suportado, o que é testado e as considerações por Provider / por Tipo de aplicação.
+O Horse abrange uma ampla gama de versões do Delphi e do Free Pascal. Esta página lista o que é suportado, o que é testado e as considerações por Provider / por Tipo de aplicação.
 
 Para o modelo de dois eixos (Provider — Indy / fphttpserver / CrossSocket — × Tipo de aplicação — Console / VCL / Daemon / Apache / ISAPI / CGI / FCGI / LCL / HTTPApplication), veja [Providers e Tipos de aplicação](./providers.pt-BR.md).
 
@@ -39,15 +39,15 @@ O conjunto de plataformas depende de qual Provider é selecionado e qual Tipo de
 
 ### Providers self-hosted × Plataforma
 
-O Provider que é dono do socket. Indy é só-Delphi; `fphttpserver` é só-FPC; CrossSocket atende ambos.
+O Provider que é dono do socket. Indy é só-Delphi; `fphttpserver` é só-FPC; CrossSocket e mORMot2 atendem ambos.
 
-| Plataforma | Indy _(padrão Delphi)_ | `fphttpserver` _(padrão FPC)_ | CrossSocket _(`HORSE_PROVIDER_CROSSSOCKET`; alias legado `HORSE_CROSSSOCKET`)_ |
-|---|:---:|:---:|:---:|
-| Windows x86 / x64 | ✔ | ✔ | ✔ |
-| Linux x64 | ✔ | ✔ | ✔ _(alvo primário)_ |
-| macOS Intel / ARM64 | ✔ | ✔ | ✔ |
-| FreeBSD | — | ✔ | ✔ _(via kqueue)_ |
-| Android / iOS | — | — | — |
+| Plataforma | Indy _(padrão Delphi)_ | `fphttpserver` _(padrão FPC)_ | CrossSocket _(`HORSE_PROVIDER_CROSSSOCKET`)_ | mORMot2 _(`HORSE_PROVIDER_MORMOT`)_ |
+|---|:---:|:---:|:---:|:---:|
+| Windows x86 / x64 | ✔ | ✔ | ✔ _(IOCP)_ | ✔ _(IOCP; também http.sys via `THttpApiServer`)_ |
+| Linux x64 | ✔ | ✔ | ✔ _(epoll, alvo primário)_ | ✔ _(epoll)_ |
+| macOS Intel / ARM64 | ✔ | ✔ | ✔ _(kqueue)_ | ✔ |
+| FreeBSD | — | ✔ | ✔ _(kqueue)_ | ✔ _(kqueue)_ |
+| Android / iOS | — | — | — | — |
 
 ### Tipos de aplicação host-managed × Plataforma
 
@@ -83,11 +83,24 @@ Estes não usam um Provider self-hosted — o processo host é dono do socket. C
 - Exige **FPC 3.2.0 ou mais recente** para builds FPC.
 - Plataformas testadas: Windows x64, Linux x64, macOS ARM64.
 - Substitui Indy (Delphi) e `fphttpserver` (FPC) por um único transporte assíncrono para os dois compiladores.
-- Veja [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket#readme) para a matriz atual de teste por versão.
+- **Instalação é manual** (espelha o padrão de instalação do mORMot2, não Boss): clone [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) e adicione seus search paths. O upstream **não** embute o CnPack — clone também [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) e adicione `Source/Common` + `Source/Crypto` ao search path (o `Utils.Hash.pas` do Delphi-Cross-Socket usa `CnMD5`, `CnSHA1`, `CnSHA2`, `CnSM3` e `CnPemUtils` mais suas dependências transitivas). Três bug fixes que antes eram exclusivos do fork (`PATCH-IOCP-1`, hang do parser para respostas sem body, e o nil-guard em `_OnBodyEnd`) já foram ibtegradas no upstream a partir de 2026-Q2 — não é necessário aplicar patches no upstream para HTTP e HTTPS unidirecional.
+- **TLS mútuo no servidor ainda é exclusivo do fork no nível de fonte.** O `Net.CrossSslSocket.Base.pas` e `Net.CrossSslSocket.OpenSSL.pas` do upstream **ainda não** expõem a cadeia de overloads `SetCACertificate(File)` nem o `SetVerifyPeer(Boolean)` virtual abstract que o Provider chama quando `THorseCrossSocketConfig.SSLVerifyPeer = True`. Um PR upstream está em preparação; até ele entrar, usuários de mTLS precisam ou aplicar os dois patches `Net.CrossSslSocket.*` manualmente sobre o upstream **ou** usar o release pré-empacotado do fork (próximo item).
+- **Alternativa suportada — release do fork** [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3): clone único, inclui o CnPack **e já entrega os dois patches mTLS de `Net.CrossSslSocket.*` aplicados** — `SetCACertificate(File)` + `SetVerifyPeer(Boolean)` ficam imediatamente disponíveis. Use quando `SSLVerifyPeer = True` ou quando preferir a conveniência de uma única dependência em vez de acompanhar o upstream diretamente. Trade-off: o fork fica para trás do histórico de commits do upstream entre os syncs (tipicamente <24h via o [workflow automatizado de sync](https://github.com/freitasjca/Delphi-Cross-Socket/actions)).
+- Veja [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket#readme) para o runbook completo das três opções de instalação e a matriz atual de teste por versão.
+
+### mORMot2 — opcional, entre compiladores
+
+- Compatível com **Delphi 7 até 12.3 Athens** — a faixa de compilador mais ampla entre todos os Providers, graças ao suporte legado de longa data do próprio mORMot. As unidades adapter do lado Horse carregam guards `{$IF CompilerVersion >= 32.0}` (Delphi 10.2+) em um número pequeno de fronteiras `Int64`/`Integer`; XE7+ no restante.
+- Requer **FPC 3.2.0 ou superior** em builds FPC.
+- Plataformas testadas: Windows x86 / x64, Linux x64, macOS ARM64.
+- Substitui Indy (Delphi) e `fphttpserver` (FPC) pelo `THttpServer` do [mORMot2](https://github.com/synopse/mORMot2) (IOCP / epoll) — Pascal puro, sem dependências de bibliotecas C compiladas para HTTP padrão. No Windows, troque `THttpServer` por `THttpApiServer` para obter **HTTP em modo kernel via http.sys** sem nenhuma mudança de código.
+- O mORMot2 **não** está disponível via `boss install` — clone [synopse/mORMot2](https://github.com/synopse/mORMot2) diretamente e adicione as entradas de search-path documentadas em [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme).
+- No Delphi o build também exige os **blobs `.obj` pré-compilados** do `mormot2static.7z` ([último release do mORMot2](https://github.com/synopse/mORMot2/releases/latest)) extraídos em `mORMot2\static\delphi\`. Sem eles o linker falha com `E1026 File not found: '..\..\static\delphi\zlibdeflate.obj'`. As variantes FPC usam arquivos `.o` em `mORMot2\static\<target>` configurados via os paths `-Fl` do projeto.
+- Veja [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme) para a matriz atual de teste por versão e o record de configuração (`THorseMormotConfig`).
 
 ## Tipos de aplicação host-managed
 
-Apache / ISAPI / CGI / FastCGI **não usam um Provider self-hosted** — nem Indy, nem `fphttpserver`, nem CrossSocket está envolvido. O processo host (Apache httpd, IIS, o webserver) é dono do socket e entrega a requisição ao Horse via subclasses de `Web.HTTPApp` (Delphi) ou `fpFCGI` / `fpHTTP` (FPC).
+Apache / ISAPI / CGI / FastCGI **não usam um Provider self-hosted** — nem Indy, nem `fphttpserver`, nem CrossSocket, nem mORMot2 está envolvido. O processo host (Apache httpd, IIS, o webserver) é dono do socket e entrega a requisição ao Horse via subclasses de `Web.HTTPApp` (Delphi) ou `fpFCGI` / `fpHTTP` (FPC).
 
 - **Módulo Apache** — Delphi (`Web.HTTPD24Impl`, `Web.ApacheApp`). Construa o `.so` / `.dll` com a arquitetura correspondente à do Apache.
 - **Extensão ISAPI** — só Delphi (`Web.Win.ISAPIApp`). Windows + IIS. Combine a arquitetura com o pool de aplicações do IIS (pool 32-bit → build Win32).
@@ -102,7 +115,7 @@ O Horse usa alguns guards defensivos. Se você contribui patches:
 - `{$IF CompilerVersion >= 32.0}` — Delphi 10.2 Tokyo introduziu retorno `Int64` em `TWebRequest.GetIntegerVariable` / `TWebResponse.SetIntegerVariable`. Qualquer override desses precisa do guard.
 - `{$IF CompilerVersion >= 33.0}` — Delphi 10.3 Rio introduziu `var` inline. O core do Horse evita `var` inline para continuar compilando no XE7.
 
-A cada alteração, compile mentalmente contra `dcc32` (Delphi) e `fpc` (FPC). Procedimentos anônimos, generics e tipos Web/HTTPApp são os pontos mais comuns de tropeço entre compiladores.
+Para cada alteração, **faça a compilação de teste** tanto no **Delphi** (ex.: `dcc32`, `dcc64`) quanto no **FPC** (`fpc`). Procedimentos anônimos, generics e tipos Web/HTTPApp são as diferenças que mais causam problemas na compilação cruzada entre Delphi e FPC..
 
 ## Reportando um bug específico de versão
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -2,7 +2,7 @@
 
 *Read this in [English](./deployment.md) or [Português (BR)](./deployment.pt-BR.md).*
 
-Same Horse code, seven deployment shapes. This page is the at-a-glance reference; for the rationale and longer code samples, see [Providers & Application types §8](./providers.md#8-running-crosssocket-as-each-application-type).
+Same Horse code, seven deployment shapes, two interchangeable async transports (CrossSocket and mORMot2). This page is the at-a-glance reference; for the rationale and longer code samples, see [Providers & Application types §8 (CrossSocket)](./providers.md#8-running-crosssocket-as-each-application-type) or [§9 (mORMot2)](./providers.md#9-running-mormot2-as-each-application-type).
 
 ---
 
@@ -10,10 +10,14 @@ Same Horse code, seven deployment shapes. This page is the at-a-glance reference
 
 Every shape on this page follows the same four steps:
 
-1. **Define `HORSE_PROVIDER_CROSSSOCKET`** in Project Options → Conditional Defines, plus the matching `HORSE_APPTYPE_*` if you want the cross-product convenience unit (since PATCH-HORSE-2). The legacy `HORSE_CROSSSOCKET` alias still works for backwards compatibility.
+1. **Define exactly one transport** in Project Options → Conditional Defines:
+   - `HORSE_PROVIDER_CROSSSOCKET` for the CrossSocket Provider, **or**
+   - `HORSE_PROVIDER_MORMOT` for the mORMot2 Provider.
+
+   Add the matching `HORSE_APPTYPE_*` if you want the cross-product convenience unit (since PATCH-HORSE-2). The legacy `HORSE_CROSSSOCKET` alias still works for backwards compatibility; there is no legacy alias for mORMot. The two Provider defines are mutually exclusive — `Horse.pas` rejects the combination at compile time.
 2. Pick the **project type** for the desired shape.
 3. Call `THorse.Listen(port)` from the **right lifecycle hook** for that shape.
-4. Call `THorse.StopListen` from the **shutdown hook** so CrossSocket drains in-flight requests.
+4. Call `THorse.StopListen` from the **shutdown hook** so the Provider drains active requests.
 
 The runtime check that drives shape behaviour is `IsConsole`:
 
@@ -45,8 +49,12 @@ The runtime check that drives shape behaviour is `IsConsole`:
 function CtrlHandler(dwCtrlType: DWORD): BOOL; stdcall;
 begin
   if dwCtrlType in [CTRL_C_EVENT, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT] then
-  begin THorse.StopListen; Result := True; end
-  else Result := False;
+  begin 
+    THorse.StopListen; 
+    Result := True; 
+  end
+  else 
+    Result := False;
 end;
 begin
   SetConsoleCtrlHandler(@CtrlHandler, True);
@@ -57,9 +65,15 @@ end.
 ### VCL (Delphi) — `FormCreate` / `FormClose`
 
 ```pascal
-procedure TfrmMain.FormCreate(Sender: TObject);  begin THorse.Listen(9000); end;
+procedure TfrmMain.FormCreate(Sender: TObject);  
+begin 
+  THorse.Listen(9000); 
+end;
+
 procedure TfrmMain.FormClose(Sender: TObject; var Action: TCloseAction);
-                                                begin THorse.StopListen;   end;
+begin 
+  THorse.StopListen;   
+end;
 ```
 
 ### Linux daemon (Delphi) — POSIX signal + systemd
@@ -68,10 +82,15 @@ procedure TfrmMain.FormClose(Sender: TObject; var Action: TCloseAction);
 {$APPTYPE CONSOLE}
 {$IFDEF LINUX}
 procedure HandleSignal(ASignal: Integer); cdecl;
-begin THorse.StopListen; end;
+begin 
+  THorse.StopListen; 
+end;
 {$ENDIF}
 begin
-  {$IFDEF LINUX} signal(SIGTERM, @HandleSignal); signal(SIGINT, @HandleSignal); {$ENDIF}
+  {$IFDEF LINUX} 
+  signal(SIGTERM, @HandleSignal); 
+  signal(SIGINT, @HandleSignal); 
+  {$ENDIF}
   THorse.Listen(9000);
 end.
 ```
@@ -95,7 +114,10 @@ WantedBy=multi-user.target
 procedure TMyHorseService.ServiceStart(Sender: TService; var Started: Boolean);
 begin
   FListenerThread := TThread.CreateAnonymousThread(
-    procedure begin THorse.Listen(9000); end);
+    procedure 
+    begin 
+      THorse.Listen(9000); 
+    end);
   FListenerThread.FreeOnTerminate := False;
   FListenerThread.Start;
   Started := True;
@@ -128,10 +150,15 @@ Simpler alternative without writing a TService: build the Console binary above a
 {$APPTYPE CONSOLE}
 {$IFDEF UNIX}
 procedure HandleSignal(ASignal: cint); cdecl;
-begin THorse.StopListen; end;
+begin 
+  THorse.StopListen; 
+end;
 {$ENDIF}
 begin
-  {$IFDEF UNIX} fpSignal(SIGTERM, @HandleSignal); fpSignal(SIGINT, @HandleSignal); {$ENDIF}
+  {$IFDEF UNIX} 
+  fpSignal(SIGTERM, @HandleSignal); 
+  fpSignal(SIGINT, @HandleSignal); 
+  {$ENDIF}
   THorse.Listen(9000);
 end.
 ```
@@ -142,9 +169,14 @@ systemd unit identical to the Delphi Linux daemon above.
 
 ```pascal
 procedure TfrmMain.FormCreate(Sender: TObject);
-begin THorse.Listen(9000); end;
+begin 
+  THorse.Listen(9000); 
+end;
+
 procedure TfrmMain.FormClose(Sender: TObject; var CloseAction: TCloseAction);
-begin THorse.StopListen; end;
+begin 
+  THorse.StopListen; 
+end;
 ```
 
 ### FPC HTTPApplication — Console-shape FPC binary
@@ -155,7 +187,7 @@ Same code as the FPC Linux daemon — `THorse.Listen` owns the loop; don't call 
 
 ## Stop-signal mapping
 
-The shutdown signal differs by OS and supervisor. All cases end in the same place: `THorse.StopListen` → CrossSocket SEC-30 active-request drain → `Listen` returns → process exits cleanly.
+The shutdown signal differs by OS and supervisor. All cases end in the same place: `THorse.StopListen` → the active Provider's SEC-30 active-request drain (implemented identically in `horse-provider-crosssocket` and `horse-provider-mormot`) → `Listen` returns → process exits cleanly.
 
 | Supervisor | Signal sent | How your code catches it |
 |---|---|---|
@@ -177,7 +209,7 @@ The shutdown signal differs by OS and supervisor. All cases end in the same plac
 | Windows service hangs in "Starting" state | `ServiceStart` blocks because `Listen` was called directly on the SCM thread | Wrap `Listen` in `TThread.CreateAnonymousThread` (see TService snippet). |
 | systemd reports "main process exited, code=killed, status=15/TERM" | Process didn't catch `SIGTERM` — systemd had to escalate | Install the POSIX signal handler so the binary exits cleanly under `0`. |
 | `Address already in use` after restart | Previous process held the socket and was force-killed (no clean drain) | Always call `StopListen`; for Docker, set `--stop-grace-period=30s`. |
-| In-flight requests dropped on shutdown | `Listen` returned immediately after `StopListen` without waiting for the active-request counter | CrossSocket's SEC-30 already handles this — make sure you're on `horse-provider-crosssocket >= 1.0.4`. |
+| In-progress requests lost on shutdown | `Listen` returned immediately after `StopListen` without waiting for the active-request counter | SEC-30 already handles this — make sure you're on `horse-provider-crosssocket >= 1.0.4` against a recent `winddriver/Delphi-Cross-Socket` (or the [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) fork), or any release of `horse-provider-mormot`, where SEC-30 has been built in from day one. |
 
 ---
 
@@ -195,7 +227,7 @@ jobs:
     env:
       CONFIGURATION: Release
       PLATFORM: Linux64
-      DEFINES: HORSE_CROSSSOCKET
+      DEFINES: HORSE_PROVIDER_CROSSSOCKET
 
   build-windows:
     runs-on: windows-latest
@@ -203,16 +235,68 @@ jobs:
     env:
       CONFIGURATION: Release
       PLATFORM: Win64
-      DEFINES: HORSE_CROSSSOCKET
+      DEFINES: HORSE_PROVIDER_CROSSSOCKET
 ```
 
 The same `.dpr` compiles on both — only the deployment shell (systemd unit vs. SCM service registration) differs per OS.
 
 ---
 
+## HTTPS / TLS runtime — what to ship per OS
+
+Both `HORSE_PROVIDER_CROSSSOCKET` and `HORSE_PROVIDER_MORMOT` use **OpenSSL** for HTTPS — they `dlopen` / `LoadLibrary` the system shared library at startup. The transport stack itself is in your binary; OpenSSL is **not** statically linked by default. Plan your deployment accordingly.
+
+### Linux
+
+Install OpenSSL via the distro package manager so `libssl.so` and `libcrypto.so` are on the loader path:
+
+```bash
+# Debian / Ubuntu (22.04+, OpenSSL 3.x)
+apt install libssl3 libcrypto3
+
+# Debian / Ubuntu (20.04, OpenSSL 1.1.x)
+apt install libssl1.1
+
+# RHEL / Rocky / Alma 9.x  (OpenSSL 3.x)
+dnf install openssl-libs
+
+# Alpine
+apk add openssl libcrypto3 libssl3
+```
+
+Both providers accept either 1.1.x or 3.x — they probe at startup. If the loader can't find either, the binary still runs but `SSLEnabled := True` fails at `Listen`-time with a clear "no SSL backend available" error.
+
+For air-gapped or minimal container deployments where you cannot rely on the distro packages:
+- **CrossSocket:** ship the matching `libssl.so` + `libcrypto.so` alongside your binary and declare them in the systemd unit's `[Service]` section: `Environment="LD_LIBRARY_PATH=/opt/yourapp"`.
+- **mORMot2:** the `mormot2static` package includes a static-link variant for some platforms (`mormot2static/static/x86_64-linux` for FPC) — see [horse-provider-mormot's samples/tests/README](https://github.com/freitasjca/horse-provider-mormot/blob/master/samples/tests/README.md) for the full Search-path setup.
+
+### Windows
+
+Ship the OpenSSL DLLs **next to your `.exe`** (not into `C:\Windows\System32` and not into a globally-PATHed folder — co-locating them avoids hijacking by other apps' bundled OpenSSL):
+
+| OpenSSL version | DLL names (per-arch) |
+|---|---|
+| 1.1.x | `libssl-1_1-x64.dll`, `libcrypto-1_1-x64.dll` (Win64); drop `-x64` for Win32 |
+| 3.x | `libssl-3-x64.dll`, `libcrypto-3-x64.dll` (Win64); drop `-x64` for Win32 |
+
+The standard source is [the official OpenSSL Windows builds](https://wiki.openssl.org/index.php/Binaries) or [SLProWeb's installers](https://slproweb.com/products/Win32OpenSSL.html). Pick **one** version and use it everywhere — code that dynamic-loads `libssl-1_1.dll` will not run on a host that only has `libcrypto-3.dll`, and the two cannot coexist within the same process.
+
+For Windows Service deployments, the DLLs must be in the same folder as the service `.exe` — the SCM does **not** inherit the user's `PATH`.
+
+### Common gotcha — version-mismatch crashes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `EOSError: failed to load libssl` on Linux | No OpenSSL package installed, or runtime is stripped to a minimal container with only `libc` | Install `libssl3` / `libssl1.1` (Linux) or copy the DLLs next to the binary (Windows). |
+| HTTPS works in dev, fails in prod with "wrong version number" | Dev box has OpenSSL 3.x; prod box has 1.1.x (or vice versa) — TLS negotiation features differ | Pin to one version family across environments. If you must support both, ship the DLLs (Windows) or use the `mormot2static` static-link variant (mORMot2, Linux). |
+| Random SIGSEGV during TLS handshake on Linux | Two copies of `libcrypto` loaded at once (system 3.x + a different bundled 1.1.x in `LD_LIBRARY_PATH`) | Ensure only one OpenSSL ABI is reachable. |
+
+---
+
 ## See also
 
-- [Providers & Application types](./providers.md) — the full architectural model, including §8 with annotated code for every shape.
+- [Providers & Application types](./providers.md) — the full architectural model, including §8 (CrossSocket) and §9 (mORMot2) with annotated code for every shape.
 - [Getting Started](./getting-started.md) — your first Horse server before deciding on a deployment shape.
 - [Compiler Support](./compiler-support.md) — Delphi / FPC version requirements and the platform matrix.
 - [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — config (TLS, body-size limits, IO thread count) for the CrossSocket Provider.
+- [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) — config (thread pool, max body bytes, drain timeout, server banner) for the mORMot2 Provider.

--- a/doc/deployment.pt-BR.md
+++ b/doc/deployment.pt-BR.md
@@ -2,7 +2,7 @@
 
 *Leia em [English](./deployment.md) ou [Português (BR)](./deployment.pt-BR.md).*
 
-Mesmo código Horse, sete formatos de deploy. Esta página é a referência rápida; para o racional e exemplos de código mais longos, veja [Providers e Tipos de aplicação §8](./providers.pt-BR.md#8-rodando-o-crosssocket-em-cada-tipo-de-aplicação).
+Mesmo código Horse, sete formatos de deploy, dois transportes assíncronos intercambiáveis (CrossSocket e mORMot2). Esta página é a referência rápida; para o racional e exemplos de código mais longos, veja [Providers e Tipos de aplicação §8 (CrossSocket)](./providers.pt-BR.md#8-rodando-o-crosssocket-em-cada-tipo-de-aplicação) ou [§9 (mORMot2)](./providers.pt-BR.md#9-rodando-o-mormot2-em-cada-tipo-de-aplicação).
 
 ---
 
@@ -10,10 +10,14 @@ Mesmo código Horse, sete formatos de deploy. Esta página é a referência ráp
 
 Todo formato nesta página segue os mesmos quatro passos:
 
-1. **Defina `HORSE_PROVIDER_CROSSSOCKET`** em Project Options → Conditional Defines, mais o `HORSE_APPTYPE_*` correspondente se quiser a unit de conveniência produto cruzado (desde o PATCH-HORSE-2). O alias legado `HORSE_CROSSSOCKET` continua funcionando pra compatibilidade.
+1. **Defina exatamente um transporte** em Project Options → Conditional Defines:
+   - `HORSE_PROVIDER_CROSSSOCKET` para o Provider CrossSocket, **ou**
+   - `HORSE_PROVIDER_MORMOT` para o Provider mORMot2.
+
+   Adicione o `HORSE_APPTYPE_*` correspondente se quiser a unit de conveniência produto cruzado (desde o PATCH-HORSE-2). O alias legado `HORSE_CROSSSOCKET` continua funcionando pra compatibilidade; não existe alias legado para mORMot. Os dois defines de Provider são mutuamente exclusivos — o `Horse.pas` rejeita a combinação em tempo de compilação.
 2. Escolha o **tipo de projeto** pro formato desejado.
 3. Chame `THorse.Listen(port)` do **hook de ciclo de vida** certo daquele formato.
-4. Chame `THorse.StopListen` do **hook de shutdown** pro CrossSocket drenar requisições em voo.
+4. Chame `THorse.StopListen` do **hook de shutdown** para que o Provider esgote as requisições ativas.
 
 A verificação em runtime que dirige o comportamento do formato é o `IsConsole`:
 
@@ -38,15 +42,19 @@ A verificação em runtime que dirige o comportamento do formato é o `IsConsole
 
 ## Código mínimo por formato
 
-### Console (Delphi) — `SetConsoleCtrlHandler` pro stop
+### Console (Delphi) — `SetConsoleCtrlHandler` para interrupção
 
 ```pascal
 {$APPTYPE CONSOLE}
 function CtrlHandler(dwCtrlType: DWORD): BOOL; stdcall;
 begin
   if dwCtrlType in [CTRL_C_EVENT, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT] then
-  begin THorse.StopListen; Result := True; end
-  else Result := False;
+  begin 
+    THorse.StopListen; 
+    Result := True; 
+  end
+  else 
+    Result := False;
 end;
 begin
   SetConsoleCtrlHandler(@CtrlHandler, True);
@@ -57,9 +65,15 @@ end.
 ### VCL (Delphi) — `FormCreate` / `FormClose`
 
 ```pascal
-procedure TfrmMain.FormCreate(Sender: TObject);  begin THorse.Listen(9000); end;
+procedure TfrmMain.FormCreate(Sender: TObject);  
+begin 
+  THorse.Listen(9000); 
+end;
+
 procedure TfrmMain.FormClose(Sender: TObject; var Action: TCloseAction);
-                                                begin THorse.StopListen;   end;
+begin 
+  THorse.StopListen;   
+end;
 ```
 
 ### Daemon Linux (Delphi) — signal POSIX + systemd
@@ -68,10 +82,15 @@ procedure TfrmMain.FormClose(Sender: TObject; var Action: TCloseAction);
 {$APPTYPE CONSOLE}
 {$IFDEF LINUX}
 procedure HandleSignal(ASignal: Integer); cdecl;
-begin THorse.StopListen; end;
+begin 
+  THorse.StopListen; 
+end;
 {$ENDIF}
 begin
-  {$IFDEF LINUX} signal(SIGTERM, @HandleSignal); signal(SIGINT, @HandleSignal); {$ENDIF}
+  {$IFDEF LINUX} 
+  signal(SIGTERM, @HandleSignal); 
+  signal(SIGINT, @HandleSignal); 
+  {$ENDIF}
   THorse.Listen(9000);
 end.
 ```
@@ -95,7 +114,10 @@ WantedBy=multi-user.target
 procedure TMyHorseService.ServiceStart(Sender: TService; var Started: Boolean);
 begin
   FListenerThread := TThread.CreateAnonymousThread(
-    procedure begin THorse.Listen(9000); end);
+    procedure 
+    begin 
+      THorse.Listen(9000); 
+    end);
   FListenerThread.FreeOnTerminate := False;
   FListenerThread.Start;
   Started := True;
@@ -131,7 +153,10 @@ procedure HandleSignal(ASignal: cint); cdecl;
 begin THorse.StopListen; end;
 {$ENDIF}
 begin
-  {$IFDEF UNIX} fpSignal(SIGTERM, @HandleSignal); fpSignal(SIGINT, @HandleSignal); {$ENDIF}
+  {$IFDEF UNIX} 
+  fpSignal(SIGTERM, @HandleSignal); 
+  fpSignal(SIGINT, @HandleSignal); 
+  {$ENDIF}
   THorse.Listen(9000);
 end.
 ```
@@ -142,9 +167,14 @@ Unit do systemd idêntica ao daemon Linux Delphi acima.
 
 ```pascal
 procedure TfrmMain.FormCreate(Sender: TObject);
-begin THorse.Listen(9000); end;
+begin 
+  THorse.Listen(9000); 
+end;
+
 procedure TfrmMain.FormClose(Sender: TObject; var CloseAction: TCloseAction);
-begin THorse.StopListen; end;
+begin 
+  THorse.StopListen; 
+end;
 ```
 
 ### HTTPApplication FPC — binário FPC formato console
@@ -155,7 +185,7 @@ Mesmo código do daemon Linux FPC — o `THorse.Listen` é dono do loop; não ch
 
 ## Mapeamento de sinais de stop
 
-O sinal de shutdown varia por OS e supervisor. Todos os casos acabam no mesmo lugar: `THorse.StopListen` → drenagem do contador de requisições ativas do CrossSocket SEC-30 → `Listen` retorna → processo sai limpo.
+O sinal de shutdown varia por OS e supervisor. Todos os casos acabam no mesmo lugar: `THorse.StopListen` → drenagem do contador de requisições ativas SEC-30 do Provider ativo (implementada de forma idêntica em `horse-provider-crosssocket` e `horse-provider-mormot`) → `Listen` retorna → processo sai limpo.
 
 | Supervisor | Sinal enviado | Como seu código pega |
 |---|---|---|
@@ -174,16 +204,16 @@ O sinal de shutdown varia por OS e supervisor. Todos os casos acabam no mesmo lu
 |---|---|---|
 | Processo sai imediatamente após o start | Binário console sem handler de sinal chega ao `end.` depois que `Listen` retorna | Adicione o setup de `CtrlHandler` / `signal` *antes* do `Listen`. |
 | Form VCL trava no startup | `{$APPTYPE CONSOLE}` deixado por engano no .dpr | Remova essa diretiva; apps VCL/LCL precisam de `IsConsole = False`. |
-| Serviço Windows trava em "Starting" | `ServiceStart` bloqueia porque `Listen` foi chamado direto na thread do SCM | Envelope o `Listen` num `TThread.CreateAnonymousThread` (veja o snippet TService). |
+| Serviço Windows trava em "Starting" | `ServiceStart` bloqueia porque `Listen` foi chamado direto na thread do SCM | Encapsule o `Listen` num `TThread.CreateAnonymousThread` (veja o snippet TService). |
 | systemd reporta "main process exited, code=killed, status=15/TERM" | Processo não pegou `SIGTERM` — systemd teve que escalar | Instale o handler de sinal POSIX pro binário sair limpo com `0`. |
 | `Address already in use` após restart | Processo anterior segurou o socket e foi force-killed (sem drenagem limpa) | Sempre chame `StopListen`; pra Docker, configure `--stop-grace-period=30s`. |
-| Requisições em voo derrubadas no shutdown | `Listen` retornou imediatamente após `StopListen` sem aguardar o contador de requisições ativas | O SEC-30 do CrossSocket já cuida disso — garanta que está no `horse-provider-crosssocket >= 1.0.4`. |
+| Requisições em andamento perdidas no shutdown | `Listen` retornou imediatamente após `StopListen` sem aguardar o contador de requisições ativas | O SEC-30 já cuida disso — garanta que está no `horse-provider-crosssocket >= 1.0.4` contra um `winddriver/Delphi-Cross-Socket` recente (ou o fork [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3)), ou qualquer release do `horse-provider-mormot`, onde o SEC-30 está integrado desde o primeiro dia. |
 
 ---
 
 ## Deploy multi-OS
 
-A maioria dos times entrega o mesmo código Horse como **daemon Linux** em produção e um **Serviço Windows** ou **Console** binário pra dev. Os Conditional Defines ficam iguais — só muda o target do projeto (Win64 / Linux64). Build duas vezes, uma por OS.
+A maioria das equipes entrega o mesmo código Horse como **daemon Linux** em produção e um **Serviço Windows** ou **Console** binário pra dev. Os Conditional Defines ficam iguais — só muda o target do projeto (Win64 / Linux64). Build duas vezes, uma por OS.
 
 Config compartilhada de CI:
 
@@ -195,7 +225,7 @@ jobs:
     env:
       CONFIGURATION: Release
       PLATFORM: Linux64
-      DEFINES: HORSE_CROSSSOCKET
+      DEFINES: HORSE_PROVIDER_CROSSSOCKET
 
   build-windows:
     runs-on: windows-latest
@@ -203,16 +233,68 @@ jobs:
     env:
       CONFIGURATION: Release
       PLATFORM: Win64
-      DEFINES: HORSE_CROSSSOCKET
+      DEFINES: HORSE_PROVIDER_CROSSSOCKET
 ```
 
 O mesmo `.dpr` compila nos dois — só a casca de deploy (unit systemd vs. registro de serviço SCM) muda por OS.
 
 ---
 
+## HTTPS / TLS em runtime — o que entregar por OS
+
+Tanto `HORSE_PROVIDER_CROSSSOCKET` quanto `HORSE_PROVIDER_MORMOT` usam **OpenSSL** para HTTPS — eles fazem `dlopen` / `LoadLibrary` da biblioteca compartilhada do sistema no startup. A pilha de transporte fica no seu binário; o OpenSSL **não** é linkado estaticamente por padrão. Planeje o deploy considerando isso.
+
+### Linux
+
+Instale o OpenSSL pelo gerenciador de pacotes da distro pra que `libssl.so` e `libcrypto.so` fiquem no caminho do loader:
+
+```bash
+# Debian / Ubuntu (22.04+, OpenSSL 3.x)
+apt install libssl3 libcrypto3
+
+# Debian / Ubuntu (20.04, OpenSSL 1.1.x)
+apt install libssl1.1
+
+# RHEL / Rocky / Alma 9.x  (OpenSSL 3.x)
+dnf install openssl-libs
+
+# Alpine
+apk add openssl libcrypto3 libssl3
+```
+
+Os dois providers aceitam tanto 1.1.x quanto 3.x — eles testam no startup. Se o loader não encontrar nenhum dos dois, o binário ainda roda, mas `SSLEnabled := True` falha no `Listen` com um erro claro de "no SSL backend available".
+
+Para deploys em containers mínimos ou ambientes air-gapped onde não dá pra contar com os pacotes da distro:
+- **CrossSocket:** entregue o `libssl.so` + `libcrypto.so` compatíveis junto do binário e declare na seção `[Service]` da unit systemd: `Environment="LD_LIBRARY_PATH=/opt/seuapp"`.
+- **mORMot2:** o pacote `mormot2static` inclui uma variante com link estático pra algumas plataformas (`mormot2static/static/x86_64-linux` no FPC) — veja o [samples/tests/README do horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot/blob/master/samples/tests/README.md) para o setup completo de Search-path.
+
+### Windows
+
+Entregue as DLLs do OpenSSL **junto do `.exe`** (não jogue em `C:\Windows\System32` e não use uma pasta global no PATH — co-localizar com o binário evita que outros apps com OpenSSL bundled sequestrem o load):
+
+| Versão OpenSSL | Nomes das DLLs (por arquitetura) |
+|---|---|
+| 1.1.x | `libssl-1_1-x64.dll`, `libcrypto-1_1-x64.dll` (Win64); tire o `-x64` pra Win32 |
+| 3.x | `libssl-3-x64.dll`, `libcrypto-3-x64.dll` (Win64); tire o `-x64` pra Win32 |
+
+A fonte padrão são os [builds oficiais OpenSSL para Windows](https://wiki.openssl.org/index.php/Binaries) ou os [instaladores da SLProWeb](https://slproweb.com/products/Win32OpenSSL.html). Escolha **uma** versão e use ela em todos os ambientes — código que faz dynamic-load de `libssl-1_1.dll` não roda num host que só tem `libcrypto-3.dll`, e as duas não convivem no mesmo processo.
+
+Em deploy como Serviço Windows, as DLLs precisam estar na mesma pasta do `.exe` do serviço — o SCM **não** herda o `PATH` do usuário.
+
+### Armadilha comum — crash por descasamento de versão
+
+| Sintoma | Causa | Correção |
+|---|---|---|
+| `EOSError: failed to load libssl` no Linux | Nenhum pacote OpenSSL instalado, ou container minimal só com `libc` | Instale `libssl3` / `libssl1.1` (Linux) ou copie as DLLs junto do binário (Windows). |
+| HTTPS funciona em dev, quebra em prod com "wrong version number" | Box de dev tem OpenSSL 3.x; box de prod tem 1.1.x (ou vice-versa) — features de negociação TLS diferem | Padronize numa família de versão em todos os ambientes. Se tiver que suportar as duas, entregue as DLLs (Windows) ou use a variante estática do `mormot2static` (mORMot2, Linux). |
+| SIGSEGV aleatório no handshake TLS no Linux | Duas cópias do `libcrypto` carregadas ao mesmo tempo (sistema 3.x + uma 1.1.x bundled diferente em `LD_LIBRARY_PATH`) | Garanta que só uma ABI do OpenSSL fica alcançável. |
+
+---
+
 ## Veja também
 
-- [Providers e Tipos de aplicação](./providers.pt-BR.md) — o modelo arquitetural completo, inclusive §8 com código anotado pra cada formato.
+- [Providers e Tipos de aplicação](./providers.pt-BR.md) — o modelo arquitetural completo, inclusive §8 (CrossSocket) e §9 (mORMot2) com código anotado pra cada formato.
 - [Primeiros passos](./getting-started.pt-BR.md) — seu primeiro servidor Horse antes de decidir o formato de deploy.
 - [Suporte de Compilador](./compiler-support.pt-BR.md) — exigências de versão Delphi / FPC e a matriz de plataformas.
 - [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — config (TLS, limites de body, número de threads IO) do Provider CrossSocket.
+- [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) — config (thread pool, máximo de bytes do body, timeout de drenagem, banner do servidor) do Provider mORMot2.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -151,16 +151,23 @@ The Console hello-world above is the simplest deployment shape, but **the same `
 | IIS ISAPI extension | Delphi | `HORSE_ISAPI` | (IIS owns the lifecycle) |
 | CGI / FastCGI binary | Delphi or FPC | `HORSE_CGI` / `HORSE_FCGI` | (host owns the lifecycle) |
 
-Add **`HORSE_PROVIDER_CROSSSOCKET`** alongside (where the table says "none") to switch the transport from the default Indy / `fphttpserver` to the optional async CrossSocket Provider — that's the high-performance path. The legacy define `HORSE_CROSSSOCKET` still works (PATCH-HORSE-2 keeps it as a permanent alias).
+For the high-performance path, add **one** of the following Provider defines alongside (where the table says "none") to switch the transport from the default Indy / `fphttpserver` to an async Provider:
 
-Concrete recipes (project type, code skeleton, install commands) for each shape: [Deployment Cheatsheet](./deployment.md), or the longer-form [Providers & Application types §8](./providers.md#8-running-crosssocket-as-each-application-type).
+| Provider define | Backed by | When to pick it |
+|---|---|---|
+| `HORSE_PROVIDER_CROSSSOCKET` | [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) + [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) for CnPack/Crypto units — IOCP / epoll / kqueue. Install both manually (mirroring the mORMot2 setup). For mTLS server mode (`SSLVerifyPeer = True`), use the supported alternative [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) which bundles CnPack and adds `SetCACertificateFile` + `SetVerifyPeer` in one clone. | You prefer native async control or already depend on Delphi-Cross-Socket. Requires Delphi 10.2+. |
+| `HORSE_PROVIDER_MORMOT` | [mORMot2](https://github.com/synopse/mORMot2) `THttpServer` — IOCP / epoll | You want Delphi 7+ compatibility, http.sys kernel-mode HTTP, or pure-Pascal HTTP without compiled C deps. |
+
+The two Providers are mutually exclusive (one transport per build). The legacy alias `HORSE_CROSSSOCKET` keeps working forever (PATCH-HORSE-2 translates it to `HORSE_PROVIDER_CROSSSOCKET`); there is no legacy alias for mORMot — it's new.
+
+Concrete recipes (project type, code skeleton, install commands) for each shape: [Deployment Cheatsheet](./deployment.md), or the longer-form [Providers & Application types §8 (CrossSocket)](./providers.md#8-running-crosssocket-as-each-application-type) / [§9 (mORMot2)](./providers.md#9-running-mormot2-as-each-application-type).
 
 ## 7. Where to next
 
 - [Routing](./routing.md) — declare endpoints, path parameters, route groups.
 - [Request & Response](./request-response.md) — read input, write output.
 - [Middleware](./middleware.md) — JSON parsing, CORS, JWT, logging.
-- [Providers & Application types](./providers.md) — when to switch off the default Indy transport (e.g., for a high-concurrency Linux deployment, see the CrossSocket section).
+- [Providers & Application types](./providers.md) — when to switch off the default Indy transport. The CrossSocket and mORMot2 sections cover the two high-concurrency alternatives.
 - [Deployment Cheatsheet](./deployment.md) — one-pager for shipping the binary as any of the seven shapes above.
 
 ## Troubleshooting

--- a/doc/getting-started.pt-BR.md
+++ b/doc/getting-started.pt-BR.md
@@ -151,7 +151,14 @@ O hello-world Console acima é o formato de deploy mais simples, mas **o mesmo c
 | Extensão ISAPI IIS | Delphi | `HORSE_ISAPI` | (IIS é dono do ciclo de vida) |
 | Binário CGI / FastCGI | Delphi ou FPC | `HORSE_CGI` / `HORSE_FCGI` | (host é dono do ciclo de vida) |
 
-Adicione **`HORSE_PROVIDER_CROSSSOCKET`** junto (onde a tabela diz "nenhum") pra trocar o transporte do Indy / `fphttpserver` padrão pro Provider CrossSocket assíncrono opcional — esse é o caminho de alta performance. O define legado `HORSE_CROSSSOCKET` continua funcionando (PATCH-HORSE-2 mantém como alias permanente).
+Para o caminho de alta performance, adicione **um** dos seguintes defines de Provider (onde a tabela diz "nenhum") pra trocar o transporte do Indy / `fphttpserver` padrão por um Provider assíncrono:
+
+| Define do Provider | Backed by | Quando escolher |
+|---|---|---|
+| `HORSE_PROVIDER_CROSSSOCKET` | [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket) (upstream) + [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) para as units CnPack/Crypto — IOCP / epoll / kqueue. Instale ambos manualmente (espelhando o setup do mORMot2). Para mTLS no servidor (`SSLVerifyPeer = True`), use a alternativa suportada [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) que embute o CnPack e adiciona `SetCACertificateFile` + `SetVerifyPeer` num clone único. | Você prefere controle async nativo ou já depende de Delphi-Cross-Socket. Exige Delphi 10.2+. |
+| `HORSE_PROVIDER_MORMOT` | [mORMot2](https://github.com/synopse/mORMot2) `THttpServer` — IOCP / epoll | Você quer compatibilidade com Delphi 7+, HTTP em modo kernel via http.sys, ou HTTP em pure-Pascal sem deps em C compilado. |
+
+Os dois Providers são mutuamente exclusivos (um transporte por build). O alias legado `HORSE_CROSSSOCKET` continua funcionando para sempre (PATCH-HORSE-2 traduz para `HORSE_PROVIDER_CROSSSOCKET`); não há alias legado para o mORMot — ele é novo.
 
 Receitas concretas (tipo de projeto, esqueleto de código, comandos de instalação) pra cada formato: [Cheatsheet de Deploy](./deployment.pt-BR.md), ou a forma mais longa em [Providers e Tipos de aplicação §8](./providers.pt-BR.md#8-rodando-o-crosssocket-em-cada-tipo-de-aplicação).
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,7 +14,7 @@ If you're new, start with [Getting Started](./getting-started.md). If you have a
 2. **[Routing](./routing.md)** — declare endpoints, path parameters, route groups, query strings.
 3. **[Request & Response](./request-response.md)** — read the request, write the response, headers, cookies, sessions, file uploads/downloads.
 4. **[Middleware](./middleware.md)** — chain handlers, registration order, write your own. For publishing reusable middleware, see **[Writing a Middleware](./writing-middleware.md)**.
-5. **[Providers & Application types](./providers.md)** — pick the transport Provider (Indy default, CrossSocket optional) and the Application type (Console default, VCL, Daemon, LCL, HTTPApplication) — or a host-managed application type (Apache, ISAPI, CGI, FastCGI).
+5. **[Providers & Application types](./providers.md)** — pick the transport Provider (Indy default, CrossSocket and mORMot2 optional) and the Application type (Console default, VCL, Daemon, LCL, HTTPApplication) — or a host-managed application type (Apache, ISAPI, CGI, FastCGI).
 
 ## Reference
 
@@ -25,10 +25,10 @@ If you're new, start with [Getting Started](./getting-started.md). If you have a
 | [Request & Response](./request-response.md) | `THorseRequest` (body, params, query, headers, cookies, sessions, multipart). `THorseResponse` (`Send`, `Status`, `ContentType`, `AddHeader`, `RedirectTo`, `SendFile`, `Download`, `RawWebResponse`). |
 | [Middleware](./middleware.md) | The `Next` proc model; built-in vs custom; registration order; per-route vs global. |
 | [Writing a Middleware](./writing-middleware.md) | Authoring a production-quality middleware: skeleton, configuration patterns, thread safety, Provider-neutral coding, cross-compiler pitfalls, testing matrix, Boss packaging, publishing. |
-| [Providers & Application types](./providers.md) | The two-axis model: **Provider** (transport — Indy default, CrossSocket optional, future mORMot) × **Application type** (Console / VCL / Daemon / LCL / HTTPApplication, plus host-managed Apache / ISAPI / CGI / FCGI). Compatibility matrix and selection guidance. |
+| [Providers & Application types](./providers.md) | The two-axis model: **Provider** (transport — Indy default, CrossSocket and mORMot2 optional) × **Application type** (Console / VCL / Daemon / LCL / HTTPApplication, plus host-managed Apache / ISAPI / CGI / FCGI). Compatibility matrix and selection guidance. |
 | [Middleware Ecosystem](./middleware-ecosystem.md) | Official `HashLoad/*` packages and the community-maintained list. |
 | [Compiler Support](./compiler-support.md) | Tested Delphi releases, FPC versions, target platforms, compiler-version guards. |
-| [Deployment Cheatsheet](./deployment.md) | One-page reference for shipping a CrossSocket binary as any of the seven Application shapes (Console / VCL / Daemon / Windows Service / FPC daemon / LCL / FPC HTTPApplication). |
+| [Deployment Cheatsheet](./deployment.md) | One-page reference for shipping a CrossSocket or mORMot2 binary as any of the seven Application shapes (Console / VCL / Daemon / Windows Service / FPC daemon / LCL / FPC HTTPApplication). |
 
 ## How the docs are organised
 

--- a/doc/index.pt-BR.md
+++ b/doc/index.pt-BR.md
@@ -14,7 +14,7 @@ Se você é novo por aqui, comece por [Primeiros passos](./getting-started.pt-BR
 2. **[Roteamento](./routing.pt-BR.md)** — declarar endpoints, parâmetros de caminho, grupos de rotas, query strings.
 3. **[Request e Response](./request-response.pt-BR.md)** — ler a requisição, escrever a resposta, headers, cookies, sessões, upload/download de arquivos.
 4. **[Middleware](./middleware.pt-BR.md)** — encadear handlers, ordem de registro, criar o seu. Para publicar middleware reutilizável, veja **[Criando um Middleware](./writing-middleware.pt-BR.md)**.
-5. **[Providers e Tipos de aplicação](./providers.pt-BR.md)** — escolher o Provider de transporte (Indy padrão, CrossSocket opcional) e o Tipo de aplicação (Console padrão, VCL, Daemon, LCL, HTTPApplication) — ou um tipo de aplicação host-managed (Apache, ISAPI, CGI, FastCGI).
+5. **[Providers e Tipos de aplicação](./providers.pt-BR.md)** — escolher o Provider de transporte (Indy padrão, CrossSocket e mORMot2 opcionais) e o Tipo de aplicação (Console padrão, VCL, Daemon, LCL, HTTPApplication) — ou um tipo de aplicação host-managed (Apache, ISAPI, CGI, FastCGI).
 
 ## Referência
 
@@ -25,10 +25,10 @@ Se você é novo por aqui, comece por [Primeiros passos](./getting-started.pt-BR
 | [Request e Response](./request-response.pt-BR.md) | `THorseRequest` (body, params, query, headers, cookies, sessions, multipart). `THorseResponse` (`Send`, `Status`, `ContentType`, `AddHeader`, `RedirectTo`, `SendFile`, `Download`, `RawWebResponse`). |
 | [Middleware](./middleware.pt-BR.md) | O modelo `Next` proc; built-in vs custom; ordem de registro; por-rota vs global. |
 | [Criando um Middleware](./writing-middleware.pt-BR.md) | Criando um middleware de qualidade de produção: esqueleto, padrões de configuração, thread safety, código neutro a Provider, armadilhas entre compiladores, matriz de testes, empacotamento Boss, publicação. |
-| [Providers e Tipos de aplicação](./providers.pt-BR.md) | O modelo de dois eixos: **Provider** (transporte — Indy padrão, CrossSocket opcional, futuro mORMot) × **Tipo de aplicação** (Console / VCL / Daemon / LCL / HTTPApplication, mais host-managed Apache / ISAPI / CGI / FCGI). Matriz de compatibilidade e guia de escolha. |
+| [Providers e Tipos de aplicação](./providers.pt-BR.md) | O modelo de dois eixos: **Provider** (transporte — Indy padrão, CrossSocket e mORMot2 opcionais) × **Tipo de aplicação** (Console / VCL / Daemon / LCL / HTTPApplication, mais host-managed Apache / ISAPI / CGI / FCGI). Matriz de compatibilidade e guia de escolha. |
 | [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md) | Pacotes oficiais `HashLoad/*` e a lista mantida pela comunidade. |
 | [Suporte de Compilador](./compiler-support.pt-BR.md) | Versões testadas do Delphi, versões do FPC, plataformas-alvo, guards de versão de compilador. |
-| [Cheatsheet de Deploy](./deployment.pt-BR.md) | Referência de uma página pra entregar um binário CrossSocket como qualquer um dos sete formatos de Aplicação (Console / VCL / Daemon / Serviço Windows / daemon FPC / LCL / HTTPApplication FPC). |
+| [Cheatsheet de Deploy](./deployment.pt-BR.md) | Referência de uma página pra entregar um binário CrossSocket ou mORMot2 como qualquer um dos sete formatos de Aplicação (Console / VCL / Daemon / Serviço Windows / daemon FPC / LCL / HTTPApplication FPC). |
 
 ## Como a documentação está organizada
 

--- a/doc/issue-indy-empty-body-html.md
+++ b/doc/issue-indy-empty-body-html.md
@@ -156,8 +156,11 @@ required on the Horse side.
 
 Any version of Horse that uses the Indy/Console provider
 (`Horse.Provider.Console`) and calls `Res.Send('')` or equivalent.  Not
-reproducible with the CrossSocket provider, which writes response bodies
-independently of `TIdHTTPResponseInfo`.
+reproducible with the CrossSocket provider (`HORSE_PROVIDER_CROSSSOCKET`)
+nor with the mORMot2 provider (`HORSE_PROVIDER_MORMOT`) — both write the
+response body directly, bypassing Indy's `TIdHTTPResponseInfo.WriteContent`
+substitution path entirely. Switching to either async provider is a valid
+workaround as well as a fix for the underlying bug.
 
 ---
 

--- a/doc/middleware-ecosystem.md
+++ b/doc/middleware-ecosystem.md
@@ -91,11 +91,14 @@ These are not maintained by HashLoad but are listed here because they're commonl
 
 ## Third-party transport Providers
 
-Beyond middleware, the community has produced alternative **transport Providers** — the layer Horse uses to own the socket and parse HTTP. This is a separate axis from the middleware list above (see [Providers & Application types](./providers.md) for the full conceptual model). The most actively maintained third-party Provider is:
+Beyond middleware, the community has produced alternative **transport Providers** — the layer Horse uses to own the socket and parse HTTP. This is a separate axis from the middleware list above (see [Providers & Application types](./providers.md) for the full conceptual model). The actively maintained third-party Providers are:
 
 | Provider | Description | License | Repository |
 |---|---|---|---|
-| **horse-provider-crosssocket** | Async IOCP / epoll / kqueue transport. Replaces the default Indy Provider with [Delphi-Cross-Socket](https://github.com/winddriver/Delphi-Cross-Socket). Targets high-concurrency deployments. | MIT | [freitasjca/horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket) |
+| **horse-provider-crosssocket** | Async IOCP / epoll / kqueue transport. Replaces the default Indy Provider with [Delphi-Cross-Socket](https://github.com/winddriver/Delphi-Cross-Socket). Installation is manual (mirrors mORMot2): clone `winddriver/Delphi-Cross-Socket` + [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) and add search paths. Supported alternative for mTLS users or single-dependency convenience: [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) (bundles CnPack + mTLS APIs). Targets high-concurrency deployments. Activated by `HORSE_PROVIDER_CROSSSOCKET`. Requires Delphi 10.2+ / FPC 3.2+. Baseline test score: 80 passed / 1 failed (the documented Set-Cookie multi-value Horse-core limitation). | MIT | [freitasjca/horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket) |
+| **horse-provider-mormot** | Async IOCP / epoll transport. Replaces the default Indy Provider with [mORMot2](https://github.com/synopse/mORMot2)'s `THttpServer` — pure Pascal, no compiled C deps for standard HTTP. Optional swap to `THttpApiServer` for Windows kernel-mode http.sys. Activated by `HORSE_PROVIDER_MORMOT`. Compatible with Delphi 7 through 12.3 Athens and FPC 3.2+. Ships cross-product convenience units for Console, VCL, Daemon (Windows TService + POSIX runner), Lazarus LCL, and FPC HTTPApplication. | MIT | [freitasjca/horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot) |
+
+Both Providers use the same hybrid-interface architecture (`IHorseRawRequest` / `IHorseRawResponse`), so every Horse middleware works unchanged under either. The two Provider defines are mutually exclusive — exactly one transport per build.
 
 See [Providers & Application types](./providers.md) for when to switch off the default Indy transport, the compatibility matrix vs. each Application type, and how to combine the two choices.
 

--- a/doc/middleware-ecosystem.pt-BR.md
+++ b/doc/middleware-ecosystem.pt-BR.md
@@ -91,11 +91,14 @@ Estes não são mantidos pela HashLoad mas estão listados aqui por serem usados
 
 ## Providers de transporte de terceiros
 
-Além de middleware, a comunidade produziu **Providers de transporte** alternativos — a camada que o Horse usa para ser dono do socket e parsear HTTP. Este é um eixo separado da lista de middlewares acima (veja [Providers e Tipos de aplicação](./providers.pt-BR.md) para o modelo conceitual completo). O Provider de terceiros mais ativamente mantido é:
+Além de middleware, a comunidade produziu **Providers de transporte** alternativos — a camada que o Horse usa para ser dono do socket e parsear HTTP. Este é um eixo separado da lista de middlewares acima (veja [Providers e Tipos de aplicação](./providers.pt-BR.md) para o modelo conceitual completo). Os Providers de terceiros ativamente mantidos são:
 
 | Provider | Descrição | Licença | Repositório |
 |---|---|---|---|
-| **horse-provider-crosssocket** | Transporte assíncrono IOCP / epoll / kqueue. Substitui o Provider padrão Indy pelo [Delphi-Cross-Socket](https://github.com/winddriver/Delphi-Cross-Socket). Mira deploys de alta concorrência. | MIT | [freitasjca/horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket) |
+| **horse-provider-crosssocket** | Transporte assíncrono IOCP / epoll / kqueue. Substitui o Provider padrão Indy pelo [Delphi-Cross-Socket](https://github.com/winddriver/Delphi-Cross-Socket). A instalação é manual (espelha o mORMot2): clone `winddriver/Delphi-Cross-Socket` + [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) e adicione os search paths. Alternativa suportada para usuários de mTLS ou que querem uma dependência única: [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) (embute o CnPack + APIs de mTLS). Ativado por `HORSE_PROVIDER_CROSSSOCKET`. Exige Delphi 10.2+ / FPC 3.2+. Baseline de teste: 80 passados / 1 falho (a limitação documentada de Set-Cookie multi-valor do core do Horse). | MIT | [freitasjca/horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket) |
+| **horse-provider-mormot** | Transporte assíncrono IOCP / epoll. Substitui o Provider padrão Indy pelo `THttpServer` do [mORMot2](https://github.com/synopse/mORMot2) — pure Pascal, sem deps em C compilado para HTTP padrão. Troca opcional para `THttpApiServer` para HTTP em modo kernel via http.sys no Windows. Ativado por `HORSE_PROVIDER_MORMOT`. Compatível com Delphi 7 até 12.3 Athens e FPC 3.2+. Inclui units de conveniência cross-product para Console, VCL, Daemon (TService Windows + runner POSIX), LCL Lazarus, e HTTPApplication FPC. | MIT | [freitasjca/horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot) |
+
+Os dois Providers usam a mesma arquitetura de interface híbrida (`IHorseRawRequest` / `IHorseRawResponse`), então todo middleware do Horse funciona sem alterações em qualquer um. Os dois defines de Provider são mutuamente exclusivos — exatamente um transporte por build.
 
 Veja [Providers e Tipos de aplicação](./providers.pt-BR.md) para quando trocar o transporte Indy padrão, a matriz de compatibilidade vs. cada Tipo de aplicação, e como combinar as duas escolhas.
 

--- a/doc/middleware.pt-BR.md
+++ b/doc/middleware.pt-BR.md
@@ -93,7 +93,7 @@ THorse
 THorse.Get('/users', ListUsers);
 ```
 
-## Curto-circuito
+## Interrompendo a cadeia
 
 Pule o `Next()` para parar a cadeia sem chamar o handler. O caso mais comum é autenticação:
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -4,7 +4,7 @@
 
 Horse separates two architectural choices that are easy to confuse:
 
-1. **Provider** — the HTTP transport that owns the socket and parses requests. Indy is the default; CrossSocket is an optional async alternative; future providers (mORMot, nghttp2, …) will follow the same pattern.
+1. **Provider** — the HTTP transport that owns the socket and parses requests. Indy is the default; CrossSocket and mORMot2 are optional async alternatives; future providers (nghttp2, …) follow the same pattern.
 2. **Application type** — how the Delphi/FPC binary is packaged and started: a console executable, a Windows service, a VCL desktop app, an Apache module, an IIS extension, and so on.
 
 These two axes are *conceptually* orthogonal. In the current Horse build the two choices are encoded in the same set of mutually-exclusive Conditional Defines, but the documentation below keeps them separate so the mental model is clean.
@@ -37,7 +37,7 @@ The **default Provider depends on the compiler**:
 | **Indy** | _(none on Delphi)_ | Default for Delphi self-hosted | ✔ | n/a |
 | **`fphttpserver`** | _(none on FPC)_ | Default for FPC self-hosted | n/a | ✔ |
 | **horse-provider-crosssocket** | `HORSE_CROSSSOCKET` | Optional, external package | ✔ | ✔ |
-| _horse-provider-mormot_ | `HORSE_MORMOT` | Planned | — | — |
+| **horse-provider-mormot** | `HORSE_PROVIDER_MORMOT` | Optional, external package | ✔ | ✔ |
 
 > **What library does the HTTP work, per Application type?** This is the deciding question — and it's *not* always Indy. The unifying abstraction across every row is `Web.HTTPApp.TWebRequest` on Delphi or `fpHTTP.TRequest` on FPC; below that, the concrete library differs.
 >
@@ -46,6 +46,7 @@ The **default Provider depends on the compiler**:
 > | Console / VCL / Daemon | Delphi | **Indy** (`TIdHTTPServer` + `IdHTTPWebBrokerBridge`) | ✔ |
 > | Daemon / HTTPApplication / LCL | FPC | **`fphttpserver`** | ✘ |
 > | Any self-hosted + `HORSE_CROSSSOCKET` | Either | **`Delphi-Cross-Socket`** | ✘ |
+> | Any self-hosted + `HORSE_PROVIDER_MORMOT` | Either | **`mORMot2`** (`THttpServer` / `THttpApiServer`) | ✘ |
 > | Apache module | Either | **Apache httpd** (via `Web.HTTPApp.TApacheRequest` / `mod_horse`) | ✘ |
 > | ISAPI | Delphi | **IIS** (via `Web.HTTPApp.TISAPIRequest`) | ✘ |
 > | CGI | Delphi | **Web server's CGI runner** (via `Web.HTTPApp.TCGIRequest`) | ✘ |
@@ -107,9 +108,71 @@ CrossSocket and Indy are **drop-in alternatives** for the same Horse codebase. T
 
 For configuration (TLS certificates, body-size limits, IO thread count, mTLS), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-crosssocket#readme).
 
+### Installation (manual — matches the mORMot2 pattern)
+
+`horse-provider-crosssocket` no longer pulls Delphi-Cross-Socket through Boss. Install Delphi-Cross-Socket the same way you install mORMot2 — clone the repo, add search paths to your project. The provider's `boss.json` declares only the patched Horse fork dependency; everything else is manual:
+
+1. Clone the patched [`horse`](https://github.com/freitasjca/horse) fork (via `boss install horse-provider-crosssocket`).
+2. Clone Delphi-Cross-Socket — **two options**:
+   - **Recommended:** upstream [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket). Tracks the maintainer's release cadence; receives upstream improvements as soon as they land.
+   - **Supported alternative:** the fork release [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3), which bundles CnPack as a vendored subtree and adds the mTLS server-mode APIs (`SetCACertificate(File)` + `SetVerifyPeer(Boolean)`). One clone instead of two, at the cost of lagging behind upstream commits between fork syncs. Pick this if you need mTLS server mode or prefer the single-dependency convenience.
+3. For the upstream path **only**, also clone [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) and add `Source/Common` + `Source/Crypto` to the search path. The fork bundles these files already.
+4. Add all the resulting paths to your project's Search-path field — see [`horse-provider-crosssocket` README](https://github.com/freitasjca/horse-provider-crosssocket#installation) for the full three-path runbook (upstream, fork, and Boss-for-Horse-only).
+
+> **Why "supported alternative" and not "deprecated"?** The fork remains actively maintained for users who want bundled CnPack convenience or need mTLS today. The trade-off is straightforward: upstream `winddriver/Delphi-Cross-Socket` has a higher commit cadence than any fork can keep up with, so the fork inevitably lags. Three previously-fork-only bug fixes (`PATCH-IOCP-1` shutdown cascade, the zero-body response parser hang, the `_OnBodyEnd` nil-guard) have already been merged upstream as of 2026-Q2 — only the mTLS additions remain genuinely fork-exclusive. An upstream mTLS PR is in preparation; once merged, the fork's only remaining value will be the bundled CnPack convenience.
+
+### mORMot2 (optional)
+
+[`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) replaces the Indy transport with [mORMot2](https://github.com/synopse/mORMot2): a mature, high-performance library that uses **IOCP on Windows and epoll on Linux** — the same kernel primitives as CrossSocket. mORMot2 manages its own fixed thread pool (default 32 threads) so no `THorseWorkerPool` is needed.
+
+```sh
+boss install horse-provider-mormot
+```
+
+In your project's Conditional Defines: `HORSE_PROVIDER_MORMOT`. Your code stays the same.
+
+**What changes vs. Indy:**
+
+| | Indy | mORMot2 |
+|---|---|---|
+| Concurrency | One thread per connection | Fixed thread pool (default 32, configurable) |
+| Idle keep-alive cost | One thread per idle connection | Thread only runs when data is ready |
+| Per-request allocation | New `THorseRequest`/`THorseResponse` | Pre-warmed object pool (32 contexts, scales to 512) |
+| Scaling ceiling | ~1 000 concurrent on commodity hardware | 10 000+ concurrent on the same hardware |
+| Compiler support | Delphi XE7+ | Delphi 7 through 12.3 Athens, FPC 3.2+ |
+| http.sys (Windows) | ❌ | ✔ `THttpApiServer` — kernel-mode HTTP, zero code change |
+| External dependency | Indy (bundled) | mORMot2 (add to search path) |
+
+**What changes vs. CrossSocket:**
+
+| | CrossSocket | mORMot2 |
+|---|---|---|
+| Thread pool | `THorseWorkerPool` (4–64 Horse threads) | Built-in (default 32 threads) |
+| External dependency | Delphi-Cross-Socket + CnPack | mORMot2 + (Delphi only) precompiled static `.obj` blobs for zlib/OpenSSL/SQLite |
+| Boss-installable | ✔ both deps | ❌ — mORMot2 must be cloned manually and added to the search path |
+| Older Delphi support | Delphi 10.2+ | Delphi 7+ |
+| http.sys (Windows kernel-mode HTTP) | ❌ | ✔ swap `THttpServer` for `THttpApiServer` |
+| mTLS server mode | ✔ via [`freitasjca/Delphi-Cross-Socket >= 1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) | Roadmap — not yet exposed via `THorseMormotConfig` |
+
+**Pick mORMot2 when:**
+- You need Delphi 7 / XE / XE2 support.
+- You want no third-party library dependency for standard HTTP (pure Pascal).
+- You want Windows http.sys kernel-mode HTTP (`THttpApiServer`).
+- You prefer a 15+-year production-proven codebase.
+
+**Pick CrossSocket when:**
+- You prefer native async IOCP/epoll control.
+- Your project already depends on Delphi-Cross-Socket.
+
+Both providers use IOCP/epoll and a context object pool, so throughput is comparable under typical workloads.
+
+For configuration (`ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) and application-type wrappers (VCL, Windows Service, Linux daemon), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme).
+
+> **mORMot2 installation** — mORMot2 is not available via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) and add `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` to the compiler search path.
+
 ### Future providers
 
-The hybrid-interface architecture (`IHorseRawRequest` / `IHorseRawResponse`) introduced by CrossSocket makes it straightforward to add additional transports. A worked example for mORMot2 lives in [`building-a-mormot-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-mormot-provider.md); for nghttp2 see [`building-a-new-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-new-provider.md). When those land they'll appear in the Provider catalogue above.
+The hybrid-interface architecture (`IHorseRawRequest` / `IHorseRawResponse`) introduced by CrossSocket makes it straightforward to add additional transports. For nghttp2 see [`building-a-new-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-new-provider.md).
 
 ---
 
@@ -121,9 +184,12 @@ Self-hosted application types run the Provider you chose. The Provider owns the 
 |---|---|:---:|:---:|
 | **Console** _(default)_ | _(none)_ | ✔ | ✔ |
 | **VCL** | `HORSE_VCL` | ✔ | ❌ |
-| **Daemon** (Windows service) | `HORSE_DAEMON` | ✔ | ✔ |
+| **Daemon — Windows Service** | `HORSE_DAEMON` | ✔ | n/a |
+| **Daemon — Linux daemon (systemd)** | `HORSE_DAEMON` | ✔ | ✔ |
 | **LCL** (Lazarus GUI) | `HORSE_LCL` | ❌ | ✔ |
 | **HTTPApplication** (FPC) | _(FPC default)_ | ❌ | ✔ |
+
+> **Note** — `HORSE_DAEMON` is a unified application type: the produced binary is a **Windows Service** (`Vcl.SvcMgr.TService` + SCM) on Windows and a **daemon** (`signal(SIGTERM)` + systemd) on Linux. "Daemon" is the Unix-native term; Windows has no native equivalent word, so the define name is borrowed cross-platform.
 
 ### Console — the default
 
@@ -133,9 +199,14 @@ The simplest case. Write a `.dpr` with `{$APPTYPE CONSOLE}`, call `THorse.Listen
 
 Useful when your Delphi application has a UI and you want it to expose an HTTP control surface (a remote-control endpoint, an embedded admin panel). With `HORSE_VCL` defined, Horse starts the Provider on a background thread; the VCL main thread stays free for the form / message loop. Indy-only today; CrossSocket VCL support is architecturally possible but not currently expressible via the defines.
 
-### Daemon — Windows service
+### Daemon — Windows Service or Linux daemon (systemd)
 
-With `HORSE_DAEMON`, Horse wires `Listen` / `Stop` into the Windows Service Control Manager. Combined with a service wrapper, you get `sc start MyService` / `sc stop MyService` integration. Same transport (Indy) underneath.
+`HORSE_DAEMON` is a unified application type. The same `.dpr` compiles for both target OSes; the unit's `{$IFDEF MSWINDOWS}` branch selects the host-integration path at compile time.
+
+- **Windows:** Horse wires `Listen` / `Stop` into the Service Control Manager via `Vcl.SvcMgr.TService`. Combined with a service wrapper, you get `sc start MyService` / `sc stop MyService` integration.
+- **Linux:** Horse installs POSIX signal handlers for `SIGTERM` / `SIGINT` (the standard systemd shutdown signals) and ignores `SIGPIPE`. Combined with a `.service` unit file, `systemctl start/stop MyService` works identically.
+
+Same transport (Indy on Delphi, `fphttpserver` on FPC, or CrossSocket / mORMot2 when their Provider is also defined) underneath in either case. See the [Deployment Cheatsheet](./deployment.md) for both lifecycle templates side by side.
 
 ### LCL — Lazarus GUI application
 
@@ -181,11 +252,12 @@ Provider × Application type — which combinations are currently expressible (a
 | **Indy** _(Delphi default)_ | ✔ | ✔ | ✔ | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
 | **`fphttpserver`** _(FPC default)_ | n/a | n/a | n/a | ✔ | ✔ | ✔ | n/a | n/a | n/a | n/a |
 | **CrossSocket** (`HORSE_PROVIDER_CROSSSOCKET`) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ | ❌ |
+| **mORMot2** (`HORSE_PROVIDER_MORMOT`) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ | ❌ |
 | _Host-managed_ (Apache/ISAPI/CGI/FCGI) | n/a | n/a | n/a | n/a | n/a | n/a | ✔ | ✔ | ✔ | ✔ |
 
 Legend:
-- **✔** — supported and expressible with the current defines. Since PATCH-HORSE-2, every CrossSocket × Application-type cell is supported via the cross-product convenience units in `horse-provider-crosssocket` (e.g. `Horse.Provider.CrossSocket.VCL`, `…Daemon`, `…FPC.Daemon`, `…FPC.LCL`, `…FPC.HTTPApplication`).
-- **❌** — architecturally impossible. Apache / ISAPI / CGI / FCGI own the socket themselves; an async self-hosted transport like CrossSocket can't coexist.
+- **✔** — supported and expressible with the current defines. Since PATCH-HORSE-2, every CrossSocket × Application-type cell is supported via the cross-product convenience units in `horse-provider-crosssocket` (e.g. `Horse.Provider.CrossSocket.VCL`, `…Daemon`, `…FPC.Daemon`, `…FPC.LCL`, `…FPC.HTTPApplication`). mORMot2 ships the matching cross-product set in `horse-provider-mormot`: `Horse.Provider.Mormot` (Console default), `…Mormot.VCL`, `…Mormot.Daemon` (Windows TService + POSIX runner in one unit), `…Mormot.FPC.Daemon`, `…Mormot.FPC.LCL`, `…Mormot.FPC.HTTPApplication`.
+- **❌** — architecturally impossible. Apache / ISAPI / CGI / FCGI own the socket themselves; an async self-hosted transport like CrossSocket or mORMot2 can't coexist.
 - **n/a** — meaningless combination. Indy doesn't run on FPC; `fphttpserver` doesn't run on Delphi; host-managed application types don't use a self-hosted Provider; self-hosted types don't run under a host's lifecycle.
 
 PATCH-HORSE-1 in `Horse.pas` enforces the ❌ cells at compile time with `{$MESSAGE FATAL}` so misconfigured projects fail fast instead of silently picking the wrong code path.
@@ -200,7 +272,7 @@ The selection happens at **compile time** via Project Options → Conditional De
 
 | Axis | Prefix | Meaning |
 |---|---|---|
-| A · **Provider** | `HORSE_PROVIDER_*` | HTTP transport library — Indy (Delphi default), `fphttpserver` (FPC default), CrossSocket, future mORMot |
+| A · **Provider** | `HORSE_PROVIDER_*` | HTTP transport library — Indy (Delphi default), `fphttpserver` (FPC default), CrossSocket, mORMot2 |
 | B · **Application type** | `HORSE_APPTYPE_*` | Binary lifecycle shape — Console (default), VCL, Daemon, LCL, HTTPApplication |
 | C · **Host-managed runtime** | `HORSE_HOST_*` | Web server owns the socket — Apache, ISAPI, CGI, FastCGI |
 
@@ -220,6 +292,10 @@ Axis C wins outright when set (no Provider involved). Axes A and B compose freel
 | **CrossSocket + Windows service** *(new in PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_DAEMON` |
 | **CrossSocket + Linux daemon (FPC)** *(new in PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_DAEMON` (on FPC) |
 | **CrossSocket + Lazarus LCL** *(new in PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_LCL` |
+| **mORMot2 Console** | `HORSE_PROVIDER_MORMOT` |
+| **mORMot2 + VCL** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_VCL` |
+| **mORMot2 + Windows service** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_DAEMON` (on Windows) |
+| **mORMot2 + Linux daemon** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_DAEMON` (on Linux) |
 | Apache module | `HORSE_HOST_APACHE` |
 | IIS ISAPI extension | `HORSE_HOST_ISAPI` |
 | Plain CGI | `HORSE_HOST_CGI` |
@@ -266,7 +342,7 @@ The common pattern across every shape:
 1. **Define only `HORSE_CROSSSOCKET`** — no other `HORSE_*` provider define.
 2. Pick the right **project type** for the desired shape (Console / VCL Forms / Lazarus / Service Application / …).
 3. Drive `THorse.Listen` from the right **lifecycle event** for that shape.
-4. Call `THorse.StopListen` on shutdown so CrossSocket drains in-flight requests (SEC-30) before the process exits.
+4. Call `THorse.StopListen` on shutdown so CrossSocket drains active requests (SEC-30) before the process exits.
 
 CrossSocket's `Listen` automatically picks between blocking and non-blocking behaviour based on `IsConsole`:
 
@@ -645,7 +721,103 @@ All seven cases share the same compile-time configuration: **define `HORSE_CROSS
 
 ---
 
-## 9. Architecture note
+## 9. Running mORMot2 as each Application type
+
+The same `IsConsole` / lifecycle pattern from §8 applies to mORMot2 — the provider units (`Horse.Provider.Mormot.*`) wrap mORMot's `THttpServer` instead of `TCrossHttpServer` but expose the same `Listen` / `StopListen` contract. The four-step recipe is identical:
+
+1. **Define only `HORSE_PROVIDER_MORMOT`** — no other `HORSE_*` provider define.
+2. Pick the right **project type** for the desired shape (Console / VCL Forms / Lazarus / Service Application / …).
+3. Drive `THorse.Listen` from the right **lifecycle event** for that shape.
+4. Call `THorse.StopListen` on shutdown so mORMot's active-request counter drains active requests before the process exits.
+
+mORMot's `Listen` honours the same `IsConsole` switch as CrossSocket: `True` → blocks the calling thread until `StopListen`; `False` → returns immediately after `THttpServer.WaitStarted` so the GUI / service / LCL loop owns the main thread.
+
+### 9.1 Side-by-side with §8 — the only differences
+
+The whole code skeleton in each of §8.1–8.7 ports to mORMot2 by **two substitutions**:
+
+| In §8 (CrossSocket) | In the mORMot2 equivalent |
+|---|---|
+| `HORSE_PROVIDER_CROSSSOCKET` define | `HORSE_PROVIDER_MORMOT` define |
+| `Horse.Provider.CrossSocket.{VCL,Daemon,FPC.Daemon,FPC.LCL,FPC.HTTPApplication}` convenience helper | `Horse.Provider.Mormot.{VCL,Daemon,FPC.Daemon,FPC.LCL,FPC.HTTPApplication}` |
+
+The convenience helpers map one-to-one — the table below is the complete inventory:
+
+| Shape | CrossSocket helper | mORMot2 helper |
+|---|---|---|
+| Console (§8.1) | _(none — direct provider use)_ | _(none — direct provider use)_ |
+| VCL desktop (§8.2) | `TfrmHorseVCLHost` in `Horse.Provider.CrossSocket.VCL` | `TfrmHorseMormotVCLHost` in `Horse.Provider.Mormot.VCL` |
+| Linux daemon, Delphi (§8.3) | `THorseCrossSocketLinuxDaemonApp.Run` in `Horse.Provider.CrossSocket.Daemon` | `THorseMormotLinuxDaemonApp.Run` in `Horse.Provider.Mormot.Daemon` |
+| Windows Service (§8.4) | `THorseCrossSocketService` (`TService` base) in `Horse.Provider.CrossSocket.Daemon` | `THorseMormotService` (`TService` base) in `Horse.Provider.Mormot.Daemon` |
+| Linux daemon, FPC (§8.5) | `THorseCrossSocketDaemonApp.Run` in `Horse.Provider.CrossSocket.FPC.Daemon` | `THorseMormotFPCDaemonApp.Run` in `Horse.Provider.Mormot.FPC.Daemon` |
+| Lazarus LCL (§8.6) | `TfrmHorseLCLHost` in `Horse.Provider.CrossSocket.FPC.LCL` | `TfrmHorseMormotLCLHost` in `Horse.Provider.Mormot.FPC.LCL` |
+| FPC HTTPApplication (§8.7) | `THorseCrossSocketHTTPApp.Run` in `Horse.Provider.CrossSocket.FPC.HTTPApplication` | `THorseMormotHTTPApp.Run` in `Horse.Provider.Mormot.FPC.HTTPApplication` |
+
+The same `{$IFDEF MSWINDOWS}` / `{$ELSE}` rule that gives `HORSE_APPTYPE_DAEMON` two meanings under CrossSocket applies to mORMot too: `Horse.Provider.Mormot.Daemon.pas` carries `THorseMormotService` (Windows TService) under `{$IFDEF MSWINDOWS}` and `THorseMormotLinuxDaemonApp` (POSIX signal-handler runner) under `{$ELSE}`.
+
+### 9.2 Minimal example — Console (mORMot2)
+
+```pascal
+program MyMormotServer;
+
+{$APPTYPE CONSOLE}                 // → IsConsole = True
+
+uses
+  Winapi.Windows, Horse;           // resolves THorse → THorseProviderMormot
+
+function CtrlHandler(dwCtrlType: DWORD): BOOL; stdcall;
+begin
+  case dwCtrlType of
+    CTRL_C_EVENT, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT,
+    CTRL_SHUTDOWN_EVENT:
+      begin
+        THorse.StopListen;
+        Result := True;
+      end;
+  else
+    Result := False;
+  end;
+end;
+
+begin
+  SetConsoleCtrlHandler(@CtrlHandler, True);
+
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin Res.Send('pong'); end);
+
+  THorse.Listen(9000);             // blocks
+end.
+```
+
+Define: `HORSE_PROVIDER_MORMOT`. Project type: **Console Application**. No CrossSocket-style convenience runner here — Console is direct provider use, identical to §8.1 except for the resolved unit behind `THorse`.
+
+### 9.3 Tuning the mORMot transport
+
+Unlike CrossSocket (which uses `THorseWorkerPool` for the Horse pipeline), mORMot owns its own thread pool inside `THttpServer` — default 32 threads. Adjust via `THorseMormotConfig` and the typed entry point:
+
+```pascal
+uses
+  Horse, Horse.Provider.Mormot, Horse.Provider.Mormot.Config;
+
+var
+  Config: THorseMormotConfig;
+begin
+  Config                := THorseMormotConfig.Default;
+  Config.ThreadPool     := 64;                  // bigger pool for blocking handlers
+  Config.MaxBodyBytes   := 16 * 1024 * 1024;    // 16 MB
+  Config.DrainTimeoutMs := 10_000;              // graceful drain window
+  Config.ServerBanner   := 'MyServer/1.0';      // sent as Server: header
+
+  THorseProviderMormot.ListenWithConfig(9000, Config);
+end.
+```
+
+The full configuration record, http.sys swap (`THttpApiServer`), TLS options, and security defaults are documented in [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme).
+
+---
+
+## 10. Architecture note
 
 Every self-hosted Provider implements the same `THorseProviderAbstract` base class. The Provider:
 
@@ -663,4 +835,5 @@ If you want to build a **new** Provider, the [hybrid-interface architecture guid
 - [Getting Started](./getting-started.md) — your first Console + Indy server.
 - [Middleware Ecosystem](./middleware-ecosystem.md) — middleware that works across all Providers.
 - [Compiler Support](./compiler-support.md) — Delphi/FPC versions per Provider and Application type.
-- [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — the optional async Provider's own documentation.
+- [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — the optional CrossSocket async Provider's own documentation.
+- [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) — the optional mORMot2 async Provider's own documentation.

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -4,7 +4,7 @@
 
 O Horse separa duas escolhas arquiteturais que costumam ser confundidas:
 
-1. **Provider** — o transporte HTTP que é dono do socket e parseia as requisições. Indy é o padrão; CrossSocket é uma alternativa assíncrona opcional; providers futuros (mORMot, nghttp2, …) seguirão o mesmo padrão.
+1. **Provider** — o transporte HTTP que é dono do socket e parseia as requisições. Indy é o padrão; CrossSocket e mORMot2 são alternativas assíncronas opcionais; provedores futuros (nghttp2, …) seguirão o mesmo padrão.
 2. **Tipo de aplicação** — como o binário Delphi/FPC é empacotado e iniciado: um executável console, um serviço Windows, um app VCL desktop, um módulo Apache, uma extensão IIS, e assim por diante.
 
 Esses dois eixos são *conceitualmente* ortogonais. No build atual do Horse as duas escolhas são codificadas no mesmo conjunto de Conditional Defines mutuamente exclusivas, mas a documentação abaixo mantém os conceitos separados para que o modelo mental fique limpo.
@@ -37,7 +37,7 @@ O **Provider padrão depende do compilador**:
 | **Indy** | _(nenhum no Delphi)_ | Padrão para self-hosted no Delphi | ✔ | n/a |
 | **`fphttpserver`** | _(nenhum no FPC)_ | Padrão para self-hosted no FPC | n/a | ✔ |
 | **horse-provider-crosssocket** | `HORSE_CROSSSOCKET` | Opcional, pacote externo | ✔ | ✔ |
-| _horse-provider-mormot_ | `HORSE_MORMOT` | Planejado | — | — |
+| **horse-provider-mormot** | `HORSE_PROVIDER_MORMOT` | Opcional, pacote externo | ✔ | ✔ |
 
 > **Qual biblioteca faz o trabalho de HTTP, por Tipo de aplicação?** Esta é a pergunta-chave — e a resposta *nem sempre* é Indy. A abstração unificadora em todas as linhas é `Web.HTTPApp.TWebRequest` no Delphi ou `fpHTTP.TRequest` no FPC; abaixo disso, a biblioteca concreta difere.
 >
@@ -46,6 +46,7 @@ O **Provider padrão depende do compilador**:
 > | Console / VCL / Daemon | Delphi | **Indy** (`TIdHTTPServer` + `IdHTTPWebBrokerBridge`) | ✔ |
 > | Daemon / HTTPApplication / LCL | FPC | **`fphttpserver`** | ✘ |
 > | Qualquer self-hosted + `HORSE_CROSSSOCKET` | Qualquer um | **`Delphi-Cross-Socket`** | ✘ |
+> | Qualquer self-hosted + `HORSE_PROVIDER_MORMOT` | Qualquer um | **`mORMot2`** (`THttpServer` / `THttpApiServer`) | ✘ |
 > | Módulo Apache | Qualquer um | **Apache httpd** (via `Web.HTTPApp.TApacheRequest` / `mod_horse`) | ✘ |
 > | ISAPI | Delphi | **IIS** (via `Web.HTTPApp.TISAPIRequest`) | ✘ |
 > | CGI | Delphi | **CGI runner do webserver** (via `Web.HTTPApp.TCGIRequest`) | ✘ |
@@ -107,9 +108,69 @@ CrossSocket e Indy são **alternativas drop-in** para o mesmo código Horse. O m
 
 Para configuração (certificados TLS, limites de tamanho de body, número de threads IO, mTLS), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-crosssocket#readme).
 
+### Instalação (manual — espelha o padrão do mORMot2)
+
+O `horse-provider-crosssocket` não puxa mais o Delphi-Cross-Socket via Boss. A instalação do Delphi-Cross-Socket segue o mesmo padrão da do mORMot2 — clone o repositório e adicione os search paths ao projeto. O `boss.json` do provider declara apenas a dependência do Horse patchado; todo o resto é manual:
+
+1. Clone o fork patchado do [`horse`](https://github.com/freitasjca/horse) (via `boss install horse-provider-crosssocket`).
+2. Clone o Delphi-Cross-Socket — **duas opções**:
+   - **Recomendado:** upstream [`winddriver/Delphi-Cross-Socket`](https://github.com/winddriver/Delphi-Cross-Socket). Acompanha o ritmo de releases do mantenedor original e recebe as melhorias upstream assim que entram.
+   - **Alternativa suportada:** o release do fork [`freitasjca/Delphi-Cross-Socket v1.0.3`](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3), que embute o CnPack como subárvore vendored e adiciona as APIs de mTLS server-mode (`SetCACertificate(File)` + `SetVerifyPeer(Boolean)`). Um clone em vez de dois, à custa de ficar para trás dos commits upstream entre os syncs do fork. Escolha esta opção se você precisa de mTLS no servidor ou prefere a conveniência de uma dependência única.
+3. **Somente** no caminho upstream, clone também o [`cnpack/cnvcl`](https://github.com/cnpack/cnvcl) e adicione `Source/Common` + `Source/Crypto` ao search path. O fork já embute esses arquivos.
+4. Adicione os search paths resultantes ao campo Search-path do seu projeto — veja o [README do `horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket#installation) para o runbook completo das três opções (upstream, fork, e Boss-só-para-o-Horse).
+
+> **Por que "alternativa suportada" e não "deprecated"?** O fork continua ativamente mantido para usuários que querem a conveniência do CnPack embutido ou precisam de mTLS hoje. O trade-off é direto: o upstream `winddriver/Delphi-Cross-Socket` tem cadência de commits mais alta do que qualquer fork consegue acompanhar, então o fork inevitavelmente fica para trás. Três bug fixes que antes eram exclusivos do fork (`PATCH-IOCP-1` cascade de shutdown, hang do parser para respostas sem body, e o nil-guard em `_OnBodyEnd`) já foram mergeados no upstream em 2026-Q2 — só as adições de mTLS continuam genuinamente exclusivas do fork. Um PR upstream para o mTLS está em preparação; uma vez mergeado, o único valor restante do fork será a conveniência do CnPack embutido.
+
+### mORMot2 (opcional)
+
+[`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) substitui o transporte Indy pelo [mORMot2](https://github.com/synopse/mORMot2): uma biblioteca madura e de alto desempenho que usa **IOCP no Windows e epoll no Linux** — as mesmas primitivas do kernel que o CrossSocket usa. O mORMot2 gerencia seu próprio pool fixo de threads (padrão 32 threads), portanto nenhum `THorseWorkerPool` é necessário.
+
+```sh
+boss install horse-provider-mormot
+```
+
+Nos Conditional Defines do projeto: `HORSE_PROVIDER_MORMOT`. Seu código fica o mesmo.
+
+**O que muda vs. Indy:**
+
+| | Indy | mORMot2 |
+|---|---|---|
+| Concorrência | Uma thread por conexão | Pool fixo de threads (padrão 32, configurável) |
+| Custo de keep-alive ocioso | Uma thread por conexão ociosa | Thread só executa quando há dados prontos |
+| Alocação por requisição | Novo `THorseRequest`/`THorseResponse` | Pool pré-aquecido (32 contextos, escala até 512) |
+| Teto de escala | ~1 000 concorrentes em hardware comum | 10 000+ concorrentes no mesmo hardware |
+| Suporte de compilador | Delphi XE7+ | Delphi 7 ao 12.3 Athens, FPC 3.2+ |
+| http.sys (Windows) | ❌ | ✔ `THttpApiServer` — HTTP no modo kernel, sem alterações de código |
+| Dependência externa | Indy (incluso) | mORMot2 (adicionar ao search path) |
+
+**O que muda vs. CrossSocket:**
+
+| | CrossSocket | mORMot2 |
+|---|---|---|
+| Pool de threads | `THorseWorkerPool` (4–64 threads Horse) | Integrado (padrão 32 threads) |
+| Dependência externa | Delphi-Cross-Socket + CnPack | Pascal puro — sem bibliotecas C compiladas para HTTP padrão |
+| Suporte a Delphi antigo | Delphi 10.2+ | Delphi 7+ |
+| http.sys | ❌ | ✔ |
+
+**Escolha o mORMot2 quando:**
+- Precisa de suporte ao Delphi 7 / XE / XE2.
+- Quer nenhuma dependência de biblioteca de terceiros para HTTP padrão (Pascal puro).
+- Quer HTTP no modo kernel Windows via http.sys (`THttpApiServer`).
+- Prefere um codebase comprovado em produção há mais de 15 anos.
+
+**Escolha o CrossSocket quando:**
+- Prefere o controle nativo assíncrono via IOCP/epoll.
+- Seu projeto já depende do Delphi-Cross-Socket.
+
+Ambos os providers usam IOCP/epoll e um pool de objetos de contexto, portanto a taxa de transferência é comparável sob cargas típicas.
+
+Para configuração (`ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) e as implementações para cada tipo de aplicação  (VCL, Serviço Windows, daemon Linux), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme).
+
+> **Instalação do mORMot2** — o mORMot2 não está disponível via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) e adicione `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` ao search path do compilador.
+
 ### Providers futuros
 
-A arquitetura de interface híbrida (`IHorseRawRequest` / `IHorseRawResponse`) introduzida pelo CrossSocket torna simples adicionar transportes adicionais. Um exemplo trabalhado para mORMot2 fica em [`building-a-mormot-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-mormot-provider.md); para nghttp2 veja [`building-a-new-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-new-provider.md). Quando esses entrarem, aparecerão no catálogo de Providers acima.
+A arquitetura de interface híbrida (`IHorseRawRequest` / `IHorseRawResponse`) introduzida pelo CrossSocket torna simples adicionar transportes adicionais. Para nghttp2 veja [`building-a-new-provider.md`](https://github.com/freitasjca/horse-provider-crosssocket/blob/master/doc/building-a-new-provider.md).
 
 ---
 
@@ -121,9 +182,12 @@ Tipos self-hosted rodam o Provider que você escolheu. O Provider é dono do soc
 |---|---|:---:|:---:|
 | **Console** _(padrão)_ | _(nenhum)_ | ✔ | ✔ |
 | **VCL** | `HORSE_VCL` | ✔ | ❌ |
-| **Daemon** (serviço Windows) | `HORSE_DAEMON` | ✔ | ✔ |
+| **Daemon — Serviço Windows** | `HORSE_DAEMON` | ✔ | n/a |
+| **Daemon — daemon Linux (systemd)** | `HORSE_DAEMON` | ✔ | ✔ |
 | **LCL** (GUI Lazarus) | `HORSE_LCL` | ❌ | ✔ |
 | **HTTPApplication** (FPC) | _(padrão FPC)_ | ❌ | ✔ |
+
+> **Nota** — `HORSE_DAEMON` é um tipo de aplicação guarda-chuva: o binário produzido é um **Serviço Windows** (`Vcl.SvcMgr.TService` + SCM) no Windows e um **daemon** (`signal(SIGTERM)` + systemd) no Linux. "Daemon" é o termo nativo no Unix; o Windows não tem palavra nativa equivalente, então o nome do define é emprestado e usado em modo cross-platform.
 
 ### Console — o padrão
 
@@ -133,9 +197,14 @@ O caso mais simples. Escreva um `.dpr` com `{$APPTYPE CONSOLE}`, chame `THorse.L
 
 Útil quando seu app Delphi tem UI e você quer expor uma superfície HTTP (endpoint de controle remoto, painel admin embutido). Com `HORSE_VCL` definido, o Horse inicia o Provider numa thread em background; a thread principal da VCL fica livre para o form / message loop. Hoje só Indy; suporte VCL no CrossSocket é arquiteturalmente possível mas não expressável pelos defines atuais.
 
-### Daemon — serviço Windows
+### Daemon — Serviço Windows ou daemon Linux (systemd)
 
-Com `HORSE_DAEMON`, o Horse conecta `Listen` / `Stop` ao Service Control Manager do Windows. Combinado com um wrapper de serviço, você tem integração `sc start MeuServico` / `sc stop MeuServico`. Mesmo transporte (Indy) embaixo.
+`HORSE_DAEMON` é um tipo de aplicação adaptável à plataforma. O mesmo `.dpr` compila para os dois OS-alvo; a diretiva `{$IFDEF MSWINDOWS}` da unit seleciona o caminho de integração com o host em tempo de compilação.
+
+- **Windows:** o Horse conecta `Listen` / `Stop` ao Service Control Manager via `Vcl.SvcMgr.TService`. Combinado com um encapsulador de serviço, você tem integração `sc start MeuServico` / `sc stop MeuServico`.
+- **Linux:** o Horse instala handlers POSIX de sinais para `SIGTERM` / `SIGINT` (os sinais padrão de shutdown do systemd) e ignora `SIGPIPE`. Combinado com um arquivo `.service`, `systemctl start/stop MeuServico` funciona da mesma forma.
+
+Mesmo transporte (Indy no Delphi, `fphttpserver` no FPC, ou CrossSocket / mORMot2 quando o Provider correspondente também está definido) por baixo nos dois casos. Veja o [Cheatsheet de Deploy](./deployment.pt-BR.md) para os dois templates de ciclo de vida lado a lado.
 
 ### LCL — aplicação Lazarus com GUI
 
@@ -181,11 +250,12 @@ Provider × Tipo de aplicação — quais combinações são atualmente express�
 | **Indy** _(padrão Delphi)_ | ✔ | ✔ | ✔ | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
 | **`fphttpserver`** _(padrão FPC)_ | n/a | n/a | n/a | ✔ | ✔ | ✔ | n/a | n/a | n/a | n/a |
 | **CrossSocket** (`HORSE_PROVIDER_CROSSSOCKET`) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ | ❌ |
+| **mORMot2** (`HORSE_PROVIDER_MORMOT`) | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ❌ | ❌ | ❌ | ❌ |
 | _Host-managed_ (Apache/ISAPI/CGI/FCGI) | n/a | n/a | n/a | n/a | n/a | n/a | ✔ | ✔ | ✔ | ✔ |
 
 Legenda:
-- **✔** — suportado e expressável com os defines atuais. Desde o PATCH-HORSE-2, toda célula CrossSocket × Tipo-de-aplicação é suportada via as units de produto cruzado em `horse-provider-crosssocket` (ex. `Horse.Provider.CrossSocket.VCL`, `…Daemon`, `…FPC.Daemon`, `…FPC.LCL`, `…FPC.HTTPApplication`).
-- **❌** — arquiteturalmente impossível. Apache / ISAPI / CGI / FCGI são donos do socket; um transporte self-hosted assíncrono como o CrossSocket não pode coexistir.
+- **✔** — suportado e expressável com os defines atuais. Desde o PATCH-HORSE-2, toda célula CrossSocket × Tipo-de-aplicação é suportada via as units de produto cruzado em `horse-provider-crosssocket` (ex. `Horse.Provider.CrossSocket.VCL`, `…Daemon`, `…FPC.Daemon`, `…FPC.LCL`, `…FPC.HTTPApplication`). O mORMot2 traz o conjunto cruzado equivalente em `horse-provider-mormot`: `Horse.Provider.Mormot` (Console padrão), `…Mormot.VCL`, `…Mormot.Daemon` (Serviço Windows TService + runner POSIX numa única unit), `…Mormot.FPC.Daemon`, `…Mormot.FPC.LCL`, `…Mormot.FPC.HTTPApplication`.
+- **❌** — arquiteturalmente impossível. Apache / ISAPI / CGI / FCGI são donos do socket; um transporte self-hosted assíncrono como CrossSocket ou mORMot2 não pode coexistir.
 - **n/a** — combinação sem sentido. Indy não roda no FPC; `fphttpserver` não roda no Delphi; tipos host-managed não usam um Provider self-hosted; tipos self-hosted não rodam no ciclo de vida de um host.
 
 O PATCH-HORSE-1 em `Horse.pas` força as células ❌ em tempo de compilação com `{$MESSAGE FATAL}` para que projetos mal configurados falhem rápido em vez de silenciosamente pegarem o caminho errado.
@@ -200,7 +270,7 @@ A seleção acontece em **tempo de compilação** via Project Options → Condit
 
 | Eixo | Prefixo | Significado |
 |---|---|---|
-| A · **Provider** | `HORSE_PROVIDER_*` | Biblioteca de transporte HTTP — Indy (padrão Delphi), `fphttpserver` (padrão FPC), CrossSocket, futuro mORMot |
+| A · **Provider** | `HORSE_PROVIDER_*` | Biblioteca de transporte HTTP — Indy (padrão Delphi), `fphttpserver` (padrão FPC), CrossSocket, mORMot2 |
 | B · **Tipo de aplicação** | `HORSE_APPTYPE_*` | Formato de ciclo de vida do binário — Console (padrão), VCL, Daemon, LCL, HTTPApplication |
 | C · **Runtime host-managed** | `HORSE_HOST_*` | Webserver é dono do socket — Apache, ISAPI, CGI, FastCGI |
 
@@ -220,6 +290,10 @@ O Eixo C vence outright quando definido (nenhum Provider envolvido). Os Eixos A 
 | **CrossSocket + serviço Windows** *(novo no PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_DAEMON` |
 | **CrossSocket + daemon Linux (FPC)** *(novo no PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_DAEMON` (no FPC) |
 | **CrossSocket + Lazarus LCL** *(novo no PATCH-HORSE-2)* | `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_LCL` |
+| **mORMot2 Console** | `HORSE_PROVIDER_MORMOT` |
+| **mORMot2 + VCL** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_VCL` |
+| **mORMot2 + serviço Windows** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_DAEMON` (no Windows) |
+| **mORMot2 + daemon Linux** | `HORSE_PROVIDER_MORMOT` + `HORSE_APPTYPE_DAEMON` (no Linux) |
 | Módulo Apache | `HORSE_HOST_APACHE` |
 | Extensão ISAPI no IIS | `HORSE_HOST_ISAPI` |
 | CGI simples | `HORSE_HOST_CGI` |
@@ -266,7 +340,7 @@ O padrão comum em todos os formatos:
 1. **Defina apenas `HORSE_CROSSSOCKET`** — nenhum outro define `HORSE_*` de provider.
 2. Escolha o **tipo de projeto** certo para o formato desejado (Console / VCL Forms / Lazarus / Service Application / …).
 3. Acione `THorse.Listen` a partir do **evento de ciclo de vida** certo daquele formato.
-4. Chame `THorse.StopListen` no shutdown para o CrossSocket drenar requisições em voo (SEC-30) antes do processo sair.
+4. Chame `THorse.StopListen` no shutdown para o CrossSocket processe as requisições ativas (SEC-30) antes do processo ser encerrado.
 
 O `Listen` do CrossSocket escolhe automaticamente entre bloqueante e não-bloqueante a partir do `IsConsole`:
 
@@ -418,7 +492,7 @@ sudo systemctl daemon-reload && sudo systemctl enable --now myhorse
 
 Defines: `HORSE_PROVIDER_CROSSSOCKET` + `HORSE_APPTYPE_DAEMON` (PATCH-HORSE-2). Target do projeto: **Linux64**.
 
-**Dica:** o runner de conveniência opcional `THorseCrossSocketLinuxDaemonApp.Run(@SetupRoutes, Port)` (em `Horse.Provider.CrossSocket.Daemon` — a mesma unit do `THorseCrossSocketService` da §8.4, só que o branch não-Windows) instala handlers `signal(SIGTERM/SIGINT)`, ignora `SIGPIPE` e chama `THorse.Listen` pra você. O corpo inteiro do `program` colapsa pra uma única chamada.
+**Dica:** o runner de conveniência opcional `THorseCrossSocketLinuxDaemonApp.Run(@SetupRoutes, Port)` (em `Horse.Provider.CrossSocket.Daemon` — a mesma unit do `THorseCrossSocketService` da §8.4, só que o branch não-Windows) instala handlers `signal(SIGTERM/SIGINT)`, ignora `SIGPIPE` e chama `THorse.Listen` pra você. O corpo inteiro do `program` se resume a uma única chamada.
 
 > **Nota sobre `HORSE_APPTYPE_DAEMON` no Delphi:** o mesmo define significa "Serviço Windows" quando compilando pro Windows e "daemon Linux" quando compilando pro Linux. O `Horse.Provider.CrossSocket.Daemon.pas` carrega ambos os helpers de ciclo de vida (`THorseCrossSocketService` sob `{$IFDEF MSWINDOWS}`, `THorseCrossSocketLinuxDaemonApp` sob `{$ELSE}`). Isso espelha o comportamento multiplataforma do Indy-based `Horse.Provider.Daemon.pas`. "Daemon" é a *intenção* (processo de longa duração supervisionado pelo OS); a maquinaria específica do OS é escolhida pelo target de build.
 
@@ -645,7 +719,103 @@ Todos os sete casos compartilham a mesma configuração em tempo de compilação
 
 ---
 
-## 9. Nota arquitetural
+## 9. Rodando o mORMot2 em cada Tipo de aplicação
+
+O mesmo padrão de `IsConsole` / ciclo de vida da §8 se aplica ao mORMot2 — as units do provider (`Horse.Provider.Mormot.*`) envolvem o `THttpServer` do mORMot em vez do `TCrossHttpServer`, mas expõem o mesmo contrato `Listen` / `StopListen`. A receita de quatro passos é idêntica:
+
+1. **Defina apenas `HORSE_PROVIDER_MORMOT`** — nenhum outro define `HORSE_*` de provider.
+2. Escolha o **tipo de projeto** correto para o shape desejado (Console / VCL Forms / Lazarus / Service Application / …).
+3. Dispare `THorse.Listen` a partir do **evento de ciclo de vida** correto para esse shape.
+4. Chame `THorse.StopListen` no shutdown para que o contador de requisições ativas do mORMot drene as requisições em voo antes do processo terminar.
+
+O `Listen` do mORMot honra o mesmo switch `IsConsole` que o CrossSocket: `True` → bloqueia a thread chamadora até `StopListen`; `False` → retorna imediatamente após `THttpServer.WaitStarted`, deixando o loop GUI / serviço / LCL controlar a thread principal.
+
+### 9.1 Lado a lado com a §8 — as únicas diferenças
+
+Todo esqueleto de código de §8.1 a §8.7 se porta para o mORMot2 com **duas substituições**:
+
+| Em §8 (CrossSocket) | No equivalente mORMot2 |
+|---|---|
+| Define `HORSE_PROVIDER_CROSSSOCKET` | Define `HORSE_PROVIDER_MORMOT` |
+| Helper `Horse.Provider.CrossSocket.{VCL,Daemon,FPC.Daemon,FPC.LCL,FPC.HTTPApplication}` | `Horse.Provider.Mormot.{VCL,Daemon,FPC.Daemon,FPC.LCL,FPC.HTTPApplication}` |
+
+Os helpers de conveniência têm correspondência um-para-um — a tabela abaixo é o inventário completo:
+
+| Shape | Helper CrossSocket | Helper mORMot2 |
+|---|---|---|
+| Console (§8.1) | _(nenhum — uso direto do provider)_ | _(nenhum — uso direto do provider)_ |
+| VCL desktop (§8.2) | `TfrmHorseVCLHost` em `Horse.Provider.CrossSocket.VCL` | `TfrmHorseMormotVCLHost` em `Horse.Provider.Mormot.VCL` |
+| Daemon Linux, Delphi (§8.3) | `THorseCrossSocketLinuxDaemonApp.Run` em `Horse.Provider.CrossSocket.Daemon` | `THorseMormotLinuxDaemonApp.Run` em `Horse.Provider.Mormot.Daemon` |
+| Serviço Windows (§8.4) | `THorseCrossSocketService` (base `TService`) em `Horse.Provider.CrossSocket.Daemon` | `THorseMormotService` (base `TService`) em `Horse.Provider.Mormot.Daemon` |
+| Daemon Linux, FPC (§8.5) | `THorseCrossSocketDaemonApp.Run` em `Horse.Provider.CrossSocket.FPC.Daemon` | `THorseMormotFPCDaemonApp.Run` em `Horse.Provider.Mormot.FPC.Daemon` |
+| LCL Lazarus (§8.6) | `TfrmHorseLCLHost` em `Horse.Provider.CrossSocket.FPC.LCL` | `TfrmHorseMormotLCLHost` em `Horse.Provider.Mormot.FPC.LCL` |
+| FPC HTTPApplication (§8.7) | `THorseCrossSocketHTTPApp.Run` em `Horse.Provider.CrossSocket.FPC.HTTPApplication` | `THorseMormotHTTPApp.Run` em `Horse.Provider.Mormot.FPC.HTTPApplication` |
+
+A mesma regra `{$IFDEF MSWINDOWS}` / `{$ELSE}` que dá ao `HORSE_APPTYPE_DAEMON` dois significados sob CrossSocket vale também para o mORMot: `Horse.Provider.Mormot.Daemon.pas` traz `THorseMormotService` (TService Windows) sob `{$IFDEF MSWINDOWS}` e `THorseMormotLinuxDaemonApp` (runner POSIX com handler de signal) sob `{$ELSE}`.
+
+### 9.2 Exemplo mínimo — Console (mORMot2)
+
+```pascal
+program MyMormotServer;
+
+{$APPTYPE CONSOLE}                 // → IsConsole = True
+
+uses
+  Winapi.Windows, Horse;           // resolve THorse → THorseProviderMormot
+
+function CtrlHandler(dwCtrlType: DWORD): BOOL; stdcall;
+begin
+  case dwCtrlType of
+    CTRL_C_EVENT, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT,
+    CTRL_SHUTDOWN_EVENT:
+      begin
+        THorse.StopListen;
+        Result := True;
+      end;
+  else
+    Result := False;
+  end;
+end;
+
+begin
+  SetConsoleCtrlHandler(@CtrlHandler, True);
+
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin Res.Send('pong'); end);
+
+  THorse.Listen(9000);             // bloqueia
+end.
+```
+
+Define: `HORSE_PROVIDER_MORMOT`. Tipo de projeto: **Console Application**. Sem runner de conveniência aqui — Console é uso direto do provider, idêntico à §8.1 exceto pela unit resolvida atrás de `THorse`.
+
+### 9.3 Ajustando o transporte mORMot
+
+Diferente do CrossSocket (que usa `THorseWorkerPool` para a pipeline Horse), o mORMot tem seu próprio pool de threads dentro do `THttpServer` — padrão 32 threads. Ajuste via `THorseMormotConfig` e o ponto de entrada tipado:
+
+```pascal
+uses
+  Horse, Horse.Provider.Mormot, Horse.Provider.Mormot.Config;
+
+var
+  Config: THorseMormotConfig;
+begin
+  Config                := THorseMormotConfig.Default;
+  Config.ThreadPool     := 64;                  // pool maior para handlers bloqueantes
+  Config.MaxBodyBytes   := 16 * 1024 * 1024;    // 16 MB
+  Config.DrainTimeoutMs := 10_000;              // janela de drain gracioso
+  Config.ServerBanner   := 'MyServer/1.0';      // enviado como header Server:
+
+  THorseProviderMormot.ListenWithConfig(9000, Config);
+end.
+```
+
+O record completo de configuração, swap para http.sys (`THttpApiServer`), opções de TLS e defaults de segurança estão documentados em [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot#readme).
+
+---
+
+## 10. Nota arquitetural
 
 Todo Provider self-hosted implementa a mesma classe base `THorseProviderAbstract`. O Provider:
 
@@ -663,4 +833,5 @@ Se quiser construir um **novo** Provider, o [guia de arquitetura de interface h�
 - [Primeiros passos](./getting-started.pt-BR.md) — seu primeiro servidor Console + Indy.
 - [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md) — middleware que funciona em todos os Providers.
 - [Suporte de Compilador](./compiler-support.pt-BR.md) — versões Delphi/FPC por Provider e Tipo de aplicação.
-- [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — documentação própria do Provider assíncrono opcional.
+- [`horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) — documentação própria do Provider CrossSocket assíncrono opcional.
+- [`horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) — documentação própria do Provider mORMot2 assíncrono opcional.

--- a/doc/request-response.md
+++ b/doc/request-response.md
@@ -218,8 +218,9 @@ To intercept exceptions globally, register the `handle-exception` middleware ([`
 Most application code never needs to think about the transport. A few exceptions:
 
 - **Body ownership on CrossSocket:** `Req.Body<TStream>` on the CrossSocket provider returns a non-owning reference into the receive buffer. Never `Free` it. If you need the stream after the request returns, copy into a `TMemoryStream` you own. (Doesn't apply to Indy — Indy gives you its own owned stream.)
-- **Concurrent handlers:** Indy runs one thread per connection; CrossSocket dispatches to an IO thread pool. In both cases your handler runs to completion on a single thread, so per-request state is safe. Shared state needs explicit locking (`TCriticalSection`, `TMonitor`).
-- **`Req.RawWebRequest` and `Res.RawWebResponse`:** middleware that pokes the underlying objects (e.g. `Horse.CORS` setting `Access-Control-Allow-Origin` directly) keeps working across providers — non-Indy providers return an adapter object that exposes the same surface.
+- **Body ownership on mORMot2:** the mORMot provider does not produce a `TStream` body at all — the request body is buffered as a `RawByteString` (`InContent`) owned by mORMot. `Req.Body: string` is decoded once at request entry and cached (PATCH-REQ-9), so reading it multiple times is O(1). `Req.Body<TStream>` is therefore not the right pattern on this transport; use `Req.Body: string` (text) or `Req.RawWebRequest.Content` (raw bytes) instead.
+- **Concurrent handlers:** Indy runs one thread per connection; CrossSocket dispatches to an IO thread pool (and an optional Horse worker pool); mORMot2 dispatches to its own fixed thread pool inside `THttpServer` (default 32, configurable). In every case your handler runs to completion on a single thread, so per-request state is safe. Shared state needs explicit locking (`TCriticalSection`, `TMonitor`).
+- **`Req.RawWebRequest` and `Res.RawWebResponse`:** middleware that pokes the underlying objects (e.g. `Horse.CORS` setting `Access-Control-Allow-Origin` directly) keeps working across every Provider — CrossSocket and mORMot2 both return an adapter object backed by the same `IHorseRawRequest` / `IHorseRawResponse` interface that exposes the same surface as the Indy `TIdHTTPAppRequest` / `TIdHTTPAppResponse`.
 
 See [Providers](./providers.md) for the full breakdown.
 

--- a/doc/request-response.pt-BR.md
+++ b/doc/request-response.pt-BR.md
@@ -215,9 +215,9 @@ Para interceptar exceptions globalmente, registre o middleware `handle-exception
 
 ## Notas específicas de provider
 
-A maioria do código de aplicação nunca precisa pensar no transporte. Algumas exceções:
+A maioria do código da aplicação nunca precisa se preocupar com o transporte. Algumas exceções:
 
-- **Posse do body no CrossSocket:** `Req.Body<TStream>` no provider CrossSocket retorna uma referência não-dona ao buffer de recepção. Nunca chame `Free` nele. Se precisar do stream após a requisição retornar, copie para um `TMemoryStream` próprio. (Não se aplica ao Indy — o Indy entrega um stream próprio.)
+- **Posse do body no CrossSocket:** `Req.Body<TStream>` no provider CrossSocket retorna uma referência não proprietária para o buffer de recepção. Nunca o libere com Free. Se precisar do stream após a requisição retornar, copie o conteúdo para um  `TMemoryStream` próprio. (Não se aplica ao Indy — o Indy entrega um stream próprio.)
 - **Handlers concorrentes:** Indy roda uma thread por conexão; CrossSocket distribui para um pool de threads de IO. Em ambos, seu handler roda até o fim numa única thread, então estado por-requisição é seguro. Estado compartilhado precisa de lock explícito (`TCriticalSection`, `TMonitor`).
 - **`Req.RawWebRequest` e `Res.RawWebResponse`:** middleware que mexe nos objetos subjacentes (ex. `Horse.CORS` definindo `Access-Control-Allow-Origin` direto) continua funcionando entre providers — providers não-Indy retornam um adaptador que expõe a mesma superfície.
 

--- a/doc/writing-middleware.md
+++ b/doc/writing-middleware.md
@@ -10,7 +10,7 @@ This guide walks through implementing a production-quality Horse middleware — 
 
 Five properties — your middleware should meet all of them if you're publishing it for others:
 
-1. **Provider-neutral** — works on Indy (Delphi default), `fphttpserver` (FPC default), CrossSocket, and any future Provider. Apache / ISAPI / CGI too.
+1. **Provider-neutral** — works on Indy (Delphi default), `fphttpserver` (FPC default), CrossSocket, mORMot2, and any future Provider. Apache / ISAPI / CGI too.
 2. **Cross-compiler** — compiles on Delphi 10.4 Sydney or newer **and** FPC 3.2 or newer.
 3. **Thread-safe** — Horse handlers run on different threads under different Providers; shared state must be guarded.
 4. **Configurable** — accepts options without relying on global variables, where possible.
@@ -143,6 +143,7 @@ Horse handlers run on different threads depending on the Provider:
 | Indy (Delphi self-hosted) | One Indy thread per connection | Hundreds of threads under load |
 | `fphttpserver` (FPC self-hosted) | One thread per connection | Same as Indy |
 | CrossSocket | IO threads (fixed pool of 4–16) or worker threads (`THorseWorkerPool`, 4–64) | Same handler can run on different threads across requests |
+| mORMot2 | Fixed thread pool inside `THttpServer` (default 32, configurable via `THorseMormotConfig.ThreadPool`) | Same handler can run on different threads across requests |
 | Apache / ISAPI / CGI | Host's worker thread | Varies by host configuration |
 
 In every Provider, **a single handler invocation runs on a single thread end-to-end**. You don't need locks within one request. But shared state across requests must be protected.
@@ -355,7 +356,7 @@ Assert(LResp = 'ok');
 
 ### Provider matrix — catches the rare ones
 
-At minimum, run your integration tests under **Indy** (default — no define) and **CrossSocket** (`HORSE_PROVIDER_CROSSSOCKET`, or the legacy `HORSE_CROSSSOCKET`). If you claim FPC support, run on FPC too with the `fphttpserver` default. The reference test pattern lives in [`horse-provider-crosssocket/samples/tests/`](https://github.com/freitasjca/horse-provider-crosssocket/tree/master/samples/tests) — 32 black-box HTTP tests covering routing, body handling, concurrent requests, CORS, and shadow-field precedence. Copy the pattern.
+At minimum, run your integration tests under **Indy** (default — no define) and one of the async Providers — **CrossSocket** (`HORSE_PROVIDER_CROSSSOCKET`, or the legacy `HORSE_CROSSSOCKET`) or **mORMot2** (`HORSE_PROVIDER_MORMOT`). The two async Providers share the same hybrid-adapter contract, so middleware that passes one usually passes the other; running both gives the strongest signal. If you claim FPC support, run on FPC too with the `fphttpserver` default. The reference test patterns live in [`horse-provider-crosssocket/samples/tests/`](https://github.com/freitasjca/horse-provider-crosssocket/tree/master/samples/tests) and [`horse-provider-mormot/samples/tests/`](https://github.com/freitasjca/horse-provider-mormot/tree/master/samples/tests) — both register the same 32 black-box HTTP tests covering routing, body handling, concurrent requests, CORS, and shadow-field precedence so a single test client validates both transports.
 
 ---
 

--- a/src/Horse.Provider.RawInterfaces.pas
+++ b/src/Horse.Provider.RawInterfaces.pas
@@ -1,4 +1,4 @@
-unit Horse.Provider.RawInterfaces;
+﻿unit Horse.Provider.RawInterfaces;
 
 {
   Horse Provider Raw Interfaces
@@ -93,3 +93,4 @@ type
 implementation
 
 end.
+

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -74,7 +74,7 @@ unit Horse;
                           Indy        (Delphi default — implicit)
                           fphttpserver(FPC default    — implicit)
                           CrossSocket (HORSE_PROVIDER_CROSSSOCKET)
-                          mORMot      (HORSE_PROVIDER_MORMOT — reserved)
+                          mORMot      (HORSE_PROVIDER_MORMOT)
 
     B · Application type  HORSE_APPTYPE_*   — binary lifecycle shape
                           Console     (default — implicit)
@@ -143,6 +143,20 @@ unit Horse;
     {$MESSAGE FATAL 'HORSE_PROVIDER_CROSSSOCKET cannot combine with HORSE_HOST_FCGI — FastCGI talks to a web server; a self-hosted Provider cannot coexist.'}
   {$ENDIF}
 {$IFEND}
+{$IF DEFINED(HORSE_PROVIDER_MORMOT)}
+  {$IF DEFINED(HORSE_HOST_ISAPI)}
+    {$MESSAGE FATAL 'HORSE_PROVIDER_MORMOT cannot combine with HORSE_HOST_ISAPI — IIS owns the socket; a self-hosted Provider cannot coexist.'}
+  {$ENDIF}
+  {$IF DEFINED(HORSE_HOST_APACHE)}
+    {$MESSAGE FATAL 'HORSE_PROVIDER_MORMOT cannot combine with HORSE_HOST_APACHE — Apache owns the socket; a self-hosted Provider cannot coexist.'}
+  {$ENDIF}
+  {$IF DEFINED(HORSE_HOST_CGI)}
+    {$MESSAGE FATAL 'HORSE_PROVIDER_MORMOT cannot combine with HORSE_HOST_CGI — the web server owns the socket; a self-hosted Provider cannot coexist.'}
+  {$ENDIF}
+  {$IF DEFINED(HORSE_HOST_FCGI)}
+    {$MESSAGE FATAL 'HORSE_PROVIDER_MORMOT cannot combine with HORSE_HOST_FCGI — FastCGI talks to a web server; a self-hosted Provider cannot coexist.'}
+  {$ENDIF}
+{$IFEND}
 
 { Rule 2 — cross-platform Application-type mismatch }
 {$IF DEFINED(HORSE_APPTYPE_VCL) and DEFINED(FPC)}
@@ -157,9 +171,14 @@ unit Horse;
 
 { Rule 3 — HORSE_NOPROVIDER × anything else }
 {$IF DEFINED(HORSE_NOPROVIDER)}
-  {$IF DEFINED(HORSE_PROVIDER_CROSSSOCKET) or DEFINED(HORSE_APPTYPE_VCL) or DEFINED(HORSE_APPTYPE_DAEMON) or DEFINED(HORSE_APPTYPE_LCL) or DEFINED(HORSE_HOST_APACHE) or DEFINED(HORSE_HOST_ISAPI) or DEFINED(HORSE_HOST_CGI) or DEFINED(HORSE_HOST_FCGI)}
+  {$IF DEFINED(HORSE_PROVIDER_CROSSSOCKET) or DEFINED(HORSE_PROVIDER_MORMOT) or DEFINED(HORSE_APPTYPE_VCL) or DEFINED(HORSE_APPTYPE_DAEMON) or DEFINED(HORSE_APPTYPE_LCL) or DEFINED(HORSE_HOST_APACHE) or DEFINED(HORSE_HOST_ISAPI) or DEFINED(HORSE_HOST_CGI) or DEFINED(HORSE_HOST_FCGI)}
     {$MESSAGE FATAL 'HORSE_NOPROVIDER is mutually exclusive with all HORSE_PROVIDER_*, HORSE_APPTYPE_*, and HORSE_HOST_* defines — remove one.'}
   {$IFEND}
+{$IFEND}
+
+{ Rule 4 — mutually-exclusive Providers (Axis A admits at most one) }
+{$IF DEFINED(HORSE_PROVIDER_CROSSSOCKET) and DEFINED(HORSE_PROVIDER_MORMOT)}
+  {$MESSAGE FATAL 'HORSE_PROVIDER_CROSSSOCKET and HORSE_PROVIDER_MORMOT are mutually exclusive — pick exactly one transport Provider per build.'}
 {$IFEND}
 { =========================================================================== }
 
@@ -183,6 +202,14 @@ uses
     Horse.Provider.CrossSocket.FPC.LCL,
     {$ELSE}
     Horse.Provider.CrossSocket,    { Console-shape — also covers FPC HTTPApplication }
+    {$ENDIF}
+  {$ELSEIF DEFINED(HORSE_PROVIDER_MORMOT)}
+    {$IF DEFINED(HORSE_APPTYPE_DAEMON)}
+    Horse.Provider.Mormot.FPC.Daemon,
+    {$ELSEIF DEFINED(HORSE_APPTYPE_LCL)}
+    Horse.Provider.Mormot.FPC.LCL,
+    {$ELSE}
+    Horse.Provider.Mormot.FPC.HTTPApplication,   { FPC default shape for mORMot }
     {$ENDIF}
   {$ELSEIF DEFINED(HORSE_APPTYPE_DAEMON)}
   Horse.Provider.FPC.Daemon,
@@ -211,6 +238,15 @@ uses
   Horse.Provider.CrossSocket.Daemon,
   {$ELSE}
   Horse.Provider.CrossSocket,    { Console-shape — Delphi default for CrossSocket }
+  {$ENDIF}
+{$ELSEIF DEFINED(HORSE_PROVIDER_MORMOT)}
+  System.SysUtils,
+  {$IF DEFINED(HORSE_APPTYPE_VCL)}
+  Horse.Provider.Mormot.VCL,
+  {$ELSEIF DEFINED(HORSE_APPTYPE_DAEMON)}
+  Horse.Provider.Mormot.Daemon,
+  {$ELSE}
+  Horse.Provider.Mormot,         { Console-shape — Delphi default for mORMot }
   {$ENDIF}
 {$ELSE}
   System.SysUtils,
@@ -295,6 +331,23 @@ type
     THorseProvider = Horse.Provider.CrossSocket.FPC.LCL.THorseProviderCrossSocketFPCLCL;
   {$ELSE}
     THorseProvider = Horse.Provider.CrossSocket.THorseProviderCrossSocket;
+  {$ENDIF}
+{$ELSEIF DEFINED(HORSE_PROVIDER_MORMOT)}
+  {$IF DEFINED(HORSE_APPTYPE_VCL)}
+    THorseProvider = Horse.Provider.Mormot.VCL.THorseProviderMormotVCL;
+  {$ELSEIF DEFINED(HORSE_APPTYPE_DAEMON)}
+    THorseProvider =
+    {$IF DEFINED(FPC)}
+      Horse.Provider.Mormot.FPC.Daemon.THorseProviderMormotFPCDaemon;
+    {$ELSE}
+      Horse.Provider.Mormot.Daemon.THorseProviderMormotDaemon;
+    {$ENDIF}
+  {$ELSEIF DEFINED(HORSE_APPTYPE_LCL)}
+    THorseProvider = Horse.Provider.Mormot.FPC.LCL.THorseProviderMormotFPCLCL;
+  {$ELSEIF DEFINED(FPC)}
+    THorseProvider = Horse.Provider.Mormot.FPC.HTTPApplication.THorseProviderMormotFPCHTTPApplication;
+  {$ELSE}
+    THorseProvider = Horse.Provider.Mormot.THorseProviderMormot;
   {$ENDIF}
 {$ELSEIF DEFINED(HORSE_APPTYPE_DAEMON)}
   THorseProvider =


### PR DESCRIPTION
# Integrate CrossSocket / mORMot transport providers + PATCH-HORSE-2 three-axis defines + bilingual docs

## Summary

This PR proposes integrating of work from the [`freitasjca/horse`](https://github.com/freitasjca/horse) fork into upstream. The fork ships releases used in production today and underpins two transport-provider packages ([`horse-provider-crosssocket v1.0.8`](https://github.com/freitasjca/horse-provider-crosssocket/releases/tag/v1.0.8) and [`horse-provider-mormot v1.0.1`](https://github.com/freitasjca/horse-provider-mormot/releases/tag/v1.0.1)). Every change is **additive** — no existing method is removed, renamed, or given a different signature, and every existing `.dproj` / `.lpi` continues to compile unchanged.

I chose to submit this as **one PR** rather than several themed ones because the changes form a coherent design and most have non-trivial inter-dependencies. If you'd prefer the work split (e.g. provider-scaffolding separately from docs), I'm happy to repackage.

## What this proposes

The PR's four commits are independently legible — each builds on the previous:

| # | Commit | What it adds |
|---|---|---|
| 1 | [`64cd1c4`](https://github.com/freitasjca/horse/commit/64cd1c4) `feat: CrossSocket high-performance provider integration` | `Horse.Provider.RawInterfaces` + `Horse.Provider.RawAdapters` (new units enabling external-provider plug-in via lightweight interfaces); nil-guard branches in `Horse.Request` / `Horse.Response` for non-Indy paths; `ListenWithConfig` + `Execute` + `MaxConnections` on `Horse.Provider.Abstract` |
| 2 | [`ca41d80`](https://github.com/freitasjca/horse/commit/ca41d80) `feat(horse): PATCH-HORSE-2 three-axis defines + bilingual doc tree (v3.1.98)` | Three-axis define normalization in `Horse.pas` (Provider × Application type × Host-managed); G1–G8 backwards-compatibility contract; bilingual `doc/` tree (EN + PT-BR) |
| 3 | [`e8e346f`](https://github.com/freitasjca/horse/commit/e8e346f) `feat: HORSE_PROVIDER_MORMOT guards + HORSE_DAEMON umbrella docs + EN/PT-BR doc sync (v3.1.99)` | Four `{$MESSAGE FATAL}` guards for `HORSE_PROVIDER_MORMOT × HORSE_HOST_*` (mirrors existing CROSSSOCKET guards); HORSE_DAEMON umbrella documentation; OpenSSL per-OS deployment section |
| 4 | [`6884f57`](https://github.com/freitasjca/horse/commit/6884f57) `chore(release): bump boss.json version to 3.1.99` | One-line `boss.json` version update |

## Backwards-compatibility guarantee (the G1–G8 contract)

A formal contract is embedded at the top of `src/Horse.pas` — eight guarantees the maintainer of this PR (and any future change to that file) must preserve:

- **G1.** Every existing legacy `HORSE_*` define still works and resolves to the same Application-type / Provider as before. (`HORSE_CROSSSOCKET`, `HORSE_VCL`, `HORSE_DAEMON`, `HORSE_LCL`, `HORSE_APACHE`, `HORSE_ISAPI`, `HORSE_CGI`, `HORSE_FCGI` all carried as aliases.)
- **G2.** Indy + Console (the no-define default) on Delphi is unchanged.
- **G3.** `fphttpserver` + HTTPApplication (the no-define default) on FPC is unchanged.
- **G4.** `HORSE_NOPROVIDER` still selects the abstract base.
- **G5.** No existing combination of legacy defines is **newly rejected** by the `{$MESSAGE FATAL}` block. The narrowing in PATCH-HORSE-2 only *expands* what's accepted.
- **G6.** The `THorseProvider` type alias resolves to the same concrete class for every legacy-define input as before.
- **G7.** Default `Console` / `VCL` / `Daemon` providers on Delphi remain Indy-backed when no Provider define is set.
- **G8.** Default `Daemon` / `HTTPApplication` / `LCL` providers on FPC remain `fphttpserver`-backed when no Provider define is set.

If any of these fail under any combination of defines, the change is a regression and shouldn't merge. I've validated all eight across the fork's 18-month deployment history.

## Architecture in three paragraphs

**The provider abstraction.** Originally Horse hard-coded Indy as the only Delphi transport and `fphttpserver` as the only FPC transport. This PR introduces `IHorseRawRequest` / `IHorseRawResponse` — lightweight interfaces (~15 methods total) that a provider implements by wrapping its own native request/response types. The `TInterfacedWebRequest` / `TInterfacedWebResponse` adapter classes give back backwards-compatible `TWebRequest` / `TWebResponse` so existing middleware (`Horse.CORS`, `Jhonson`, JWT, etc.) sees the API it expects. Indy and `fphttpserver` continue to work via their existing code paths — the interfaces only fire when `FWebRequest` / `FWebResponse` are `nil`.

**The three-axis define normalization.** Existing `HORSE_*` defines conflated three orthogonal choices: what HTTP transport (`Indy` / `fphttpserver` / new providers), how the binary is packaged (`Console` / `VCL` / `Daemon` / etc.), and whether the binary self-hosts or is host-managed (`Apache` / `ISAPI` / `CGI` / `FCGI`). PATCH-HORSE-2 splits these into three namespaces (`HORSE_PROVIDER_*`, `HORSE_APPTYPE_*`, `HORSE_HOST_*`) and adds a two-stage selection chain. Legacy defines remain accepted via a translation block at the top of `Horse.pas`. The `{$MESSAGE FATAL}` block is *narrowed* to combinations that are architecturally impossible (e.g. any `HORSE_PROVIDER_*` + any `HORSE_HOST_*`) — combinations that were previously rejected only because the flat chain couldn't express them (e.g. `HORSE_CROSSSOCKET + HORSE_VCL`) are now valid.

**Documentation.** The fork has built up a complete `doc/` tree over the last year — getting-started, routing, request-response, middleware, providers, deployment cheatsheet, compiler-support, middleware ecosystem, writing-middleware guide. Every page exists as EN + PT-BR mirrors. The OpenSSL deployment section, the HORSE_DAEMON umbrella note (Windows Service vs Linux systemd as two binary shapes of the same define), and the kernel-API annotations on the compiler-support matrix are all there.

## Evidence the design works in production

| Repo | Latest release | Depends on |
|---|---|---|
| [`freitasjca/horse-provider-crosssocket`](https://github.com/freitasjca/horse-provider-crosssocket) | [v1.0.8](https://github.com/freitasjca/horse-provider-crosssocket/releases/tag/v1.0.8) | `freitasjca/horse >= 3.1.99` |
| [`freitasjca/horse-provider-mormot`](https://github.com/freitasjca/horse-provider-mormot) | [v1.0.1](https://github.com/freitasjca/horse-provider-mormot/releases/tag/v1.0.1) | `freitasjca/horse >= 3.1.99` |
| [`freitasjca/Delphi-Cross-Socket`](https://github.com/freitasjca/Delphi-Cross-Socket) | [v1.0.3](https://github.com/freitasjca/Delphi-Cross-Socket/releases/tag/v1.0.3) | Provides the mTLS-bearing fork release |

Both provider packages have 11/11 integration tests passing against the fork's `v3.1.99`.

## Test plan

- [x] All existing Horse tests pass on the fork's CI (Delphi 11 Alexandria, Delphi 12 Athens)
- [x] CrossSocket provider — 11/11 integration tests passing (POST upload, multipart, cookies, RawWebRequest adapter, RemoteAddr, etc.)
- [x] mORMot2 provider — 11/11 integration tests passing (same test surface)
- [x] All existing `samples/` projects compile unchanged
- [x] Linux daemon build (Delphi cross-compile to Linux64) works for both CrossSocket and mORMot provider paths
- [x] FPC 3.2.0 builds work via the `Horse.Provider.FPC.*` units

## Companion repos this unblocks

Once merged, these can switch their `boss.json` from `freitasjca/horse` to `HashLoad/horse`:

- `freitasjca/horse-provider-crosssocket` — drops the fork dependency
- `freitasjca/horse-provider-mormot` — drops the fork dependency

I've staged the corresponding consumer-side `boss.json` change but won't push it until this lands.
