### PR TITLE
Feature/httpsys provider

### DIFF
--- a/samples/delphi/httpsys/HttpSys.dpr
+++ b/samples/delphi/httpsys/HttpSys.dpr
@@ -40,10 +40,9 @@ begin
         LJSON.AddPair('provedor', 'HTTP.sys');
         LJSON.AddPair('mensagem', 'Exemplo de integração funcionando perfeitamente!');
         
-        Res.Send<TJSONObject>(LJSON);
-      except
+        Res.Send(LJSON.ToJSON);
+      finally
         LJSON.Free;
-        raise;
       end;
     end);
 

--- a/samples/delphi/httpsys/HttpSys.dpr
+++ b/samples/delphi/httpsys/HttpSys.dpr
@@ -1,0 +1,65 @@
+program HttpSys;
+
+{$APPTYPE CONSOLE}
+
+// Habilita o provider HTTP.sys nativo do Windows
+{$DEFINE HORSE_PROVIDER_HTTPSYS}
+
+uses
+  Horse,
+  System.SysUtils,
+  System.JSON;
+
+begin
+  ReportMemoryLeaksOnShutdown := True;
+
+  // Rota simples de ping
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  // Rota para demonstrar leitura de parâmetros de rota, query string e envio de JSON
+  THorse.Get('/users/:id',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    var
+      LJSON: TJSONObject;
+      LUserId: string;
+      LUserName: string;
+    begin
+      LUserId := Req.Params.Items['id'];
+      LUserName := Req.Query.Items['nome'];
+      if LUserName.IsEmpty then
+        LUserName := 'Visitante';
+
+      LJSON := TJSONObject.Create;
+      try
+        LJSON.AddPair('id', LUserId);
+        LJSON.AddPair('nome', LUserName);
+        LJSON.AddPair('provedor', 'HTTP.sys');
+        LJSON.AddPair('mensagem', 'Exemplo de integração funcionando perfeitamente!');
+        
+        Res.Send<TJSONObject>(LJSON);
+      except
+        LJSON.Free;
+        raise;
+      end;
+    end);
+
+  // Escuta em localhost:9095 (evita necessidade de executar como Administrador no Windows HTTP.sys)
+  THorse.Listen(9095, 'localhost',
+    procedure
+    begin
+      Writeln('--------------------------------------------------');
+      Writeln(' Servidor Horse HTTP.sys Iniciado Localmente');
+      Writeln(Format(' Escutando em: http://%s:%d/', [THorse.Host, THorse.Port]));
+      Writeln('--------------------------------------------------');
+      Writeln(' Rotas disponiveis para teste:');
+      Writeln('  - GET http://localhost:9095/ping');
+      Writeln('  - GET http://localhost:9095/users/123?nome=Regys');
+      Writeln('--------------------------------------------------');
+      Writeln(' Pressione [Enter] para encerrar.');
+      Readln;
+    end);
+end.

--- a/samples/delphi/httpsys/HttpSys.dproj
+++ b/samples/delphi/httpsys/HttpSys.dproj
@@ -1,0 +1,1099 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{2AF29AEE-B106-4674-AB7E-25CE8D53056B}</ProjectGuid>
+        <ProjectVersion>20.3</ProjectVersion>
+        <FrameworkType>None</FrameworkType>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>HttpSys</AppType>
+        <MainSource>HttpSys.dpr</MainSource>
+        <ProjectName Condition="'$(ProjectName)'==''">HttpSys</ProjectName>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
+        <Base_Win64>true</Base_Win64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_DcuOutput>.\$(Platform)\$(Config)</DCC_DcuOutput>
+        <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
+        <DCC_E>false</DCC_E>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <SanitizedProjectName>HttpSys</SanitizedProjectName>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_UsePackage>DBXSqliteDriver;RESTComponents;fmxase;DBXDb2Driver;DBXInterBaseDriver;vclactnband;vclFireDAC;bindcompvclsmp;emsclientfiredac;tethering;svnui;DataSnapFireDAC;FireDACADSDriver;DBXMSSQLDriver;DatasnapConnectorsFreePascal;FireDACMSSQLDriver;vcltouch;vcldb;bindcompfmx;svn;DBXOracleDriver;inetdb;FmxTeeUI;emsedge;fmx;FireDACIBDriver;fmxdae;vcledge;FireDACDBXDriver;dbexpress;IndyCore;boss_ide;vclx;dsnap;emsclient;DataSnapCommon;FireDACCommon;RESTBackendComponents;DataSnapConnectors;VCLRESTComponents;soapserver;vclie;bindengine;DBXMySQLDriver;CloudService;FireDACOracleDriver;FireDACMySQLDriver;DBXFirebirdDriver;FireDACCommonODBC;FireDACCommonDriver;DataSnapClient;inet;IndyIPCommon;bindcompdbx;vcl;IndyIPServer;DBXSybaseASEDriver;IndySystem;FireDACDb2Driver;dsnapcon;FireDACMSAccDriver;fmxFireDAC;FireDACInfxDriver;vclimg;TeeDB;FireDAC;emshosting;FireDACSqliteDriver;FireDACPgDriver;FireDACASADriver;DBXOdbcDriver;FireDACTDataDriver;FMXTee;soaprtl;DbxCommonDriver;Tee;DataSnapServer;xmlrtl;soapmidas;DataSnapNativeClient;fmxobj;vclwinx;FireDACDSDriver;rtl;emsserverresource;DbxClientDriver;DBXSybaseASADriver;CustomIPTransport;vcldsnap;DOSCommandDR;bindcomp;appanalytics;DBXInformixDriver;IndyIPClient;bindcompvcl;TeeUI;dbxcds;VclSmp;adortl;FireDACODBCDriver;DataSnapIndy10ServerTransport;dsnapxml;DataSnapProviderClient;dbrtl;IndyProtocols;inetdbxpress;FireDACMongoDBDriver;DataSnapServerMidas;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <DCC_HttpSysTarget>true</DCC_HttpSysTarget>
+        <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win64)'!=''">
+        <DCC_UsePackage>DBXSqliteDriver;RESTComponents;fmxase;DBXDb2Driver;DBXInterBaseDriver;vclactnband;vclFireDAC;bindcompvclsmp;emsclientfiredac;tethering;DataSnapFireDAC;FireDACADSDriver;DBXMSSQLDriver;DatasnapConnectorsFreePascal;FireDACMSSQLDriver;vcltouch;vcldb;bindcompfmx;DBXOracleDriver;inetdb;FmxTeeUI;emsedge;fmx;FireDACIBDriver;fmxdae;vcledge;FireDACDBXDriver;dbexpress;IndyCore;vclx;dsnap;emsclient;DataSnapCommon;FireDACCommon;RESTBackendComponents;DataSnapConnectors;VCLRESTComponents;soapserver;vclie;bindengine;DBXMySQLDriver;CloudService;FireDACOracleDriver;FireDACMySQLDriver;DBXFirebirdDriver;FireDACCommonODBC;FireDACCommonDriver;DataSnapClient;inet;IndyIPCommon;bindcompdbx;vcl;IndyIPServer;DBXSybaseASEDriver;IndySystem;FireDACDb2Driver;dsnapcon;FireDACMSAccDriver;fmxFireDAC;FireDACInfxDriver;vclimg;TeeDB;FireDAC;emshosting;FireDACSqliteDriver;FireDACPgDriver;FireDACASADriver;DBXOdbcDriver;FireDACTDataDriver;FMXTee;soaprtl;DbxCommonDriver;Tee;DataSnapServer;xmlrtl;soapmidas;DataSnapNativeClient;fmxobj;vclwinx;FireDACDSDriver;rtl;emsserverresource;DbxClientDriver;DBXSybaseASADriver;CustomIPTransport;vcldsnap;DOSCommandDR;bindcomp;appanalytics;DBXInformixDriver;IndyIPClient;bindcompvcl;TeeUI;dbxcds;VclSmp;adortl;FireDACODBCDriver;DataSnapIndy10ServerTransport;dsnapxml;DataSnapProviderClient;dbrtl;IndyProtocols;inetdbxpress;FireDACMongoDBDriver;DataSnapServerMidas;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_HttpSysTarget>true</DCC_HttpSysTarget>
+        <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_150.png</UWP_DelphiLogo150>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_DebugDCUs>true</DCC_DebugDCUs>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+        <DCC_RemoteDebug>true</DCC_RemoteDebug>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <DCC_UnitSearchPath>..\..\..\src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>(None)</Manifest_File>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType>Application</Borland.ProjectType>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">HttpSys.dpr</Source>
+                </Source>
+                <Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclDataSnapNativeServer260.bpl">Embarcadero DBExpress DataSnap Native Server Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k260.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp260.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                </Excluded_Packages>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+            <Deployment Version="5">
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win32\Debug\HttpSys.exe" Configuration="Debug" Class="ProjectOutput"/>
+                <DeployClass Name="AdditionalDebugSymbols">
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidFileProvider">
+                    <Platform Name="Android">
+                        <RemoteDir>res\xml</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\xml</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeArmeabiv7aFile">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidLibnativeMipsFile">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\mips</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidServiceOutput">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidServiceOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDef">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashImageDefV21">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStyles">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV21">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV31">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV35">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v35</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v35</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v26</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v26</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconBackground">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconForeground">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconMonochrome">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_AdaptiveIconV33">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v33</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v33</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_Colors">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_ColorsDark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-night-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-night-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_DefaultAppIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon144">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon192">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-ldpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_LauncherIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon24">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-mdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon36">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-hdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon48">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon72">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_NotificationIcon96">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xxxhdpi</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage426">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-small</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage470">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-normal</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage640">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-large</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_SplashImage960">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-xlarge</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_Strings">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedNotificationIcon">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v24</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v24</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplash">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashDark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-night-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-night-anydpi-v21</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashV31">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="Android_VectorizedSplashV31Dark">
+                    <Platform Name="Android">
+                        <RemoteDir>res\drawable-night-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\drawable-night-anydpi-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DebugSymbols">
+                    <Platform Name="iOSSimulator">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyFramework">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="DependencyModule">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.dll;.bpl</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="DependencyPackage">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                        <Extensions>.bpl</Extensions>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="File">
+                    <Platform Name="Android">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice32">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectAndroidManifest">
+                    <Platform Name="Android">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXDebug">
+                    <Platform Name="OSX64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXEntitlements">
+                    <Platform Name="OSX32">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXInfoPList">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOSXResource">
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Required="true" Name="ProjectOutput">
+                    <Platform Name="Android">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\arm64-v8a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Linux64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX32">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win32">
+                        <Operation>0</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectOutput_Android32">
+                    <Platform Name="Android64">
+                        <RemoteDir>library\lib\armeabi-v7a</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectUWPManifest">
+                    <Platform Name="Win32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64x">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSDeviceDebug">
+                    <Platform Name="iOSDevice32">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSEntitlements">
+                    <Platform Name="iOSDevice32">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSInfoPList">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSLaunchScreen">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen</RemoteDir>
+                        <Operation>64</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen</RemoteDir>
+                        <Operation>64</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="ProjectiOSResource">
+                    <Platform Name="iOSDevice32">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSDevice64">
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="UWP_DelphiLogo150">
+                    <Platform Name="Win32">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="UWP_DelphiLogo44">
+                    <Platform Name="Win32">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Win64">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iOS_AppStore1024">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_AppIcon152">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_AppIcon167">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Launch2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_LaunchDark2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Notification40">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_Setting58">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPad_SpotLight80">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_AppIcon120">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_AppIcon180">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Launch3x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_LaunchDark2x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_LaunchDark3x">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\LaunchScreenImage.imageset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Notification40">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Notification60">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Setting58">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Setting87">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Spotlight120">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="iPhone_Spotlight80">
+                    <Platform Name="iOSDevice64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="iOSSimARM64">
+                        <RemoteDir>..\$(PROJECTNAME).launchscreen\Assets\AppIcon.appiconset</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimARM64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="Win64x" Name="$(PROJECTNAME)"/>
+            </Deployment>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
+</Project>

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -37,6 +37,9 @@ const
   // Request flags
   HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS = $00000001;
 
+{$MINENUMSIZE 4}
+{$ALIGN 8}
+
 type
   ULONG = Cardinal;
   USHORT = Word;
@@ -264,6 +267,9 @@ function HttpReceiveRequestEntityBody(ReqQueueHandle: THandle; RequestId: HTTP_R
 function HttpSendHttpResponse(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; pHttpResponse: PHTTP_RESPONSE; pReserved1: Pointer; var BytesSent: ULONG; pReserved2: Pointer; Reserved3: ULONG; pOverlapped: POverlapped; pLogData: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
 function HttpSendResponseEntityBody(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; EntityChunkCount: USHORT; pEntityChunks: Pointer; var BytesSent: ULONG; pReserved1: Pointer; pReserved2: Pointer; pOverlapped: POverlapped; pLogData: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
 function HttpSetUrlGroupProperty(UrlGroupId: HTTP_URL_GROUP_ID; PropertyId: HTTP_SERVER_PROPERTY; pPropertyInformation: Pointer; PropertyInformationLength: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+
+{$MINENUMSIZE 1}
+{$ALIGN ON}
 
 type
   THttpSysListenerThread = class;
@@ -976,7 +982,8 @@ begin
           LWebResponse.Free;
         end;
       except
-        // Catch all exceptions inside thread execution
+        on E: Exception do
+          Writeln('Erro no Dispatch: ' + E.ClassName + ': ' + E.Message);
       end;
     end
   );

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -785,7 +785,11 @@ begin
 
   // Set Custom Headers
   LHeadersList := ARes.CustomHeaders;
-  LHeaderCount := LHeadersList.Count;
+  if LHeadersList <> nil then
+    LHeaderCount := LHeadersList.Count
+  else
+    LHeaderCount := 0;
+
   if LHeaderCount > 0 then
   begin
     SetLength(LHeaders, LHeaderCount);

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -38,7 +38,6 @@ const
   HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS = $00000001;
 
 {$MINENUMSIZE 4}
-{$ALIGN 8}
 
 type
   ULONG = Cardinal;
@@ -269,7 +268,6 @@ function HttpSendResponseEntityBody(ReqQueueHandle: THandle; RequestId: HTTP_REQ
 function HttpSetUrlGroupProperty(UrlGroupId: HTTP_URL_GROUP_ID; PropertyId: HTTP_SERVER_PROPERTY; pPropertyInformation: Pointer; PropertyInformationLength: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
 
 {$MINENUMSIZE 1}
-{$ALIGN ON}
 
 type
   THttpSysListenerThread = class;

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -1,0 +1,1283 @@
+unit Horse.Provider.HttpSys;
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+{$IFDEF MSWINDOWS}
+uses
+  System.SysUtils,
+  System.Classes,
+  System.SyncObjs,
+  System.Threading,
+  System.NetEncoding,
+  System.Generics.Collections,
+  System.Generics.Defaults,
+  Winapi.Windows,
+  Horse.Provider.Abstract,
+  Horse.Provider.Config,
+  Horse.Request,
+  Horse.Response,
+  Horse.Provider.RawInterfaces,
+  Horse.Provider.RawAdapters,
+  Horse.Proc,
+  Horse.Commons;
+
+const
+  HTTPAPI_DLL = 'httpapi.dll';
+
+  HTTP_INITIALIZE_SERVER = $00000001;
+
+  // HttpSendHttpResponse flags
+  HTTP_SEND_RESPONSE_FLAG_DISCONNECT  = $00000001;
+  HTTP_SEND_RESPONSE_FLAG_MORE_DATA   = $00000002;
+
+  // Request flags
+  HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS = $00000001;
+
+type
+  ULONG = Cardinal;
+  USHORT = Word;
+  UCHAR = Byte;
+  PUCHAR = ^Byte;
+  HTTP_OPAQUE_ID = UInt64;
+  HTTP_REQUEST_ID = HTTP_OPAQUE_ID;
+  HTTP_CONNECTION_ID = HTTP_OPAQUE_ID;
+  HTTP_RAW_CONNECTION_ID = HTTP_OPAQUE_ID;
+  HTTP_URL_GROUP_ID = HTTP_OPAQUE_ID;
+  HTTP_SERVER_SESSION_ID = HTTP_OPAQUE_ID;
+  HTTP_URL_CONTEXT = HTTP_OPAQUE_ID;
+
+  HTTPAPI_VERSION = record
+    HttpApiMajorVersion: USHORT;
+    HttpApiMinorVersion: USHORT;
+  end;
+
+  HTTP_VERSION = record
+    MajorVersion: USHORT;
+    MinorVersion: USHORT;
+  end;
+
+  THttpVerb = (
+    HttpVerbUnparsed,
+    HttpVerbUnknown,
+    HttpVerbInvalid,
+    HttpVerbOPTIONS,
+    HttpVerbGET,
+    HttpVerbHEAD,
+    HttpVerbPOST,
+    HttpVerbPUT,
+    HttpVerbDELETE,
+    HttpVerbTRACE,
+    HttpVerbCONNECT,
+    HttpVerbTRACK,
+    HttpVerbMOVE,
+    HttpVerbCOPY,
+    HttpVerbPROPFIND,
+    HttpVerbPROPPATCH,
+    HttpVerbMKCOL,
+    HttpVerbLOCK,
+    HttpVerbUNLOCK,
+    HttpVerbSEARCH,
+    HttpVerbMaximum
+  );
+
+  HTTP_COOKED_URL = record
+    FullUrlLength: USHORT;
+    HostLength: USHORT;
+    AbsPathLength: USHORT;
+    QueryStringLength: USHORT;
+    pFullUrl: PWideChar;
+    pHost: PWideChar;
+    pAbsPath: PWideChar;
+    pQueryString: PWideChar;
+  end;
+
+  HTTP_TRANSPORT_ADDRESS = record
+    pRemoteAddress: Pointer;
+    pLocalAddress: Pointer;
+  end;
+
+  HTTP_UNKNOWN_HEADER = record
+    NameLength: USHORT;
+    RawValueLength: USHORT;
+    pName: PAnsiChar;
+    pRawValue: PAnsiChar;
+  end;
+  PHTTP_UNKNOWN_HEADER = ^HTTP_UNKNOWN_HEADER;
+  THTTP_UNKNOWN_HEADER_ARRAY = array[0..65535] of HTTP_UNKNOWN_HEADER;
+  PHTTP_UNKNOWN_HEADER_ARRAY = ^THTTP_UNKNOWN_HEADER_ARRAY;
+
+  HTTP_KNOWN_HEADER = record
+    RawValueLength: USHORT;
+    pRawValue: PAnsiChar;
+  end;
+
+  HTTP_REQUEST_HEADERS = record
+    UnknownHeaderCount: USHORT;
+    pUnknownHeaders: PHTTP_UNKNOWN_HEADER;
+    TrailerCount: USHORT;
+    pTrailers: Pointer;
+    KnownHeaders: array[0..40] of HTTP_KNOWN_HEADER;
+  end;
+
+  HTTP_RESPONSE_HEADERS = record
+    UnknownHeaderCount: USHORT;
+    pUnknownHeaders: PHTTP_UNKNOWN_HEADER;
+    TrailerCount: USHORT;
+    pTrailers: Pointer;
+    KnownHeaders: array[0..29] of HTTP_KNOWN_HEADER;
+  end;
+
+  HTTP_SSL_INFO = record
+    ServerCertKeySize: USHORT;
+    ConnectionKeySize: USHORT;
+    ServerCertIssuerSize: ULONG;
+    ServerCertSubjectSize: ULONG;
+    pServerCertIssuer: PAnsiChar;
+    pServerCertSubject: PAnsiChar;
+    pClientCertInfo: Pointer;
+    SslClientCertNegotiated: ULONG;
+  end;
+  PHTTP_SSL_INFO = ^HTTP_SSL_INFO;
+
+  HTTP_REQUEST = record
+    Flags: ULONG;
+    ConnectionId: HTTP_CONNECTION_ID;
+    RequestId: HTTP_REQUEST_ID;
+    UrlContext: HTTP_URL_CONTEXT;
+    Version: HTTP_VERSION;
+    Verb: THttpVerb;
+    UnknownVerbLength: USHORT;
+    RawUrlLength: USHORT;
+    pUnknownVerb: PAnsiChar;
+    pRawUrl: PAnsiChar;
+    CookedUrl: HTTP_COOKED_URL;
+    Address: HTTP_TRANSPORT_ADDRESS;
+    Headers: HTTP_REQUEST_HEADERS;
+    BytesReceived: UInt64;
+    EntityChunkCount: USHORT;
+    pEntityChunks: Pointer;
+    RawConnectionId: HTTP_RAW_CONNECTION_ID;
+    pSslInfo: PHTTP_SSL_INFO;
+    RequestInfoCount: USHORT;
+    pRequestInfo: Pointer;
+  end;
+  PHTTP_REQUEST = ^HTTP_REQUEST;
+
+  THttpChunkType = (
+    hctFromMemory,
+    hctFromFileHandle,
+    hctFromFragmentCache
+  );
+
+  HTTP_DATA_CHUNK_INMEMORY = record
+    DataChunkType: THttpChunkType;
+    Reserved1: ULONG;
+    pBuffer: Pointer;
+    BufferLength: ULONG;
+    {$IFDEF CPUX64}
+    Reserved2: array[0..2] of ULONG;
+    {$ELSE}
+    Reserved2: array[0..3] of ULONG;
+    {$ENDIF}
+  end;
+  PHTTP_DATA_CHUNK_INMEMORY = ^HTTP_DATA_CHUNK_INMEMORY;
+
+  HTTP_RESPONSE = record
+    Flags: ULONG;
+    Version: HTTP_VERSION;
+    StatusCode: USHORT;
+    ReasonLength: USHORT;
+    pReason: PAnsiChar;
+    Headers: HTTP_RESPONSE_HEADERS;
+    EntityChunkCount: USHORT;
+    pEntityChunks: Pointer;
+    ResponseInfoCount: USHORT;
+    pResponseInfo: Pointer;
+  end;
+  PHTTP_RESPONSE = ^HTTP_RESPONSE;
+
+  HTTP_SERVER_PROPERTY = (
+    HttpServerAuthenticationProperty,
+    HttpServerLoggingProperty,
+    HttpServerQosProperty,
+    HttpServerTimeoutsProperty,
+    HttpServerQueueLengthProperty,
+    HttpServerStateProperty,
+    HttpServer503VerbosityProperty,
+    HttpServerBindingProperty
+  );
+
+  HTTP_BINDING_INFO = record
+    Flags: ULONG;
+    RequestQueueHandle: THandle;
+  end;
+  PHTTP_BINDING_INFO = ^HTTP_BINDING_INFO;
+
+  TSockAddrIn = record
+    sin_family: Word;
+    sin_port: Word;
+    sin_addr: array[0..3] of Byte;
+    sin_zero: array[0..7] of Byte;
+  end;
+  PSockAddrIn = ^TSockAddrIn;
+
+const
+  HTTPAPI_VERSION_2: HTTPAPI_VERSION = (HttpApiMajorVersion: 2; HttpApiMinorVersion: 0);
+
+  HTTP_KNOWN_REQUEST_HEADERS: array[0..40] of string = (
+    'Cache-Control', 'Connection', 'Date', 'Keep-Alive', 'Pragma', 'Trailer',
+    'Transfer-Encoding', 'Upgrade', 'Via', 'Warning', 'Allow', 'Content-Length',
+    'Content-Type', 'Content-Encoding', 'Content-Language', 'Content-Location',
+    'Content-MD5', 'Content-Range', 'Expires', 'Last-Modified', 'Accept',
+    'Accept-Charset', 'Accept-Encoding', 'Accept-Language', 'Authorization',
+    'Cookie', 'Expect', 'From', 'Host', 'If-Match', 'If-Modified-Since',
+    'If-None-Match', 'If-Range', 'If-Unmodified-Since', 'Max-Forwards',
+    'Proxy-Authorization', 'Referer', 'Range', 'TE', 'Translate', 'User-Agent'
+  );
+
+  HTTP_KNOWN_RESPONSE_HEADERS: array[0..29] of string = (
+    'Cache-Control', 'Connection', 'Date', 'Keep-Alive', 'Pragma', 'Trailer',
+    'Transfer-Encoding', 'Upgrade', 'Via', 'Warning', 'Allow', 'Content-Length',
+    'Content-Type', 'Content-Encoding', 'Content-Language', 'Content-Location',
+    'Content-MD5', 'Content-Range', 'Expires', 'Last-Modified', 'Accept-Ranges',
+    'Age', 'ETag', 'Location', 'Proxy-Authenticate', 'Retry-After', 'Server',
+    'Set-Cookie', 'Vary', 'Www-Authenticate'
+  );
+
+// Windows Http.sys native APIs
+function HttpInitialize(Version: HTTPAPI_VERSION; Flags: ULONG; pReserved: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpTerminate(Flags: ULONG; pReserved: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCreateServerSession(Version: HTTPAPI_VERSION; var ServerSessionId: HTTP_SERVER_SESSION_ID; Reserved: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCloseServerSession(ServerSessionId: HTTP_SERVER_SESSION_ID): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCreateUrlGroup(ServerSessionId: HTTP_SERVER_SESSION_ID; var UrlGroupId: HTTP_URL_GROUP_ID; Reserved: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCloseUrlGroup(UrlGroupId: HTTP_URL_GROUP_ID): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpAddUrlToUrlGroup(UrlGroupId: HTTP_URL_GROUP_ID; pFullyQualifiedUrl: PWideChar; UrlContext: HTTP_URL_CONTEXT; Reserved: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpRemoveUrlFromUrlGroup(UrlGroupId: HTTP_URL_GROUP_ID; pFullyQualifiedUrl: PWideChar; Flags: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCreateRequestQueue(Version: HTTPAPI_VERSION; pName: PWideChar; pSecurityAttributes: Pointer; Flags: ULONG; var ReqQueueHandle: THandle): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpCloseRequestQueue(ReqQueueHandle: THandle): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpReceiveHttpRequest(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; pRequestBuffer: PHTTP_REQUEST; RequestBufferLength: ULONG; var BytesReturned: ULONG; pOverlapped: POverlapped): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpReceiveRequestEntityBody(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; pBuffer: Pointer; BufferLength: ULONG; var BytesReceived: ULONG; pOverlapped: POverlapped): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpSendHttpResponse(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; pHttpResponse: PHTTP_RESPONSE; pReserved1: Pointer; var BytesSent: ULONG; pReserved2: Pointer; Reserved3: ULONG; pOverlapped: POverlapped; pLogData: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpSendResponseEntityBody(ReqQueueHandle: THandle; RequestId: HTTP_REQUEST_ID; Flags: ULONG; EntityChunkCount: USHORT; pEntityChunks: Pointer; var BytesSent: ULONG; pReserved1: Pointer; pReserved2: Pointer; pOverlapped: POverlapped; pLogData: Pointer): ULONG; stdcall; external HTTPAPI_DLL;
+function HttpSetUrlGroupProperty(UrlGroupId: HTTP_URL_GROUP_ID; PropertyId: HTTP_SERVER_PROPERTY; pPropertyInformation: Pointer; PropertyInformationLength: ULONG): ULONG; stdcall; external HTTPAPI_DLL;
+
+type
+  THttpSysListenerThread = class;
+
+  // IHorseRawRequest implementation
+  THttpSysRawRequest = class(TInterfacedObject, IHorseRawRequest)
+  private
+    FRequest: PHTTP_REQUEST;
+    FBuffer: TBytes;
+    FBodyStream: TMemoryStream;
+    procedure EnsureBodyStream;
+  public
+    constructor Create(ARequest: PHTTP_REQUEST; const ABuffer: TBytes);
+    destructor Destroy; override;
+
+    function GetMethod: string;
+    function GetProtocolVersion: string;
+    function GetURL: string;
+    function GetPathInfo: string;
+    function GetQueryString: string;
+    function GetHost: string;
+    function GetRemoteAddr: string;
+    function GetServerPort: Integer;
+    function GetContentType: string;
+    function GetContent: string;
+    function GetContentLength: Int64;
+    function GetFieldByName(const AName: string): string;
+
+    procedure PopulateQueryFields(ADest: TStrings);
+    procedure PopulateContentFields(ADest: TStrings);
+    procedure PopulateCookieFields(ADest: TStrings);
+
+    function ReadBody(var Buffer; Count: Integer): Integer;
+  end;
+
+  // IHorseRawResponse implementation
+  THttpSysRawResponse = class(TInterfacedObject, IHorseRawResponse)
+  private
+    FReqQueue: THandle;
+    FRequestId: HTTP_REQUEST_ID;
+  public
+    constructor Create(AReqQueue: THandle; ARequestId: HTTP_REQUEST_ID);
+    procedure SetCustomHeader(const AName, AValue: string);
+    procedure SendResponse(const ARes: THorseResponse);
+  end;
+
+  THttpSysWebResponse = class(TInterfacedWebResponse)
+  private
+    FStatusCode: Integer;
+    FContent: string;
+    FContentType: string;
+    FContentEncoding: string;
+  protected
+    function  GetStringVariable(Index: Integer): string; override;
+    procedure SetStringVariable(Index: Integer; const Value: string); override;
+{$IF CompilerVersion >= 32.0}
+    function  GetIntegerVariable(Index: Integer): Int64; override;
+    procedure SetIntegerVariable(Index: Integer; Value: Int64); override;
+{$ELSE}
+    function  GetIntegerVariable(Index: Integer): Integer; override;
+    procedure SetIntegerVariable(Index: Integer; Value: Integer); override;
+{$IFEND}
+    function  GetContent: string; override;
+    procedure SetContent(const Value: string); override;
+    function  GetStatusCode: Integer; override;
+    procedure SetStatusCode(Value: Integer); override;
+  public
+    constructor Create(const ARawRes: IHorseRawResponse); reintroduce;
+  end;
+
+  // Listener Thread
+  THttpSysListenerThread = class(TThread)
+  private
+    FReqQueue: THandle;
+    FRunning: Boolean;
+    procedure DispatchRequest(ABuffer: TBytes);
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(AReqQueue: THandle);
+    property Running: Boolean read FRunning write FRunning;
+  end;
+
+  // Concrete THorseProvider for HTTP.sys
+  THorseProviderHttpSys = class(THorseProviderAbstract)
+  private
+    class var FPort: Integer;
+    class var FHost: string;
+    class var FRunning: Boolean;
+    class var FServerSessionId: HTTP_SERVER_SESSION_ID;
+    class var FUrlGroupId: HTTP_URL_GROUP_ID;
+    class var FReqQueue: THandle;
+    class var FListenerThread: THttpSysListenerThread;
+    class var FKnownRequestHeadersMap: TDictionary<string, Integer>;
+    class var FKnownResponseHeadersMap: TDictionary<string, Integer>;
+
+    class procedure SetPort(const AValue: Integer); static;
+    class procedure SetHost(const AValue: string); static;
+    class function GetPort: Integer; static;
+    class function GetHost: string; static;
+    class function GetDefaultPort: Integer; static;
+    class function GetDefaultHost: string; static;
+
+    class procedure InternalListen;
+    class procedure InternalStopListen;
+  public
+    class property Host: string read GetHost write SetHost;
+    class property Port: Integer read GetPort write SetPort;
+    class procedure Listen; overload; override;
+    class procedure Listen(const APort: Integer; const AHost: string = 'localhost'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const AHost: string; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure ListenWithConfig(const APort: Integer; const AConfig: THorseCrossSocketConfig); override;
+    class procedure StopListen; override;
+    class function IsRunning: Boolean;
+
+    class property ServerSessionId: HTTP_SERVER_SESSION_ID read FServerSessionId;
+    class property UrlGroupId: HTTP_URL_GROUP_ID read FUrlGroupId;
+    class property ReqQueue: THandle read FReqQueue;
+    class property KnownRequestHeadersMap: TDictionary<string, Integer> read FKnownRequestHeadersMap;
+    class property KnownResponseHeadersMap: TDictionary<string, Integer> read FKnownResponseHeadersMap;
+
+    class constructor CreateClass;
+    class destructor DestroyClass;
+  end;
+
+  THorseProvider = class(THorseProviderHttpSys);
+
+{$ENDIF}
+
+implementation
+
+{$IFDEF MSWINDOWS}
+
+{ THttpSysRawRequest }
+
+constructor THttpSysRawRequest.Create(ARequest: PHTTP_REQUEST; const ABuffer: TBytes);
+begin
+  inherited Create;
+  FRequest := ARequest;
+  FBuffer := ABuffer;
+  FBodyStream := nil;
+end;
+
+destructor THttpSysRawRequest.Destroy;
+begin
+  if Assigned(FBodyStream) then
+    FBodyStream.Free;
+  inherited;
+end;
+
+procedure THttpSysRawRequest.EnsureBodyStream;
+var
+  PChunk: PHTTP_DATA_CHUNK_INMEMORY;
+  I: Integer;
+  BytesReceived: ULONG;
+  Ret: ULONG;
+  TempBuf: TBytes;
+begin
+  if FBodyStream <> nil then Exit;
+
+  FBodyStream := TMemoryStream.Create;
+  
+  // 1. Copy initial body chunk if any
+  if (FRequest.EntityChunkCount > 0) and (FRequest.pEntityChunks <> nil) then
+  begin
+    PChunk := PHTTP_DATA_CHUNK_INMEMORY(FRequest.pEntityChunks);
+    for I := 0 to FRequest.EntityChunkCount - 1 do
+    begin
+      if PChunk.DataChunkType = hctFromMemory then
+      begin
+        if (PChunk.pBuffer <> nil) and (PChunk.BufferLength > 0) then
+          FBodyStream.WriteBuffer(PChunk.pBuffer^, PChunk.BufferLength);
+      end;
+      Inc(PChunk);
+    end;
+  end;
+
+  // 2. Retrieve remaining request body entity chunks from HTTP.sys queue
+  if (FRequest.Flags and HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS) <> 0 then
+  begin
+    SetLength(TempBuf, 32768);
+    while True do
+    begin
+      BytesReceived := 0;
+      Ret := HttpReceiveRequestEntityBody(
+        THorseProviderHttpSys.ReqQueue,
+        FRequest.RequestId,
+        0,
+        @TempBuf[0],
+        Length(TempBuf),
+        BytesReceived,
+        nil
+      );
+      
+      if Ret = ERROR_SUCCESS then
+      begin
+        if BytesReceived > 0 then
+          FBodyStream.WriteBuffer(TempBuf[0], BytesReceived)
+        else
+          Break;
+      end
+      else if Ret = ERROR_HANDLE_EOF then
+      begin
+        if BytesReceived > 0 then
+          FBodyStream.WriteBuffer(TempBuf[0], BytesReceived);
+        Break;
+      end
+      else
+        Break;
+    end;
+  end;
+
+  FBodyStream.Position := 0;
+end;
+
+function THttpSysRawRequest.GetMethod: string;
+begin
+  case FRequest.Verb of
+    HttpVerbGET: Result := 'GET';
+    HttpVerbPOST: Result := 'POST';
+    HttpVerbPUT: Result := 'PUT';
+    HttpVerbDELETE: Result := 'DELETE';
+    HttpVerbOPTIONS: Result := 'OPTIONS';
+    HttpVerbHEAD: Result := 'HEAD';
+    HttpVerbTRACE: Result := 'TRACE';
+    HttpVerbCONNECT: Result := 'CONNECT';
+  else
+    if FRequest.pUnknownVerb <> nil then
+      SetString(Result, PAnsiChar(FRequest.pUnknownVerb), FRequest.UnknownVerbLength)
+    else
+      Result := 'GET';
+  end;
+end;
+
+function THttpSysRawRequest.GetProtocolVersion: string;
+begin
+  Result := Format('HTTP/%d.%d', [FRequest.Version.MajorVersion, FRequest.Version.MinorVersion]);
+end;
+
+function THttpSysRawRequest.GetURL: string;
+begin
+  if FRequest.pRawUrl <> nil then
+    SetString(Result, PAnsiChar(FRequest.pRawUrl), FRequest.RawUrlLength)
+  else
+    Result := '/';
+end;
+
+function THttpSysRawRequest.GetPathInfo: string;
+begin
+  if FRequest.CookedUrl.pAbsPath <> nil then
+    SetString(Result, FRequest.CookedUrl.pAbsPath, FRequest.CookedUrl.AbsPathLength div SizeOf(WideChar))
+  else
+    Result := '/';
+end;
+
+function THttpSysRawRequest.GetQueryString: string;
+begin
+  if FRequest.CookedUrl.pQueryString <> nil then
+    SetString(Result, FRequest.CookedUrl.pQueryString, FRequest.CookedUrl.QueryStringLength div SizeOf(WideChar))
+  else
+    Result := '';
+end;
+
+function THttpSysRawRequest.GetHost: string;
+begin
+  Result := GetFieldByName('Host');
+  if (Result = '') and (FRequest.CookedUrl.pHost <> nil) then
+    SetString(Result, FRequest.CookedUrl.pHost, FRequest.CookedUrl.HostLength div SizeOf(WideChar));
+end;
+
+function THttpSysRawRequest.GetRemoteAddr: string;
+var
+  LFamily: Word;
+  LIPv4: PSockAddrIn;
+begin
+  if FRequest.Address.pRemoteAddress = nil then
+    Exit('127.0.0.1');
+
+  LFamily := PWord(FRequest.Address.pRemoteAddress)^;
+  if LFamily = 2 then // AF_INET
+  begin
+    LIPv4 := PSockAddrIn(FRequest.Address.pRemoteAddress);
+    Result := Format('%d.%d.%d.%d', [LIPv4.sin_addr[0], LIPv4.sin_addr[1], LIPv4.sin_addr[2], LIPv4.sin_addr[3]]);
+  end
+  else
+    Result := '127.0.0.1'; // Fallback
+end;
+
+function THttpSysRawRequest.GetServerPort: Integer;
+var
+  LFamily: Word;
+  LIPv4: PSockAddrIn;
+begin
+  if FRequest.Address.pLocalAddress = nil then
+    Exit(80);
+
+  LFamily := PWord(FRequest.Address.pLocalAddress)^;
+  if LFamily = 2 then // AF_INET
+  begin
+    LIPv4 := PSockAddrIn(FRequest.Address.pLocalAddress);
+    Result := (LIPv4.sin_port shl 8) or (LIPv4.sin_port shr 8); // Swap endianness
+  end
+  else
+    Result := 80;
+end;
+
+function THttpSysRawRequest.GetContentType: string;
+begin
+  Result := GetFieldByName('Content-Type');
+end;
+
+function THttpSysRawRequest.GetContent: string;
+var
+  LBytes: TBytes;
+begin
+  EnsureBodyStream;
+  if FBodyStream.Size = 0 then
+    Exit('');
+
+  SetLength(LBytes, FBodyStream.Size);
+  FBodyStream.Position := 0;
+  FBodyStream.ReadBuffer(LBytes[0], FBodyStream.Size);
+  Result := TEncoding.UTF8.GetString(LBytes);
+end;
+
+function THttpSysRawRequest.GetContentLength: Int64;
+begin
+  Result := StrToInt64Def(GetFieldByName('Content-Length'), 0);
+end;
+
+function THttpSysRawRequest.GetFieldByName(const AName: string): string;
+var
+  LIndex: Integer;
+  I: Integer;
+  LUnknownName: string;
+begin
+  Result := '';
+  if THorseProviderHttpSys.KnownRequestHeadersMap.TryGetValue(AName, LIndex) then
+  begin
+    if FRequest.Headers.KnownHeaders[LIndex].RawValueLength > 0 then
+    begin
+      SetString(Result, PAnsiChar(FRequest.Headers.KnownHeaders[LIndex].pRawValue), FRequest.Headers.KnownHeaders[LIndex].RawValueLength);
+      Exit;
+    end;
+  end;
+
+  if (FRequest.Headers.UnknownHeaderCount > 0) and (FRequest.Headers.pUnknownHeaders <> nil) then
+  begin
+    for I := 0 to FRequest.Headers.UnknownHeaderCount - 1 do
+    begin
+      SetString(LUnknownName, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pName), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].NameLength);
+      if SameText(LUnknownName, AName) then
+      begin
+        SetString(Result, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pRawValue), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].RawValueLength);
+        Exit;
+      end;
+    end;
+  end;
+end;
+
+procedure THttpSysRawRequest.PopulateQueryFields(ADest: TStrings);
+var
+  LQuery: string;
+  LFields: TArray<string>;
+  LField: string;
+  LPos: Integer;
+  LName, LValue: string;
+begin
+  LQuery := GetQueryString;
+  if LQuery = '' then Exit;
+  if LQuery.StartsWith('?') then
+    LQuery := LQuery.Substring(1);
+
+  LFields := LQuery.Split(['&']);
+  for LField in LFields do
+  begin
+    LPos := LField.IndexOf('=');
+    if LPos >= 0 then
+    begin
+      LName := LField.Substring(0, LPos);
+      LValue := LField.Substring(LPos + 1);
+      ADest.Add(TNetEncoding.URL.Decode(LName) + '=' + TNetEncoding.URL.Decode(LValue));
+    end
+    else
+      ADest.Add(TNetEncoding.URL.Decode(LField) + '=');
+  end;
+end;
+
+procedure THttpSysRawRequest.PopulateContentFields(ADest: TStrings);
+var
+  LBody: string;
+  LFields: TArray<string>;
+  LField: string;
+  LPos: Integer;
+  LName, LValue: string;
+begin
+  if not SameText(GetContentType, 'application/x-www-form-urlencoded') then
+    Exit;
+
+  LBody := GetContent;
+  if LBody = '' then Exit;
+
+  LFields := LBody.Split(['&']);
+  for LField in LFields do
+  begin
+    LPos := LField.IndexOf('=');
+    if LPos >= 0 then
+    begin
+      LName := LField.Substring(0, LPos);
+      LValue := LField.Substring(LPos + 1);
+      ADest.Add(TNetEncoding.URL.Decode(LName) + '=' + TNetEncoding.URL.Decode(LValue));
+    end
+    else
+      ADest.Add(TNetEncoding.URL.Decode(LField) + '=');
+  end;
+end;
+
+procedure THttpSysRawRequest.PopulateCookieFields(ADest: TStrings);
+var
+  LCookies: string;
+  LParts: TArray<string>;
+  LPart: string;
+  LPartTrimmed: string;
+  LPos: Integer;
+  LName, LValue: string;
+begin
+  LCookies := GetFieldByName('Cookie');
+  if LCookies = '' then Exit;
+
+  LParts := LCookies.Split([';']);
+  for LPart in LParts do
+  begin
+    LPartTrimmed := LPart.Trim;
+    LPos := LPartTrimmed.IndexOf('=');
+    if LPos >= 0 then
+    begin
+      LName := LPartTrimmed.Substring(0, LPos);
+      LValue := LPartTrimmed.Substring(LPos + 1);
+      ADest.Add(LName + '=' + LValue);
+    end;
+  end;
+end;
+
+function THttpSysRawRequest.ReadBody(var Buffer; Count: Integer): Integer;
+begin
+  EnsureBodyStream;
+  Result := FBodyStream.Read(Buffer, Count);
+end;
+
+
+{ THttpSysRawResponse }
+
+constructor THttpSysRawResponse.Create(AReqQueue: THandle; ARequestId: HTTP_REQUEST_ID);
+begin
+  inherited Create;
+  FReqQueue := AReqQueue;
+  FRequestId := ARequestId;
+end;
+
+procedure THttpSysRawResponse.SetCustomHeader(const AName, AValue: string);
+begin
+  // SetCustomHeader is inherited from TWebResponse and handled on SendResponse.
+end;
+
+procedure THttpSysRawResponse.SendResponse(const ARes: THorseResponse);
+var
+  LResponse: HTTP_RESPONSE;
+  LChunk: HTTP_DATA_CHUNK_INMEMORY;
+  LBytesSent: ULONG;
+  LRet: ULONG;
+  LBodyBytes: TBytes;
+  LHeaders: TArray<HTTP_UNKNOWN_HEADER>;
+  LHeaderCount: Integer;
+  LContentType: AnsiString;
+  LStatusCode: Word;
+  LReason: AnsiString;
+  LHeadersList: TDictionary<string, string>;
+  LPair: TPair<string, string>;
+  I: Integer;
+  LContentLengthAnsi: AnsiString;
+  LHeaderStrings: TArray<AnsiString>;
+begin
+  FillChar(LResponse, SizeOf(LResponse), 0);
+  
+  LStatusCode := ARes.Status;
+  LResponse.StatusCode := LStatusCode;
+  
+  LReason := 'OK';
+  if LStatusCode = 201 then LReason := 'Created'
+  else if LStatusCode = 204 then LReason := 'No Content'
+  else if LStatusCode = 400 then LReason := 'Bad Request'
+  else if LStatusCode = 401 then LReason := 'Unauthorized'
+  else if LStatusCode = 403 then LReason := 'Forbidden'
+  else if LStatusCode = 404 then LReason := 'Not Found'
+  else if LStatusCode = 500 then LReason := 'Internal Server Error';
+  
+  LResponse.ReasonLength := Length(LReason);
+  LResponse.pReason := PAnsiChar(LReason);
+  LResponse.Version.MajorVersion := 1;
+  LResponse.Version.MinorVersion := 1;
+
+  // Set Content-Type
+  if (ARes.RawWebResponse <> nil) and (ARes.RawWebResponse.ContentType <> '') then
+    LContentType := AnsiString(ARes.RawWebResponse.ContentType)
+  else
+    LContentType := AnsiString(ARes.CSContentType);
+
+  if LContentType = '' then
+    LContentType := 'text/html; charset=utf-8';
+  
+  LResponse.Headers.KnownHeaders[12].pRawValue := PAnsiChar(LContentType);
+  LResponse.Headers.KnownHeaders[12].RawValueLength := Length(LContentType);
+
+  // Set Custom Headers
+  LHeadersList := ARes.CustomHeaders;
+  LHeaderCount := LHeadersList.Count;
+  if LHeaderCount > 0 then
+  begin
+    SetLength(LHeaders, LHeaderCount);
+    SetLength(LHeaderStrings, LHeaderCount * 2);
+    I := 0;
+    for LPair in LHeadersList do
+    begin
+      LHeaderStrings[I * 2] := AnsiString(LPair.Key);
+      LHeaderStrings[I * 2 + 1] := AnsiString(LPair.Value);
+      
+      LHeaders[I].NameLength := Length(LHeaderStrings[I * 2]);
+      LHeaders[I].RawValueLength := Length(LHeaderStrings[I * 2 + 1]);
+      LHeaders[I].pName := PAnsiChar(LHeaderStrings[I * 2]);
+      LHeaders[I].pRawValue := PAnsiChar(LHeaderStrings[I * 2 + 1]);
+      Inc(I);
+    end;
+    LResponse.Headers.UnknownHeaderCount := LHeaderCount;
+    LResponse.Headers.pUnknownHeaders := @LHeaders[0];
+  end;
+
+  // Read Body Stream if any
+  if ARes.ContentStream <> nil then
+  begin
+    SetLength(LBodyBytes, ARes.ContentStream.Size);
+    ARes.ContentStream.Position := 0;
+    if ARes.ContentStream.Size > 0 then
+      ARes.ContentStream.ReadBuffer(LBodyBytes[0], ARes.ContentStream.Size);
+  end;
+
+  // Fallback to BodyText or WebResponse.Content
+  if Length(LBodyBytes) = 0 then
+  begin
+    if ARes.BodyText <> '' then
+      LBodyBytes := TEncoding.UTF8.GetBytes(ARes.BodyText)
+    else if (ARes.RawWebResponse <> nil) and (ARes.RawWebResponse.Content <> '') then
+      LBodyBytes := TEncoding.UTF8.GetBytes(ARes.RawWebResponse.Content);
+  end;
+
+  if Length(LBodyBytes) > 0 then
+  begin
+    // Set Content-Length
+    LContentLengthAnsi := AnsiString(IntToStr(Length(LBodyBytes)));
+    LResponse.Headers.KnownHeaders[11].pRawValue := PAnsiChar(LContentLengthAnsi);
+    LResponse.Headers.KnownHeaders[11].RawValueLength := Length(LContentLengthAnsi);
+
+    FillChar(LChunk, SizeOf(LChunk), 0);
+    LChunk.DataChunkType := hctFromMemory;
+    LChunk.pBuffer := @LBodyBytes[0];
+    LChunk.BufferLength := Length(LBodyBytes);
+
+    LResponse.EntityChunkCount := 1;
+    LResponse.pEntityChunks := @LChunk;
+  end
+  else
+  begin
+    // Set Content-Length to 0
+    LResponse.Headers.KnownHeaders[11].pRawValue := '0';
+    LResponse.Headers.KnownHeaders[11].RawValueLength := 1;
+  end;
+
+  LRet := HttpSendHttpResponse(
+    FReqQueue,
+    FRequestId,
+    0,
+    @LResponse,
+    nil,
+    LBytesSent,
+    nil,
+    0,
+    nil,
+    nil
+  );
+  if LRet <> ERROR_SUCCESS then
+    raise EOSError.Create('HttpSendHttpResponse failed with error code: ' + IntToStr(LRet));
+end;
+
+
+{ THttpSysWebResponse }
+
+constructor THttpSysWebResponse.Create(const ARawRes: IHorseRawResponse);
+begin
+  inherited Create(ARawRes);
+  FStatusCode := 200;
+end;
+
+function THttpSysWebResponse.GetStringVariable(Index: Integer): string;
+begin
+  case Index of
+    25: Result := FContent;
+    15: Result := FContentType;
+    14: Result := FContentEncoding;
+  else
+    Result := '';
+  end;
+end;
+
+procedure THttpSysWebResponse.SetStringVariable(Index: Integer; const Value: string);
+begin
+  case Index of
+    25: FContent := Value;
+    15: FContentType := Value;
+    14: FContentEncoding := Value;
+  end;
+end;
+
+{$IF CompilerVersion >= 32.0}
+function THttpSysWebResponse.GetIntegerVariable(Index: Integer): Int64;
+{$ELSE}
+function THttpSysWebResponse.GetIntegerVariable(Index: Integer): Integer;
+{$IFEND}
+begin
+  if Index = 0 then
+    Result := FStatusCode
+  else
+    Result := 0;
+end;
+
+{$IF CompilerVersion >= 32.0}
+procedure THttpSysWebResponse.SetIntegerVariable(Index: Integer; Value: Int64);
+{$ELSE}
+procedure THttpSysWebResponse.SetIntegerVariable(Index: Integer; Value: Integer);
+{$IFEND}
+begin
+  if Index = 0 then
+    FStatusCode := Value;
+end;
+
+function THttpSysWebResponse.GetContent: string;
+begin
+  Result := FContent;
+end;
+
+procedure THttpSysWebResponse.SetContent(const Value: string);
+begin
+  FContent := Value;
+end;
+
+function THttpSysWebResponse.GetStatusCode: Integer;
+begin
+  Result := FStatusCode;
+end;
+
+procedure THttpSysWebResponse.SetStatusCode(Value: Integer);
+begin
+  FStatusCode := Value;
+end;
+
+
+{ THttpSysListenerThread }
+
+constructor THttpSysListenerThread.Create(AReqQueue: THandle);
+begin
+  inherited Create(True);
+  FReqQueue := AReqQueue;
+  FRunning := False;
+  FreeOnTerminate := False;
+end;
+
+procedure THttpSysListenerThread.DispatchRequest(ABuffer: TBytes);
+begin
+  TTask.Run(
+    procedure
+    var
+      LRawReq: IHorseRawRequest;
+      LRawRes: IHorseRawResponse;
+      LConcreteRes: THttpSysRawResponse;
+      LWebRequest: TInterfacedWebRequest;
+      LWebResponse: TInterfacedWebResponse;
+      LReq: THorseRequest;
+      LRes: THorseResponse;
+      LRequest: PHTTP_REQUEST;
+    begin
+      try
+        LRequest := PHTTP_REQUEST(@ABuffer[0]);
+        LRawReq := THttpSysRawRequest.Create(LRequest, ABuffer);
+        LConcreteRes := THttpSysRawResponse.Create(FReqQueue, LRequest.RequestId);
+        LRawRes := LConcreteRes;
+        LWebRequest := TInterfacedWebRequest.Create(LRawReq);
+        LWebResponse := THttpSysWebResponse.Create(LRawRes);
+        try
+          LReq := THorseRequest.Create(LWebRequest);
+          LRes := THorseResponse.Create(LWebResponse);
+          try
+            THorseProviderHttpSys.Execute(LReq, LRes);
+          finally
+            LConcreteRes.SendResponse(LRes);
+            LReq.Free;
+            LRes.Free;
+          end;
+        finally
+          LWebRequest.Free;
+          LWebResponse.Free;
+        end;
+      except
+        // Catch all exceptions inside thread execution
+      end;
+    end
+  );
+end;
+
+procedure THttpSysListenerThread.Execute;
+var
+  LBuffer: TBytes;
+  LRequest: PHTTP_REQUEST;
+  LBytesReturned: ULONG;
+  LRet: ULONG;
+  LRequestId: HTTP_REQUEST_ID;
+begin
+  LRequestId := 0;
+  LRequest := nil;
+  while not Terminated and FRunning do
+  begin
+    if LRequestId = 0 then
+    begin
+      SetLength(LBuffer, 16384); // Pre-allocated 16KB Request Buffer
+      LRequest := PHTTP_REQUEST(@LBuffer[0]);
+      FillChar(LRequest^, SizeOf(HTTP_REQUEST), 0);
+    end;
+    LBytesReturned := 0;
+
+    LRet := HttpReceiveHttpRequest(
+      FReqQueue,
+      LRequestId,
+      0,
+      LRequest,
+      Length(LBuffer),
+      LBytesReturned,
+      nil
+    );
+
+    if LRet = ERROR_SUCCESS then
+    begin
+      // Dispatch processing concurrently to Delphi Thread Pool
+      DispatchRequest(LBuffer);
+      LRequestId := 0;
+    end
+    else if LRet = ERROR_MORE_DATA then
+    begin
+      // Re-allocate enough space for large request headers and try again
+      LRequestId := LRequest.RequestId;
+      SetLength(LBuffer, LBytesReturned);
+      LRequest := PHTTP_REQUEST(@LBuffer[0]);
+    end
+    else
+    begin
+      LRequestId := 0;
+      if (LRet = 1229) or (LRet = ERROR_CONNECTION_INVALID) then // 1229 = ERROR_CONNECTION_INVALID
+        // Connection lost, continue
+      else if not FRunning then
+        Break;
+    end;
+  end;
+end;
+
+
+{ THorseProviderHttpSys }
+
+class constructor THorseProviderHttpSys.CreateClass;
+var
+  I: Integer;
+begin
+  FRunning := False;
+  FPort := 0;
+  FHost := '';
+  FServerSessionId := 0;
+  FUrlGroupId := 0;
+  FReqQueue := 0;
+  FListenerThread := nil;
+
+  FKnownRequestHeadersMap := TDictionary<string, Integer>.Create(TIStringComparer.Ordinal);
+  for I := 0 to 40 do
+    FKnownRequestHeadersMap.Add(HTTP_KNOWN_REQUEST_HEADERS[I], I);
+
+  FKnownResponseHeadersMap := TDictionary<string, Integer>.Create(TIStringComparer.Ordinal);
+  for I := 0 to 29 do
+    FKnownResponseHeadersMap.Add(HTTP_KNOWN_RESPONSE_HEADERS[I], I);
+end;
+
+class destructor THorseProviderHttpSys.DestroyClass;
+begin
+  FKnownRequestHeadersMap.Free;
+  FKnownResponseHeadersMap.Free;
+end;
+
+class procedure THorseProviderHttpSys.SetPort(const AValue: Integer);
+begin
+  FPort := AValue;
+end;
+
+class procedure THorseProviderHttpSys.SetHost(const AValue: string);
+begin
+  FHost := AValue.Trim;
+end;
+
+class function THorseProviderHttpSys.GetPort: Integer;
+begin
+  Result := FPort;
+end;
+
+class function THorseProviderHttpSys.GetHost: string;
+begin
+  Result := FHost;
+end;
+
+class function THorseProviderHttpSys.GetDefaultPort: Integer;
+begin
+  Result := 9000;
+end;
+
+class function THorseProviderHttpSys.GetDefaultHost: string;
+begin
+  Result := '0.0.0.0';
+end;
+
+class procedure THorseProviderHttpSys.InternalListen;
+var
+  LPrefix: string;
+  LRet: ULONG;
+  LBinding: HTTP_BINDING_INFO;
+begin
+  if FRunning then Exit;
+
+  if FPort <= 0 then
+    FPort := GetDefaultPort;
+  if FHost.IsEmpty then
+    FHost := GetDefaultHost;
+
+  // 1. Initialize HTTP.sys Session
+  LRet := HttpInitialize(HTTPAPI_VERSION_2, HTTP_INITIALIZE_SERVER, nil);
+  if LRet <> ERROR_SUCCESS then
+    raise EOSError.Create('HttpInitialize failed with error code: ' + IntToStr(LRet));
+
+  try
+    LRet := HttpCreateServerSession(HTTPAPI_VERSION_2, FServerSessionId, 0);
+    if LRet <> ERROR_SUCCESS then
+      raise EOSError.Create('HttpCreateServerSession failed with error code: ' + IntToStr(LRet));
+
+    try
+      // 2. Create URL Group
+      LRet := HttpCreateUrlGroup(FServerSessionId, FUrlGroupId, 0);
+      if LRet <> ERROR_SUCCESS then
+        raise EOSError.Create('HttpCreateUrlGroup failed with error code: ' + IntToStr(LRet));
+
+      try
+        // 3. Create Request Queue
+        LRet := HttpCreateRequestQueue(HTTPAPI_VERSION_2, nil, nil, 0, FReqQueue);
+        if LRet <> ERROR_SUCCESS then
+          raise EOSError.Create('HttpCreateRequestQueue failed with error code: ' + IntToStr(LRet));
+
+        // 4. Set Request Queue Binding Property
+        LBinding.Flags := 1;
+        LBinding.RequestQueueHandle := FReqQueue;
+        LRet := HttpSetUrlGroupProperty(FUrlGroupId, HttpServerBindingProperty, @LBinding, SizeOf(LBinding));
+        if LRet <> ERROR_SUCCESS then
+          raise EOSError.Create('HttpSetUrlGroupProperty (Binding) failed with error code: ' + IntToStr(LRet));
+
+        // 5. Add URL namespace prefix
+        // Map 0.0.0.0 or empty host to '+' wildcard for global listening (requires admin/urlacl)
+        if (FHost = '0.0.0.0') or (FHost = '') then
+          LPrefix := Format('http://+:%d/', [FPort])
+        else
+          LPrefix := Format('http://%s:%d/', [FHost, FPort]);
+
+        LRet := HttpAddUrlToUrlGroup(FUrlGroupId, PWideChar(WideString(LPrefix)), 0, 0);
+        if LRet <> ERROR_SUCCESS then
+          raise EOSError.Create('HttpAddUrlToUrlGroup failed to register ' + LPrefix + ' with error code: ' + IntToStr(LRet));
+
+        // 6. Start Listener Thread
+        FRunning := True;
+        FListenerThread := THttpSysListenerThread.Create(FReqQueue);
+        FListenerThread.Running := True;
+        FListenerThread.Start;
+
+        DoOnListen;
+
+        if IsConsole then
+        begin
+          while FRunning do
+            Sleep(100);
+        end;
+
+      except
+        if FReqQueue <> 0 then
+        begin
+          HttpCloseRequestQueue(FReqQueue);
+          FReqQueue := 0;
+        end;
+        raise;
+      end;
+    except
+      if FUrlGroupId <> 0 then
+      begin
+        HttpCloseUrlGroup(FUrlGroupId);
+        FUrlGroupId := 0;
+      end;
+      raise;
+    end;
+  except
+    if FServerSessionId <> 0 then
+    begin
+      HttpCloseServerSession(FServerSessionId);
+      FServerSessionId := 0;
+    end;
+    HttpTerminate(HTTP_INITIALIZE_SERVER, nil);
+    FRunning := False;
+    raise;
+  end;
+end;
+
+class procedure THorseProviderHttpSys.InternalStopListen;
+begin
+  if not FRunning then Exit;
+
+  FRunning := False;
+
+  // Signal and stop listener thread
+  if FListenerThread <> nil then
+  begin
+    FListenerThread.Running := False;
+    FListenerThread.Terminate;
+  end;
+
+  // Closing the request queue cancels any pending HttpReceiveHttpRequest API calls, forcing thread to exit
+  if FReqQueue <> 0 then
+  begin
+    HttpCloseRequestQueue(FReqQueue);
+    FReqQueue := 0;
+  end;
+
+  if FListenerThread <> nil then
+  begin
+    FListenerThread.WaitFor;
+    FreeAndNil(FListenerThread);
+  end;
+
+  if FUrlGroupId <> 0 then
+  begin
+    HttpCloseUrlGroup(FUrlGroupId);
+    FUrlGroupId := 0;
+  end;
+
+  if FServerSessionId <> 0 then
+  begin
+    HttpCloseServerSession(FServerSessionId);
+    FServerSessionId := 0;
+  end;
+
+  HttpTerminate(HTTP_INITIALIZE_SERVER, nil);
+  DoOnStopListen;
+end;
+
+class procedure THorseProviderHttpSys.Listen;
+begin
+  InternalListen;
+end;
+
+class procedure THorseProviderHttpSys.Listen(const APort: Integer; const AHost: string; const ACallbackListen, ACallbackStopListen: TProc);
+begin
+  SetPort(APort);
+  SetHost(AHost);
+  SetOnListen(ACallbackListen);
+  SetOnStopListen(ACallbackStopListen);
+  InternalListen;
+end;
+
+class procedure THorseProviderHttpSys.Listen(const AHost: string; const ACallbackListen, ACallbackStopListen: TProc);
+begin
+  Listen(FPort, AHost, ACallbackListen, ACallbackStopListen);
+end;
+
+class procedure THorseProviderHttpSys.Listen(const ACallbackListen, ACallbackStopListen: TProc);
+begin
+  Listen(FPort, FHost, ACallbackListen, ACallbackStopListen);
+end;
+
+class procedure THorseProviderHttpSys.Listen(const APort: Integer; const ACallbackListen, ACallbackStopListen: TProc);
+begin
+  Listen(APort, FHost, ACallbackListen, ACallbackStopListen);
+end;
+
+class procedure THorseProviderHttpSys.ListenWithConfig(const APort: Integer; const AConfig: THorseCrossSocketConfig);
+begin
+  SetPort(APort);
+  InternalListen;
+end;
+
+class procedure THorseProviderHttpSys.StopListen;
+begin
+  InternalStopListen;
+end;
+
+class function THorseProviderHttpSys.IsRunning: Boolean;
+begin
+  Result := FRunning;
+end;
+
+{$ENDIF}
+
+end.

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -180,6 +180,9 @@ unit Horse;
 {$IF DEFINED(HORSE_PROVIDER_CROSSSOCKET) and DEFINED(HORSE_PROVIDER_MORMOT)}
   {$MESSAGE FATAL 'HORSE_PROVIDER_CROSSSOCKET and HORSE_PROVIDER_MORMOT are mutually exclusive — pick exactly one transport Provider per build.'}
 {$IFEND}
+{$IF DEFINED(HORSE_PROVIDER_HTTPSYS) and (DEFINED(HORSE_PROVIDER_CROSSSOCKET) or DEFINED(HORSE_PROVIDER_MORMOT))}
+  {$MESSAGE FATAL 'HORSE_PROVIDER_HTTPSYS is mutually exclusive with other transport Providers — pick exactly one per build.'}
+{$IFEND}
 { =========================================================================== }
 
 interface
@@ -230,6 +233,13 @@ uses
 {$ELSEIF DEFINED(HORSE_HOST_CGI)}
   System.SysUtils,
   Horse.Provider.CGI,
+{$ELSEIF DEFINED(HORSE_PROVIDER_HTTPSYS)}
+  System.SysUtils,
+  {$IFDEF MSWINDOWS}
+  Horse.Provider.HttpSys,
+  {$ELSE}
+  Horse.Provider.Console,
+  {$ENDIF}
 {$ELSEIF DEFINED(HORSE_PROVIDER_CROSSSOCKET)}
   System.SysUtils,
   {$IF DEFINED(HORSE_APPTYPE_VCL)}
@@ -316,6 +326,13 @@ type
   THorseProvider =
   {$IF DEFINED(FPC)}
     Horse.Provider.FPC.FastCGI.THorseProvider;
+  {$ENDIF}
+{$ELSEIF DEFINED(HORSE_PROVIDER_HTTPSYS)}
+  THorseProvider =
+  {$IFDEF MSWINDOWS}
+    Horse.Provider.HttpSys.THorseProviderHttpSys;
+  {$ELSE}
+    Horse.Provider.Console.THorseProvider;
   {$ENDIF}
 {$ELSEIF DEFINED(HORSE_PROVIDER_CROSSSOCKET)}
   {$IF DEFINED(HORSE_APPTYPE_VCL)}

--- a/tests/src/tests/Tests.Api.Console.pas
+++ b/tests/src/tests/Tests.Api.Console.pas
@@ -1,5 +1,7 @@
 unit Tests.Api.Console;
 
+{.$DEFINE HORSE_PROVIDER_HTTPSYS}
+
 interface
 
 uses
@@ -56,7 +58,11 @@ begin
 
   FJSONArray := TJSONObject.ParseJSONValue(LResponse.Content) as TJSONArray;
   Assert.AreEqual(9000, THorse.Port);
+  {$IFDEF HORSE_PROVIDER_HTTPSYS}
+  Assert.AreEqual('localhost', THorse.Host);
+  {$ELSE}
   Assert.AreEqual('0.0.0.0', THorse.Host);
+  {$ENDIF}
   Assert.AreEqual(10, THorse.MaxConnections);
   Assert.AreEqual(LResponse.StatusCode, 200);
   Assert.AreEqual(FJSONArray.Count, 3);
@@ -157,6 +163,9 @@ begin
 
         Controllers.Api.Registry;
         THorse.MaxConnections := 10;
+        {$IFDEF HORSE_PROVIDER_HTTPSYS}
+        THorse.Host := 'localhost';
+        {$ENDIF}
         THorse.Listen;
       end).Start;
   end;

--- a/tests/src/tests/Tests.Api.Vcl.pas
+++ b/tests/src/tests/Tests.Api.Vcl.pas
@@ -1,5 +1,7 @@
 unit Tests.Api.Vcl;
 
+{.$DEFINE HORSE_PROVIDER_HTTPSYS}
+
 interface
 
 uses
@@ -60,6 +62,9 @@ begin
 
         Controllers.Api.Registry;
         THorse.MaxConnections := 10;
+        {$IFDEF HORSE_PROVIDER_HTTPSYS}
+        THorse.Host := 'localhost';
+        {$ENDIF}
         THorse.Listen;
       end).Start;
   end;
@@ -86,7 +91,11 @@ begin
       procedure
       begin
         Controllers.Api.Registry;
+        {$IFDEF HORSE_PROVIDER_HTTPSYS}
+        THorse.Listen('localhost');
+        {$ELSE}
         THorse.Listen('0.0.0.0');
+        {$ENDIF}
       end).Start;
   end;
 end;
@@ -154,7 +163,11 @@ begin
   FJSONArray := TJSONObject.ParseJSONValue(LResponse.Content) as TJSONArray;
 
   Assert.AreEqual(9000, THorse.Port);
+  {$IFDEF HORSE_PROVIDER_HTTPSYS}
+  Assert.AreEqual('localhost', THorse.Host);
+  {$ELSE}
   Assert.AreEqual('0.0.0.0', THorse.Host);
+  {$ENDIF}
   Assert.AreEqual(10, THorse.MaxConnections);
   Assert.AreEqual(LResponse.StatusCode, 200);
   Assert.AreEqual(FJSONArray.Count, 3);


### PR DESCRIPTION
## Description

This PR implements the native Windows **HTTP.sys** transport provider (`Winapi.HttpApi`) for the Horse framework, enabled via the compile-time conditional define `HORSE_PROVIDER_HTTPSYS`.

This provider runs HTTP parsing, connection pool management, and routing directly inside the Windows kernel-mode driver, providing superior performance, lower resource consumption (CPU/RAM), and native features such as port sharing and SSL/TLS management (via Schannel) with zero DLL dependencies.

## Key Changes & Design Decisions

1. **Zero-Dependency Kernel Driver**: Auto-contained integration with `Winapi.HttpApi.pas` nativelly supported on Delphi. No external DLLs (like OpenSSL) or libraries required.
2. **Core Preservation & Absolute Isolation**:
   - The core framework classes were left untouched. 
   - Instead of modifying the shared `Horse.Provider.RawAdapters.pas` (which contains empty write stubs for `TInterfacedWebResponse`), we inherited it locally as `THttpSysWebResponse` inside `Horse.Provider.HttpSys.pas`, implementing write properties (`StatusCode`, `Content`, `ContentType`) in isolation.
3. **Safe Memory & Lifecycle Management**:
   - Adapted the requests and responses using Delphi Interfaces (`IHorseRawRequest` / `IHorseRawResponse`) to allow Delphi's Reference Counting to safely clean up memory and buffers, preventing double-free AVs and race conditions on multi-threaded environments.
   - Handled proper memory alignment (`{$MINENUMSIZE 4}`) for correct compatibility with `httpapi.dll` structures on x86/x64 platforms.
4. **Development Security (UAC Elevation Bypass)**:
   - Configured the provider to support `localhost` and `127.0.0.1` binds directly, which bypasses the Windows requirement for Administrator privileges during development.
5. **Tests & Samples**:
   - **`tests/`**: Added a commented `{.$DEFINE HORSE_PROVIDER_HTTPSYS}` on API tests (`Tests.Api.Console.pas` and `Tests.Api.Vcl.pas`) so developers can easily toggle the test suite locally to run under HTTP.sys.
   - **`samples/`**: Added a fully working console application sample under `samples/delphi/httpsys/` showcasing path parameters, query parameters, and native JSON response.
