### PR TITLE
Feature/optimize httpsys

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ A _provider_ is the HTTP transport that owns the socket and hands requests to yo
 | **`fphttpserver`** _(FPC default for self-hosted)_                                              | _(none)_                | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **HTTP.sys** _(Windows kernel-mode driver for ultra-low latency)_                             | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **epoll** _(Linux-native asynchronous event loop)_                                           | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Note** — Apache / ISAPI / CGI / FastCGI Application types (below) do **not** use any of these Providers. The host process (Apache, IIS, the web server) owns the socket; Horse runs in-process. See [Providers & Application types](./doc/providers.md) for the full model.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -87,6 +87,8 @@ Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições
 | **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **HTTP.sys** _(driver de modo kernel do Windows para ultra-baixa latência)_                 | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **epoll** _(event loop assíncrono nativo do Linux)_                                         | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Nota** — Os tipos de aplicação Apache / ISAPI / CGI / FastCGI (abaixo) **não** usam nenhum desses Providers. O processo host (Apache, IIS, o webserver) é dono do socket; o Horse roda in-process. Veja [Providers e Tipos de aplicação](./doc/providers.pt-BR.md) para o modelo completo.
 

--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
   "name": "horse",
   "description": "Horse web framework \u2014 CrossSocket-compatible fork",
-  "version": "3.1.103",
+  "version": "3.1.104",
   "homepage": "https://github.com/freitasjca/horse",
   "license": "MIT",
   "mainsrc": "src/",

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -133,6 +133,8 @@ boss install horse-provider-mormot
 
 In your project's Conditional Defines: `HORSE_PROVIDER_MORMOT`. Your code stays the same.
 
+**Three server backends.** The provider can host any of mORMot2's HTTP servers, selected via `THorseMormotConfig.ServerKind`: `mskThreadPool` (`THttpServer`, the default — one thread per concurrent request), `mskAsync` (`THttpAsyncServer`, a non-blocking IOCP/epoll/kqueue event loop that scales past thread-per-request), or `mskHttpApi` (`THttpApiServer`, Windows **http.sys** kernel-mode HTTP — Windows only). Switch at runtime (`Cfg.ServerKind := mskAsync` before `THorse.ListenWithConfig`) or set a project-wide define (`HORSE_MORMOT_ASYNC`, or `HORSE_MORMOT_HTTPAPI` on Windows) to flip the default. With none, the default stays `THttpServer` — unchanged behaviour. `mskHttpApi` registers `http://+:<port>/` with http.sys, which needs Administrator rights or a one-time `netsh http add urlacl`. See the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme) for details.
+
 **What changes vs. Indy:**
 
 | | Indy | mORMot2 |
@@ -168,7 +170,7 @@ In your project's Conditional Defines: `HORSE_PROVIDER_MORMOT`. Your code stays 
 
 Both providers use IOCP/epoll and a context object pool, so throughput is comparable under typical workloads.
 
-For configuration (`ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) and application-type wrappers (VCL, Windows Service, Linux daemon), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme).
+For configuration (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) and application-type wrappers (VCL, Windows Service, Linux daemon), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **mORMot2 installation** — mORMot2 is not available via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) and add `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` to the compiler search path.
 

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -133,6 +133,8 @@ boss install horse-provider-mormot
 
 Nos Conditional Defines do projeto: `HORSE_PROVIDER_MORMOT`. Seu código fica o mesmo.
 
+**Três back-ends de servidor.** O provider pode hospedar qualquer um dos servidores HTTP do mORMot2, selecionado por `THorseMormotConfig.ServerKind`: `mskThreadPool` (`THttpServer`, o padrão — uma thread por requisição concorrente), `mskAsync` (`THttpAsyncServer`, um laço de eventos não bloqueante IOCP/epoll/kqueue que escala além de uma thread por requisição) ou `mskHttpApi` (`THttpApiServer`, HTTP em modo kernel via **http.sys** do Windows — somente Windows). Troque em tempo de execução (`Cfg.ServerKind := mskAsync` antes de `THorse.ListenWithConfig`) ou defina um define de projeto (`HORSE_MORMOT_ASYNC`, ou `HORSE_MORMOT_HTTPAPI` no Windows) para alterar o padrão. Sem nenhum deles, o padrão continua sendo `THttpServer` — comportamento inalterado. O `mskHttpApi` registra `http://+:<porta>/` no http.sys, o que exige direitos de Administrador ou um `netsh http add urlacl` executado uma única vez. Veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme) para detalhes.
+
 **O que muda vs. Indy:**
 
 | | Indy | mORMot2 |
@@ -166,7 +168,7 @@ Nos Conditional Defines do projeto: `HORSE_PROVIDER_MORMOT`. Seu código fica o 
 
 Ambos os providers usam IOCP/epoll e um pool de objetos de contexto, portanto a taxa de transferência é comparável sob cargas típicas.
 
-Para configuração (`ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) e as implementações para cada tipo de aplicação  (VCL, Serviço Windows, daemon Linux), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme).
+Para configuração (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) e as implementações para cada tipo de aplicação  (VCL, Serviço Windows, daemon Linux), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **Instalação do mORMot2** — o mORMot2 não está disponível via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) e adicione `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` ao search path do compilador.
 

--- a/doc/request-response.md
+++ b/doc/request-response.md
@@ -22,7 +22,7 @@ For the route declaration itself, see [Routing](./routing.md). For middleware th
 | `Params` | `THorseCoreParam` | Route path parameters: `Req.Params['id']`. |
 | `Query` | `THorseCoreParam` | URL query string: `Req.Query['name']`. |
 | `Headers` | `THorseCoreParam` | Request headers: `Req.Headers['Content-Type']`. Case-insensitive lookup. |
-| `Cookie` | `THorseCoreParam` | Parsed `Cookie:` header: `Req.Cookie['session']`. |
+| `Cookie` | `THorseCoreParam` | Parsed `Cookie:` header: `Req.Cookie['session']`. Values containing `=` (base64/JWT) are preserved in full (the parser splits on the **first** `=` only). |
 | `ContentFields` | `THorseCoreParam` | Parsed `application/x-www-form-urlencoded` body fields. |
 | `Sessions` | `THorseSessions` | Server-side session map (one per request). |
 | `Method` | `string` | Raw HTTP verb: `'GET'`, `'POST'`, `'OPTIONS'`, etc. |
@@ -119,6 +119,8 @@ THorse.Post('/upload',
 | `ContentType(AContentType: string)` | `THorseResponse` | Sets `Content-Type` header. |
 | `AddHeader(AName, AValue: string)` | `THorseResponse` | Adds a response header. |
 | `RemoveHeader(AName: string)` | `THorseResponse` | Removes a previously-added header. |
+| `Cookie(AName, AValue: string)` | `THorseCookie` | Adds a cookie and returns it for fluent attribute setting. See [Cookies](#cookies). |
+| `AddCookie(ACookie: THorseCookie)` | `THorseResponse` | Adds a pre-built `THorseCookie` (ownership transferred to the response). |
 | `RedirectTo(ALocation: string)` | `THorseResponse` | Sends `302 Found` with `Location:`. |
 | `RedirectTo(ALocation, AStatus)` | `THorseResponse` | Lets you choose `301`, `307`, etc. |
 | `SendFile(AFileName: string)` | `THorseResponse` | Streams a file as the body; sets `Content-Type` from the extension. |
@@ -155,6 +157,44 @@ Res.Status(THTTPStatus.BadRequest)
 ```delphi
 Res.RedirectTo('/login');
 ```
+
+### Cookies
+
+`Res.Cookie(name, value)` adds an RFC 6265 cookie and returns a `THorseCookie`
+(unit `Horse.Core.Cookie`) for fluent attribute setting. Each cookie becomes its
+own `Set-Cookie` header — you can set **several** cookies in one response:
+
+```delphi
+uses Horse.Core.Cookie;   // for TSameSite (ssStrict / ssLax / ssNone)
+
+Res.Cookie('sid', SessionId)
+   .Path('/')
+   .HttpOnly(True)
+   .Secure(True)
+   .SameSite(ssLax)
+   .MaxAge(3600);
+
+Res.Cookie('theme', 'dark');   // a second cookie → a second Set-Cookie line
+```
+
+| Attribute | Method |
+|---|---|
+| `Path` / `Domain` | `.Path('/')`, `.Domain('example.com')` |
+| `Expires` (UTC) | `.Expires(EncodeDate(2030,1,1))` |
+| `Max-Age` (seconds) | `.MaxAge(3600)` |
+| `Secure` / `HttpOnly` | `.Secure(True)`, `.HttpOnly(True)` |
+| `SameSite` | `.SameSite(ssStrict | ssLax | ssNone)` |
+
+**Validation:** the cookie name must be a token and neither name nor value may
+contain control characters, CR/LF or `;` — invalid input raises `EHorseException`.
+This validation applies only to the typed API; the legacy
+`Res.AddHeader('Set-Cookie', …)` path is unchanged (but holds only **one** cookie,
+since it goes through the header map).
+
+**Provider notes:**
+- **CrossSocket** and **mORMot** emit every attribute, one `Set-Cookie` line per cookie.
+- **Indy (Delphi)** maps onto `TWebResponse.Cookies`: `Max-Age` is not representable
+  there (use `.Expires()` on Indy); `HttpOnly` needs Delphi 10.1+, `SameSite` Delphi 10.4+.
 
 **File download:**
 ```delphi

--- a/doc/request-response.pt-BR.md
+++ b/doc/request-response.pt-BR.md
@@ -22,7 +22,7 @@ Para a declaração da rota em si, veja [Roteamento](./routing.pt-BR.md). Para m
 | `Params` | `THorseCoreParam` | Parâmetros de caminho: `Req.Params['id']`. |
 | `Query` | `THorseCoreParam` | Query string: `Req.Query['name']`. |
 | `Headers` | `THorseCoreParam` | Headers da requisição: `Req.Headers['Content-Type']`. Lookup case-insensitive. |
-| `Cookie` | `THorseCoreParam` | Header `Cookie:` parseado: `Req.Cookie['session']`. |
+| `Cookie` | `THorseCoreParam` | Header `Cookie:` parseado: `Req.Cookie['session']`. Valores que contêm `=` (base64/JWT) são preservados por inteiro (o parser separa apenas no **primeiro** `=`). |
 | `ContentFields` | `THorseCoreParam` | Campos parseados de body `application/x-www-form-urlencoded`. |
 | `Sessions` | `THorseSessions` | Mapa de sessões no servidor (um por requisição). |
 | `Method` | `string` | Verbo HTTP cru: `'GET'`, `'POST'`, `'OPTIONS'`, etc. |
@@ -119,6 +119,8 @@ THorse.Post('/upload',
 | `ContentType(AContentType: string)` | `THorseResponse` | Define o header `Content-Type`. |
 | `AddHeader(AName, AValue: string)` | `THorseResponse` | Adiciona um header de resposta. |
 | `RemoveHeader(AName: string)` | `THorseResponse` | Remove um header previamente adicionado. |
+| `Cookie(AName, AValue: string)` | `THorseCookie` | Adiciona um cookie e o retorna para configurar atributos de forma fluente. Veja [Cookies](#cookies). |
+| `AddCookie(ACookie: THorseCookie)` | `THorseResponse` | Adiciona um `THorseCookie` já construído (a propriedade do objeto passa para a resposta). |
 | `RedirectTo(ALocation: string)` | `THorseResponse` | Envia `302 Found` com `Location:`. |
 | `RedirectTo(ALocation, AStatus)` | `THorseResponse` | Permite escolher `301`, `307`, etc. |
 | `SendFile(AFileName: string)` | `THorseResponse` | Faz stream de um arquivo como body; define `Content-Type` pela extensão. |
@@ -155,6 +157,44 @@ Res.Status(THTTPStatus.BadRequest)
 ```delphi
 Res.RedirectTo('/login');
 ```
+
+### Cookies
+
+`Res.Cookie(name, value)` adiciona um cookie RFC 6265 e retorna um `THorseCookie`
+(unit `Horse.Core.Cookie`) para configurar atributos de forma fluente. Cada cookie
+vira seu próprio header `Set-Cookie` — dá para definir **vários** numa só resposta:
+
+```delphi
+uses Horse.Core.Cookie;   // para TSameSite (ssStrict / ssLax / ssNone)
+
+Res.Cookie('sid', SessionId)
+   .Path('/')
+   .HttpOnly(True)
+   .Secure(True)
+   .SameSite(ssLax)
+   .MaxAge(3600);
+
+Res.Cookie('theme', 'dark');   // um segundo cookie → uma segunda linha Set-Cookie
+```
+
+| Atributo | Método |
+|---|---|
+| `Path` / `Domain` | `.Path('/')`, `.Domain('example.com')` |
+| `Expires` (UTC) | `.Expires(EncodeDate(2030,1,1))` |
+| `Max-Age` (segundos) | `.MaxAge(3600)` |
+| `Secure` / `HttpOnly` | `.Secure(True)`, `.HttpOnly(True)` |
+| `SameSite` | `.SameSite(ssStrict | ssLax | ssNone)` |
+
+**Validação:** o nome do cookie precisa ser um token e nem o nome nem o valor podem
+conter caracteres de controle, CR/LF ou `;` — entrada inválida levanta
+`EHorseException`. Essa validação vale só para a API tipada; o caminho legado
+`Res.AddHeader('Set-Cookie', …)` continua igual (mas guarda apenas **um** cookie,
+por passar pelo mapa de headers).
+
+**Notas por provider:**
+- **CrossSocket** e **mORMot** emitem todos os atributos, uma linha `Set-Cookie` por cookie.
+- **Indy (Delphi)** mapeia para `TWebResponse.Cookies`: `Max-Age` não é representável
+  ali (use `.Expires()` no Indy); `HttpOnly` exige Delphi 10.1+, `SameSite` Delphi 10.4+.
 
 **Download de arquivo:**
 ```delphi

--- a/samples/delphi/httpsys/HttpSys.dpr
+++ b/samples/delphi/httpsys/HttpSys.dpr
@@ -188,6 +188,6 @@ begin
       Writeln('  - DELETE http://localhost:9095/users/123');
       Writeln('--------------------------------------------------');
       Writeln(' Pressione [Enter] para encerrar.');
-      Readln;
+      while True do Sleep(1000);
     end);
 end.

--- a/samples/delphi/httpsys/HttpSys.dpr
+++ b/samples/delphi/httpsys/HttpSys.dpr
@@ -31,12 +31,22 @@ const
     '<h1>Horse Server API &mdash; Delphi HTTP.sys (Windows)</h1>' +
     '<p>Bem-vindo ao servidor Horse! Use os links abaixo para testar as rotas:</p>' +
     '<ul>' +
-    '<li><span class="method get">GET</span><a href="/ping">/ping</a><div class="desc">Retorna a resposta simples de ping (pong)</div></li>' +
-    '<li><span class="method get">GET</span><a href="/users/123?nome=Regys">/users/123?nome=Regys</a><div class="desc">Retorna JSON a partir do ID e QueryParam</div></li>' +
-    '<li><span class="method post">POST</span><a href="#" onclick="fetch(''/users'', {method: ''POST''}).then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users</a><div class="desc">Executa requisição POST e exibe o JSON resultante</div></li>' +
-    '<li><span class="method put">PUT</span><a href="#" onclick="fetch(''/users/123'', {method: ''PUT''}).then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a><div class="desc">Executa requisição PUT e exibe o JSON resultante</div></li>' +
-    '<li><span class="method patch">PATCH</span><a href="#" onclick="fetch(''/users/123'', {method: ''PATCH''}).then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a><div class="desc">Executa requisição PATCH e exibe o JSON resultante</div></li>' +
-    '<li><span class="method delete">DELETE</span><a href="#" onclick="fetch(''/users/123'', {method: ''DELETE''}).then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a><div class="desc">Executa requisição DELETE e exibe o JSON resultante</div></li>' +
+    '<li><span class="method get">GET</span><a href="/ping">/ping</a>' +
+    '<div class="desc">Retorna a resposta simples de ping (pong)</div></li>' +
+    '<li><span class="method get">GET</span><a href="/users/123?nome=Regys">/users/123?nome=Regys</a>' +
+    '<div class="desc">Retorna JSON a partir do ID e QueryParam</div></li>' +
+    '<li><span class="method post">POST</span><a href="#" onclick="fetch(''/users'', {method: ''POST''})' +
+    '.then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users</a>' +
+    '<div class="desc">Executa requisição POST e exibe o JSON resultante</div></li>' +
+    '<li><span class="method put">PUT</span><a href="#" onclick="fetch(''/users/123'', {method: ''PUT''})' +
+    '.then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a>' +
+    '<div class="desc">Executa requisição PUT e exibe o JSON resultante</div></li>' +
+    '<li><span class="method patch">PATCH</span><a href="#" onclick="fetch(''/users/123'', {method: ''PATCH''})' +
+    '.then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a>' +
+    '<div class="desc">Executa requisição PATCH e exibe o JSON resultante</div></li>' +
+    '<li><span class="method delete">DELETE</span><a href="#" onclick="fetch(''/users/123'', {method: ''DELETE''})' +
+    '.then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a>' +
+    '<div class="desc">Executa requisição DELETE e exibe o JSON resultante</div></li>' +
     '</ul></body></html>';
 
 begin

--- a/samples/lazarus/httpsys/HttpSysConsole.lpr
+++ b/samples/lazarus/httpsys/HttpSysConsole.lpr
@@ -155,9 +155,8 @@ begin
   Writeln('  - PUT    http://localhost:9095/users/123');
   Writeln('  - PATCH  http://localhost:9095/users/123');
   Writeln('  - DELETE http://localhost:9095/users/123');
-  Writeln('--------------------------------------------------');
   Writeln(' Pressione [Enter] para encerrar.');
-  Readln;
+  while True do Sleep(1000);
 end;
 
 begin

--- a/src/Horse.Core.Cookie.pas
+++ b/src/Horse.Core.Cookie.pas
@@ -1,0 +1,250 @@
+unit Horse.Core.Cookie;
+
+{
+  Horse — RFC 6265 Set-Cookie builder
+  ===================================
+  Provider-agnostic typed cookie used by THorseResponse.AddCookie / .Cookie.
+  ToHeaderValue produces an RFC 6265 §4.1-compliant Set-Cookie *value* (without
+  the "Set-Cookie:" prefix); each provider's response bridge emits one header
+  line per cookie.
+
+  Validation (RFC 6265 §4.1.1): the cookie name must be a token (no controls /
+  separators); name and value must not contain control chars, CR, LF or ';'
+  (anti-injection). Invalid input raises EHorseException. This validation lives
+  ONLY here (the opt-in API) — it is never retrofitted onto Res.AddHeader.
+
+  Dates: Expires is emitted as a fixed-locale IMF-fixdate
+  ("Sun, 06 Nov 1994 08:49:37 GMT") — never DateTimeToStr (locale-dependent).
+  The TDateTime passed to Expires(...) is treated as UTC.
+
+  Dual-compilation: Delphi and Lazarus/FPC.
+}
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+uses
+{$IF DEFINED(FPC)}
+  SysUtils,
+{$ELSE}
+  System.SysUtils,
+{$ENDIF}
+  Horse.Exception;
+
+type
+  TSameSite = (ssNotSet, ssStrict, ssLax, ssNone);
+
+  { Read-only snapshot of a cookie's fields, used by the Indy response path to
+    map onto Web.HTTPApp.TCookie without exposing getters that would clash with
+    the fluent setter method names (Path/HttpOnly/...).  Note: TCookie has no
+    Max-Age, so the Indy mapper uses HasExpires/Expires only — see ToHeaderValue
+    (CrossSocket/mORMot) for full Max-Age fidelity. }
+  THorseCookieState = record
+    Name:       string;
+    Value:      string;
+    Domain:     string;
+    Path:       string;
+    HasExpires: Boolean;
+    Expires:    TDateTime;
+    Secure:     Boolean;
+    HttpOnly:   Boolean;
+    SameSite:   TSameSite;
+  end;
+
+  THorseCookie = class
+  private
+    FName:       string;
+    FValue:      string;
+    FDomain:     string;
+    FPath:       string;
+    FExpires:    TDateTime;
+    FHasExpires: Boolean;
+    FMaxAge:     Integer;
+    FHasMaxAge:  Boolean;
+    FSecure:     Boolean;
+    FHttpOnly:   Boolean;
+    FSameSite:   TSameSite;
+    procedure ValidateName(const AName: string);
+    function  CheckedValue(const AValue, AWhat: string): string;
+  public
+    constructor Create(const AName: string = ''; const AValue: string = '');
+
+    { Fluent attribute setters — return Self for chaining. }
+    function Value(const AValue: string): THorseCookie;
+    function Domain(const AValue: string): THorseCookie;
+    function Path(const AValue: string): THorseCookie;
+    function Expires(const AValue: TDateTime): THorseCookie;
+    function MaxAge(const AValue: Integer): THorseCookie;
+    function Secure(const AValue: Boolean = True): THorseCookie;
+    function HttpOnly(const AValue: Boolean = True): THorseCookie;
+    function SameSite(const AValue: TSameSite): THorseCookie;
+
+    { RFC 6265 §4.1 Set-Cookie value (no "Set-Cookie:" prefix). }
+    function ToHeaderValue: string;
+
+    { Read-only field snapshot (for the Indy TCookie mapper). }
+    function State: THorseCookieState;
+
+    property Name:  string read FName;
+  end;
+
+implementation
+
+const
+  IMF_DAYS: array[1..7] of string =
+    ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat');   // DayOfWeek: 1=Sunday
+  IMF_MONTHS: array[1..12] of string =
+    ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec');
+  { RFC 2616 separators that may not appear in a cookie-name token. }
+  COOKIE_NAME_SEPARATORS = '()<>@,;:\"/[]?={} ' + #9;
+
+function DateTimeToIMF(const ADateTime: TDateTime): string;
+var
+  Y, M, D, H, Mi, S, Ms: Word;
+  LDow: Integer;
+begin
+  DecodeDate(ADateTime, Y, M, D);
+  DecodeTime(ADateTime, H, Mi, S, Ms);
+  LDow := DayOfWeek(ADateTime);   // 1 = Sunday .. 7 = Saturday
+  Result := Format('%s, %.2d %s %.4d %.2d:%.2d:%.2d GMT',
+    [IMF_DAYS[LDow], D, IMF_MONTHS[M], Y, H, Mi, S]);
+end;
+
+{ THorseCookie }
+
+constructor THorseCookie.Create(const AName, AValue: string);
+begin
+  inherited Create;
+  FExpires    := 0;
+  FHasExpires := False;
+  FMaxAge     := 0;
+  FHasMaxAge  := False;
+  FSecure     := False;
+  FHttpOnly   := False;
+  FSameSite   := ssNotSet;
+  if AName <> '' then
+  begin
+    ValidateName(AName);
+    FName := AName;
+  end;
+  FValue := CheckedValue(AValue, 'value');
+end;
+
+procedure THorseCookie.ValidateName(const AName: string);
+var
+  C: Char;
+begin
+  if AName = '' then
+    raise EHorseException.Create('Cookie name must not be empty');
+  for C in AName do
+    if (C <= #31) or (C = #127) or (Pos(C, COOKIE_NAME_SEPARATORS) > 0) then
+      raise EHorseException.CreateFmt(
+        'Invalid character in cookie name "%s" (RFC 6265 token)', [AName]);
+end;
+
+{ Reject control chars / CR / LF / ';' in attribute values (anti-injection);
+  return the value unchanged when valid. AWhat names the field for the message. }
+function THorseCookie.CheckedValue(const AValue, AWhat: string): string;
+var
+  C: Char;
+begin
+  for C in AValue do
+    if (C < #32) or (C = #127) or (C = ';') then
+      raise EHorseException.CreateFmt(
+        'Invalid character in cookie %s (control char or ";")', [AWhat]);
+  Result := AValue;
+end;
+
+function THorseCookie.Value(const AValue: string): THorseCookie;
+begin
+  FValue := CheckedValue(AValue, 'value');
+  Result := Self;
+end;
+
+function THorseCookie.Domain(const AValue: string): THorseCookie;
+begin
+  FDomain := CheckedValue(AValue, 'Domain');
+  Result := Self;
+end;
+
+function THorseCookie.Path(const AValue: string): THorseCookie;
+begin
+  FPath := CheckedValue(AValue, 'Path');
+  Result := Self;
+end;
+
+function THorseCookie.Expires(const AValue: TDateTime): THorseCookie;
+begin
+  FExpires    := AValue;
+  FHasExpires := True;
+  Result := Self;
+end;
+
+function THorseCookie.MaxAge(const AValue: Integer): THorseCookie;
+begin
+  FMaxAge    := AValue;
+  FHasMaxAge := True;
+  Result := Self;
+end;
+
+function THorseCookie.Secure(const AValue: Boolean): THorseCookie;
+begin
+  FSecure := AValue;
+  Result := Self;
+end;
+
+function THorseCookie.HttpOnly(const AValue: Boolean): THorseCookie;
+begin
+  FHttpOnly := AValue;
+  Result := Self;
+end;
+
+function THorseCookie.SameSite(const AValue: TSameSite): THorseCookie;
+begin
+  FSameSite := AValue;
+  Result := Self;
+end;
+
+function THorseCookie.ToHeaderValue: string;
+begin
+  if FName = '' then
+    raise EHorseException.Create('Cookie name must be set before ToHeaderValue');
+
+  Result := FName + '=' + FValue;
+
+  if FPath <> '' then
+    Result := Result + '; Path=' + FPath;
+  if FDomain <> '' then
+    Result := Result + '; Domain=' + FDomain;
+  if FHasExpires then
+    Result := Result + '; Expires=' + DateTimeToIMF(FExpires);
+  if FHasMaxAge then
+    Result := Result + '; Max-Age=' + IntToStr(FMaxAge);
+  if FSecure then
+    Result := Result + '; Secure';
+  if FHttpOnly then
+    Result := Result + '; HttpOnly';
+  case FSameSite of
+    ssStrict: Result := Result + '; SameSite=Strict';
+    ssLax:    Result := Result + '; SameSite=Lax';
+    ssNone:   Result := Result + '; SameSite=None';
+  end;
+end;
+
+function THorseCookie.State: THorseCookieState;
+begin
+  Result.Name       := FName;
+  Result.Value      := FValue;
+  Result.Domain     := FDomain;
+  Result.Path       := FPath;
+  Result.HasExpires := FHasExpires;
+  Result.Expires    := FExpires;
+  Result.Secure     := FSecure;
+  Result.HttpOnly   := FHttpOnly;
+  Result.SameSite   := FSameSite;
+end;
+
+end.

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -265,6 +265,10 @@ begin
   finally
     LQueue.Free;
   end;
+{ PATCH-COOKIE-1 â€” emit typed cookies on the Indy path. The handler has run, so
+  all fluent attributes are set. No-op when FWebResponse is nil (CrossSocket /
+  mORMot emit FCookies from their response bridges instead). }
+  AResponse.FlushCookiesToWebResponse;
 end;
 
 function THorseRouterTree.ExecuteInternal(const APath: TQueue<string>; const AHTTPType: TMethodType; const ARequest: THorseRequest;
@@ -444,7 +448,7 @@ begin
     // A genuine duplicate is a second ROUTE HANDLER for the same path+method
     // (two .Get('/same', ...) calls). Middleware attached via AddCallback()
     // arrives first with AIsMiddleware=True and shares the same callback list,
-    // so we must NOT treat the pre-existing list as a duplicate — only a
+    // so we must NOT treat the pre-existing list as a duplicate ï¿½ only a
     // previously-registered handler counts. FHandlerMethods tracks exactly
     // that, independent of the middleware entries in FCallBack.
     if (not AIsMiddleware) and (FHandlerMethods.IndexOf(AHTTPType) >= 0) then

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -11,10 +11,10 @@ uses
   {$IF DEFINED(FPC)}
     SysUtils,
     Classes,
-    SyncObjs,
     Generics.Collections,
     Generics.Defaults,
     Windows,
+    SyncObjs,
     httpprotocol,
   {$ELSE}
     System.SysUtils,
@@ -299,7 +299,7 @@ type
   private
     FQueue: TQueue<TBytes>;
     FSync: TCriticalSection;
-    FEvent: TSimpleEvent;
+    FEvent: TEvent;
     FWorkers: TList<TThread>;
     FActive: Boolean;
     class var FInstance: THttpSysThreadPool;
@@ -501,7 +501,7 @@ begin
     LHasItem := False;
     LBuffer := nil;
 
-    FPool.FSync.Enter;
+    FPool.FSync.Acquire;
     try
       if FPool.FQueue.Count > 0 then
       begin
@@ -509,7 +509,7 @@ begin
         LHasItem := True;
       end;
     finally
-      FPool.FSync.Leave;
+      FPool.FSync.Release;
     end;
 
     if LHasItem then
@@ -557,7 +557,7 @@ var
 begin
   FQueue := TQueue<TBytes>.Create;
   FSync := TCriticalSection.Create;
-  FEvent := TSimpleEvent.Create;
+  FEvent := TEvent.Create(nil, False, False, '');
   FWorkers := TList<TThread>.Create;
   FActive := True;
 
@@ -596,11 +596,11 @@ end;
 
 procedure THttpSysThreadPool.QueueRequest(const ABuffer: TBytes);
 begin
-  FSync.Enter;
+  FSync.Acquire;
   try
     FQueue.Enqueue(ABuffer);
   finally
-    FSync.Leave;
+    FSync.Release;
   end;
   FEvent.SetEvent;
 end;
@@ -1322,11 +1322,14 @@ begin
 end;
 
 procedure THttpSysListenerThread.DispatchRequest(ABuffer: TBytes);
+var
+  LBuf: TBytes;
 begin
   {$IF DEFINED(FPC)}
   if Assigned(THttpSysThreadPool.Instance) then
     THttpSysThreadPool.Instance.QueueRequest(ABuffer);
   {$ELSE}
+  LBuf := Copy(ABuffer);
   TTask.Run(
     procedure
     var
@@ -1340,8 +1343,8 @@ begin
       LRequest: PHTTP_REQUEST;
     begin
       try
-        LRequest := PHTTP_REQUEST(@ABuffer[0]);
-        LRawReq := THttpSysRawRequest.Create(LRequest, ABuffer);
+        LRequest := PHTTP_REQUEST(@LBuf[0]);
+        LRawReq := THttpSysRawRequest.Create(LRequest, LBuf);
         LConcreteRes := THttpSysRawResponse.Create(FReqQueue, LRequest.RequestId);
         LRawRes := LConcreteRes;
         LWebRequest := TInterfacedWebRequest.Create(LRawReq);

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -283,14 +283,31 @@ type
   THttpSysListenerThread = class;
 
   {$IF DEFINED(FPC)}
-  THttpSysRequestThread = class(TThread)
+  THttpSysThreadPool = class;
+
+  THttpSysWorkerThread = class(TThread)
   private
+    FPool: THttpSysThreadPool;
     FReqQueue: THandle;
-    FBuffer: TBytes;
   protected
     procedure Execute; override;
   public
-    constructor Create(AReqQueue: THandle; ABuffer: TBytes);
+    constructor Create(APool: THttpSysThreadPool; AReqQueue: THandle);
+  end;
+
+  THttpSysThreadPool = class
+  private
+    FQueue: TQueue<TBytes>;
+    FSync: TCriticalSection;
+    FEvent: TSimpleEvent;
+    FWorkers: TList<TThread>;
+    FActive: Boolean;
+    class var FInstance: THttpSysThreadPool;
+  public
+    constructor Create(AMaxThreads: Integer);
+    destructor Destroy; override;
+    procedure QueueRequest(const ABuffer: TBytes);
+    class property Instance: THttpSysThreadPool read FInstance;
   end;
   {$ENDIF}
 
@@ -299,7 +316,9 @@ type
   private
     FRequest: PHTTP_REQUEST;
     FBuffer: TBytes;
-    FBodyStream: TMemoryStream;
+    FBodyStream: TStream;
+    FTempFileName: string;
+    FHeadersCache: TDictionary<string, string>;
     procedure EnsureBodyStream;
   public
     constructor Create(ARequest: PHTTP_REQUEST; const ABuffer: TBytes);
@@ -433,19 +452,40 @@ implementation
 
 {$IFDEF MSWINDOWS}
 
-{$IF DEFINED(FPC)}
-{ THttpSysRequestThread }
-
-constructor THttpSysRequestThread.Create(AReqQueue: THandle; ABuffer: TBytes);
+function GetWindowsTempPath: string;
+var
+  LBuffer: array[0..MAX_PATH] of Char;
 begin
-  inherited Create(False);
-  FReqQueue := AReqQueue;
-  FBuffer := ABuffer;
-  FreeOnTerminate := True;
+  if GetTempPath(MAX_PATH, LBuffer) > 0 then
+    Result := string(LBuffer)
+  else
+    Result := 'C:\Temp\';
+  Result := IncludeTrailingPathDelimiter(Result);
 end;
 
-procedure THttpSysRequestThread.Execute;
+function HttpSysDeleteFile(const AFileName: string): Boolean;
+begin
+  {$IF DEFINED(FPC)}
+  Result := SysUtils.DeleteFile(AFileName);
+  {$ELSE}
+  Result := System.SysUtils.DeleteFile(AFileName);
+  {$ENDIF}
+end;
+
+{$IF DEFINED(FPC)}
+{ THttpSysWorkerThread }
+
+constructor THttpSysWorkerThread.Create(APool: THttpSysThreadPool; AReqQueue: THandle);
+begin
+  inherited Create(False);
+  FPool := APool;
+  FReqQueue := AReqQueue;
+  FreeOnTerminate := False;
+end;
+
+procedure THttpSysWorkerThread.Execute;
 var
+  LBuffer: TBytes;
   LRawReq: IHorseRawRequest;
   LRawRes: IHorseRawResponse;
   LConcreteRes: THttpSysRawResponse;
@@ -454,33 +494,115 @@ var
   LReq: THorseRequest;
   LRes: THorseResponse;
   LRequest: PHTTP_REQUEST;
+  LHasItem: Boolean;
 begin
-  try
-    LRequest := PHTTP_REQUEST(@FBuffer[0]);
-    LRawReq := THttpSysRawRequest.Create(LRequest, FBuffer);
-    LConcreteRes := THttpSysRawResponse.Create(FReqQueue, LRequest.RequestId);
-    LRawRes := LConcreteRes;
-    LWebRequest := TInterfacedWebRequest.Create(LRawReq);
-    LWebResponse := THttpSysWebResponse.Create(LRawRes);
+  while not Terminated and FPool.FActive do
+  begin
+    LHasItem := False;
+    LBuffer := nil;
+
+    FPool.FSync.Enter;
     try
-      LReq := THorseRequest.Create(LWebRequest);
-      LRes := THorseResponse.Create(LWebResponse);
-      try
-        THorseProviderHttpSys.Execute(LReq, LRes);
-      finally
-        LConcreteRes.SendResponse(LRes);
-        LReq.Free;
-        LRes.Free;
+      if FPool.FQueue.Count > 0 then
+      begin
+        LBuffer := FPool.FQueue.Dequeue;
+        LHasItem := True;
       end;
     finally
-      LWebRequest.Free;
-      LWebResponse.Free;
+      FPool.FSync.Leave;
     end;
-  except
-    on E: Exception do
-      // Silencia erros de Dispatch
-      ;
+
+    if LHasItem then
+    begin
+      try
+        LRequest := PHTTP_REQUEST(@LBuffer[0]);
+        LRawReq := THttpSysRawRequest.Create(LRequest, LBuffer);
+        LConcreteRes := THttpSysRawResponse.Create(FReqQueue, LRequest.RequestId);
+        LRawRes := LConcreteRes;
+        LWebRequest := TInterfacedWebRequest.Create(LRawReq);
+        LWebResponse := THttpSysWebResponse.Create(LRawRes);
+        try
+          LReq := THorseRequest.Create(LWebRequest);
+          LRes := THorseResponse.Create(LWebResponse);
+          try
+            THorseProviderHttpSys.Execute(LReq, LRes);
+          finally
+            LConcreteRes.SendResponse(LRes);
+            LReq.Free;
+            LRes.Free;
+          end;
+        finally
+          LWebRequest.Free;
+          LWebResponse.Free;
+        end;
+      except
+        on E: Exception do
+          // Silencia erros de Dispatch
+          ;
+      end;
+      LBuffer := nil;
+    end
+    else
+    begin
+      FPool.FEvent.WaitFor(1000);
+    end;
   end;
+end;
+
+{ THttpSysThreadPool }
+
+constructor THttpSysThreadPool.Create(AMaxThreads: Integer);
+var
+  I: Integer;
+begin
+  FQueue := TQueue<TBytes>.Create;
+  FSync := TCriticalSection.Create;
+  FEvent := TSimpleEvent.Create;
+  FWorkers := TList<TThread>.Create;
+  FActive := True;
+
+  for I := 0 to AMaxThreads - 1 do
+    FWorkers.Add(THttpSysWorkerThread.Create(Self, THorseProviderHttpSys.ReqQueue));
+end;
+
+destructor THttpSysThreadPool.Destroy;
+var
+  LWorker: TThread;
+begin
+  FActive := False;
+  FEvent.SetEvent;
+
+  for LWorker in FWorkers do
+    LWorker.Terminate;
+
+  FEvent.SetEvent;
+
+  for LWorker in FWorkers do
+  begin
+    LWorker.WaitFor;
+    LWorker.Free;
+  end;
+
+  FWorkers.Free;
+  FEvent.Free;
+
+  while FQueue.Count > 0 do
+    FQueue.Dequeue;
+  FQueue.Free;
+
+  FSync.Free;
+  inherited;
+end;
+
+procedure THttpSysThreadPool.QueueRequest(const ABuffer: TBytes);
+begin
+  FSync.Enter;
+  try
+    FQueue.Enqueue(ABuffer);
+  finally
+    FSync.Leave;
+  end;
+  FEvent.SetEvent;
 end;
 {$ENDIF}
 
@@ -492,12 +614,18 @@ begin
   FRequest := ARequest;
   FBuffer := ABuffer;
   FBodyStream := nil;
+  FTempFileName := '';
+  FHeadersCache := nil;
 end;
 
 destructor THttpSysRawRequest.Destroy;
 begin
   if Assigned(FBodyStream) then
     FBodyStream.Free;
+  if FTempFileName <> '' then
+    HttpSysDeleteFile(FTempFileName);
+  if Assigned(FHeadersCache) then
+    FHeadersCache.Free;
   inherited;
 end;
 
@@ -508,62 +636,131 @@ var
   BytesReceived: ULONG;
   Ret: ULONG;
   TempBuf: TBytes;
+  LTempPath, LTempFile: string;
+  LFileStream: TFileStream;
+  LContentLength: Int64;
+  LChunkLength: ULONG;
 begin
   if FBodyStream <> nil then Exit;
 
-  FBodyStream := TMemoryStream.Create;
-  
-  // 1. Copy initial body chunk if any
-  if (FRequest.EntityChunkCount > 0) and (FRequest.pEntityChunks <> nil) then
+  LContentLength := GetContentLength;
+
+  if (LContentLength > 0) and (LContentLength >= 2097152) then
   begin
-    PChunk := PHTTP_DATA_CHUNK_INMEMORY(FRequest.pEntityChunks);
-    for I := 0 to FRequest.EntityChunkCount - 1 do
-    begin
-      if PChunk.DataChunkType = hctFromMemory then
-      begin
-        if (PChunk.pBuffer <> nil) and (PChunk.BufferLength > 0) then
-          FBodyStream.WriteBuffer(PChunk.pBuffer^, PChunk.BufferLength);
-      end;
-      Inc(PChunk);
-    end;
+    LTempPath := GetWindowsTempPath;
+    LTempFile := LTempPath + 'horse_httpsys_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(FRequest.RequestId) + '.tmp';
+    FTempFileName := LTempFile;
+    FBodyStream := TFileStream.Create(LTempFile, fmCreate or fmOpenReadWrite);
+  end
+  else
+  begin
+    FBodyStream := TMemoryStream.Create;
   end;
 
-  // 2. Retrieve remaining request body entity chunks from HTTP.sys queue
-  if (FRequest.Flags and HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS) <> 0 then
-  begin
-    SetLength(TempBuf, 32768);
-    while True do
+  try
+    // 1. Copy initial body chunk if any
+    if (FRequest.EntityChunkCount > 0) and (FRequest.pEntityChunks <> nil) then
     begin
-      BytesReceived := 0;
-      Ret := HttpReceiveRequestEntityBody(
-        THorseProviderHttpSys.ReqQueue,
-        FRequest.RequestId,
-        0,
-        @TempBuf[0],
-        Length(TempBuf),
-        BytesReceived,
-        nil
-      );
-      
-      if Ret = ERROR_SUCCESS then
+      PChunk := PHTTP_DATA_CHUNK_INMEMORY(FRequest.pEntityChunks);
+      for I := 0 to FRequest.EntityChunkCount - 1 do
       begin
-        if BytesReceived > 0 then
-          FBodyStream.WriteBuffer(TempBuf[0], BytesReceived)
+        if PChunk.DataChunkType = hctFromMemory then
+        begin
+          if (PChunk.pBuffer <> nil) and (PChunk.BufferLength > 0) then
+          begin
+            LChunkLength := PChunk.BufferLength;
+
+            if (FBodyStream is TMemoryStream) and (FBodyStream.Size + LChunkLength >= 2097152) then
+            begin
+              LTempPath := GetWindowsTempPath;
+              LTempFile := LTempPath + 'horse_httpsys_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(FRequest.RequestId) + '.tmp';
+              FTempFileName := LTempFile;
+              LFileStream := TFileStream.Create(LTempFile, fmCreate or fmOpenReadWrite);
+              try
+                if FBodyStream.Size > 0 then
+                begin
+                  TMemoryStream(FBodyStream).Position := 0;
+                  LFileStream.CopyFrom(FBodyStream, FBodyStream.Size);
+                end;
+                FBodyStream.Free;
+                FBodyStream := LFileStream;
+              except
+                LFileStream.Free;
+                HttpSysDeleteFile(LTempFile);
+                raise;
+              end;
+            end;
+
+            FBodyStream.WriteBuffer(PChunk.pBuffer^, LChunkLength);
+          end;
+        end;
+        Inc(PChunk);
+      end;
+    end;
+
+    // 2. Retrieve remaining request body entity chunks from HTTP.sys queue
+    if (FRequest.Flags and HTTP_REQUEST_FLAG_MORE_ENTITY_BODY_EXISTS) <> 0 then
+    begin
+      SetLength(TempBuf, 65536);
+      while True do
+      begin
+        BytesReceived := 0;
+        Ret := HttpReceiveRequestEntityBody(
+          THorseProviderHttpSys.ReqQueue,
+          FRequest.RequestId,
+          0,
+          @TempBuf[0],
+          Length(TempBuf),
+          BytesReceived,
+          nil
+        );
+
+        if (Ret = ERROR_SUCCESS) or (Ret = ERROR_HANDLE_EOF) then
+        begin
+          if BytesReceived > 0 then
+          begin
+            if (FBodyStream is TMemoryStream) and (FBodyStream.Size + BytesReceived >= 2097152) then
+            begin
+              LTempPath := GetWindowsTempPath;
+              LTempFile := LTempPath + 'horse_httpsys_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(FRequest.RequestId) + '.tmp';
+              FTempFileName := LTempFile;
+              LFileStream := TFileStream.Create(LTempFile, fmCreate or fmOpenReadWrite);
+              try
+                if FBodyStream.Size > 0 then
+                begin
+                  TMemoryStream(FBodyStream).Position := 0;
+                  LFileStream.CopyFrom(FBodyStream, FBodyStream.Size);
+                end;
+                FBodyStream.Free;
+                FBodyStream := LFileStream;
+              except
+                LFileStream.Free;
+                HttpSysDeleteFile(LTempFile);
+                raise;
+              end;
+            end;
+
+            FBodyStream.WriteBuffer(TempBuf[0], BytesReceived);
+          end;
+
+          if Ret = ERROR_HANDLE_EOF then
+            Break;
+        end
         else
           Break;
-      end
-      else if Ret = ERROR_HANDLE_EOF then
-      begin
-        if BytesReceived > 0 then
-          FBodyStream.WriteBuffer(TempBuf[0], BytesReceived);
-        Break;
-      end
-      else
-        Break;
+      end;
     end;
-  end;
 
-  FBodyStream.Position := 0;
+    FBodyStream.Position := 0;
+  except
+    FreeAndNil(FBodyStream);
+    if FTempFileName <> '' then
+    begin
+      HttpSysDeleteFile(FTempFileName);
+      FTempFileName := '';
+    end;
+    raise;
+  end;
 end;
 
 function THttpSysRawRequest.GetMethod: string;
@@ -697,28 +894,37 @@ function THttpSysRawRequest.GetFieldByName(const AName: string): string;
 var
   LIndex: Integer;
   I: Integer;
-  LUnknownName: string;
+  LUnknownName, LUnknownVal: string;
 begin
+  if FHeadersCache = nil then
+  begin
+    {$IF DEFINED(FPC)}
+    FHeadersCache := TDictionary<string, string>.Create;
+    {$ELSE}
+    FHeadersCache := TDictionary<string, string>.Create(TIStringComparer.Ordinal);
+    {$ENDIF}
+
+    if (FRequest.Headers.UnknownHeaderCount > 0) and (FRequest.Headers.pUnknownHeaders <> nil) then
+    begin
+      for I := 0 to FRequest.Headers.UnknownHeaderCount - 1 do
+      begin
+        SetString(LUnknownName, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pName), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].NameLength);
+        SetString(LUnknownVal, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pRawValue), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].RawValueLength);
+        FHeadersCache.AddOrSetValue(LUnknownName, LUnknownVal);
+      end;
+    end;
+  end;
+
+  if FHeadersCache.TryGetValue(AName, Result) then
+    Exit;
+
   Result := '';
   if THorseProviderHttpSys.KnownRequestHeadersMap.TryGetValue(AName, LIndex) then
   begin
     if FRequest.Headers.KnownHeaders[LIndex].RawValueLength > 0 then
     begin
       SetString(Result, PAnsiChar(FRequest.Headers.KnownHeaders[LIndex].pRawValue), FRequest.Headers.KnownHeaders[LIndex].RawValueLength);
-      Exit;
-    end;
-  end;
-
-  if (FRequest.Headers.UnknownHeaderCount > 0) and (FRequest.Headers.pUnknownHeaders <> nil) then
-  begin
-    for I := 0 to FRequest.Headers.UnknownHeaderCount - 1 do
-    begin
-      SetString(LUnknownName, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pName), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].NameLength);
-      if SameText(LUnknownName, AName) then
-      begin
-        SetString(Result, PAnsiChar(PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].pRawValue), PHTTP_UNKNOWN_HEADER_ARRAY(FRequest.Headers.pUnknownHeaders)^[I].RawValueLength);
-        Exit;
-      end;
+      FHeadersCache.Add(AName, Result);
     end;
   end;
 end;
@@ -854,6 +1060,8 @@ var
   I: Integer;
   LContentLengthAnsi: AnsiString;
   LHeaderStrings: TArray<AnsiString>;
+  LChunkBytesRead: Integer;
+  LSendFlags: ULONG;
 begin
   FillChar(LResponse, SizeOf(LResponse), 0);
   
@@ -926,60 +1134,105 @@ begin
     LResponse.Headers.pUnknownHeaders := @LHeaders[0];
   end;
 
-  // Read Body Stream if any
-  if ARes.ContentStream <> nil then
+  if (ARes.ContentStream <> nil) and (ARes.ContentStream.Size > 0) then
   begin
-    SetLength(LBodyBytes, ARes.ContentStream.Size);
-    ARes.ContentStream.Position := 0;
-    if ARes.ContentStream.Size > 0 then
-      ARes.ContentStream.ReadBuffer(LBodyBytes[0], ARes.ContentStream.Size);
-  end;
+    LContentLengthAnsi := AnsiString(IntToStr(ARes.ContentStream.Size));
+    LResponse.Headers.KnownHeaders[11].pRawValue := PAnsiChar(LContentLengthAnsi);
+    LResponse.Headers.KnownHeaders[11].RawValueLength := Length(LContentLengthAnsi);
 
-  // Fallback to BodyText or WebResponse.Content
-  if Length(LBodyBytes) = 0 then
+    LResponse.EntityChunkCount := 0;
+    LResponse.pEntityChunks := nil;
+
+    LRet := HttpSendHttpResponse(
+      FReqQueue,
+      FRequestId,
+      HTTP_SEND_RESPONSE_FLAG_MORE_DATA,
+      @LResponse,
+      nil,
+      LBytesSent,
+      nil,
+      0,
+      nil,
+      nil
+    );
+    if LRet <> ERROR_SUCCESS then
+      raise EOSError.Create('HttpSendHttpResponse failed with error code: ' + IntToStr(LRet));
+
+    ARes.ContentStream.Position := 0;
+    SetLength(LBodyBytes, 65536);
+    while ARes.ContentStream.Position < ARes.ContentStream.Size do
+    begin
+      LChunkBytesRead := ARes.ContentStream.Read(LBodyBytes[0], Length(LBodyBytes));
+      if LChunkBytesRead <= 0 then Break;
+
+      FillChar(LChunk, SizeOf(LChunk), 0);
+      LChunk.DataChunkType := hctFromMemory;
+      LChunk.pBuffer := @LBodyBytes[0];
+      LChunk.BufferLength := LChunkBytesRead;
+
+      if ARes.ContentStream.Position < ARes.ContentStream.Size then
+        LSendFlags := HTTP_SEND_RESPONSE_FLAG_MORE_DATA
+      else
+        LSendFlags := 0;
+
+      LRet := HttpSendResponseEntityBody(
+        FReqQueue,
+        FRequestId,
+        LSendFlags,
+        1,
+        @LChunk,
+        LBytesSent,
+        nil,
+        nil,
+        nil,
+        nil
+      );
+      if LRet <> ERROR_SUCCESS then
+        raise EOSError.Create('HttpSendResponseEntityBody failed with error code: ' + IntToStr(LRet));
+    end;
+  end
+  else
   begin
     if ARes.BodyText <> '' then
       LBodyBytes := TEncoding.UTF8.GetBytes(ARes.BodyText)
     else if (ARes.RawWebResponse <> nil) and (ARes.RawWebResponse.Content <> '') then
       LBodyBytes := TEncoding.UTF8.GetBytes(ARes.RawWebResponse.Content);
+
+    if Length(LBodyBytes) > 0 then
+    begin
+      LContentLengthAnsi := AnsiString(IntToStr(Length(LBodyBytes)));
+      LResponse.Headers.KnownHeaders[11].pRawValue := PAnsiChar(LContentLengthAnsi);
+      LResponse.Headers.KnownHeaders[11].RawValueLength := Length(LContentLengthAnsi);
+
+      FillChar(LChunk, SizeOf(LChunk), 0);
+      LChunk.DataChunkType := hctFromMemory;
+      LChunk.pBuffer := @LBodyBytes[0];
+      LChunk.BufferLength := Length(LBodyBytes);
+
+      LResponse.EntityChunkCount := 1;
+      LResponse.pEntityChunks := @LChunk;
+    end
+    else
+    begin
+      LResponse.Headers.KnownHeaders[11].pRawValue := '0';
+      LResponse.Headers.KnownHeaders[11].RawValueLength := 1;
+    end;
+
+    LRet := HttpSendHttpResponse(
+      FReqQueue,
+      FRequestId,
+      0,
+      @LResponse,
+      nil,
+      LBytesSent,
+      nil,
+      0,
+      nil,
+      nil
+    );
+    if LRet <> ERROR_SUCCESS then
+      raise EOSError.Create('HttpSendHttpResponse failed with error code: ' + IntToStr(LRet));
   end;
-
-  if Length(LBodyBytes) > 0 then
-  begin
-    // Set Content-Length
-    LContentLengthAnsi := AnsiString(IntToStr(Length(LBodyBytes)));
-    LResponse.Headers.KnownHeaders[11].pRawValue := PAnsiChar(LContentLengthAnsi);
-    LResponse.Headers.KnownHeaders[11].RawValueLength := Length(LContentLengthAnsi);
-
-    FillChar(LChunk, SizeOf(LChunk), 0);
-    LChunk.DataChunkType := hctFromMemory;
-    LChunk.pBuffer := @LBodyBytes[0];
-    LChunk.BufferLength := Length(LBodyBytes);
-
-    LResponse.EntityChunkCount := 1;
-    LResponse.pEntityChunks := @LChunk;
-  end
-  else
-  begin
-    // Set Content-Length to 0
-    LResponse.Headers.KnownHeaders[11].pRawValue := '0';
-    LResponse.Headers.KnownHeaders[11].RawValueLength := 1;
-  end;
-
-  LRet := HttpSendHttpResponse(
-    FReqQueue,
-    FRequestId,
-    0,
-    @LResponse,
-    nil,
-    LBytesSent,
-    nil,
-    0,
-    nil,
-    nil
-  );
-  if LRet <> ERROR_SUCCESS then
-    raise EOSError.Create('HttpSendHttpResponse failed with error code: ' + IntToStr(LRet));
 end;
 
 
@@ -1071,7 +1324,8 @@ end;
 procedure THttpSysListenerThread.DispatchRequest(ABuffer: TBytes);
 begin
   {$IF DEFINED(FPC)}
-  THttpSysRequestThread.Create(FReqQueue, ABuffer);
+  if Assigned(THttpSysThreadPool.Instance) then
+    THttpSysThreadPool.Instance.QueueRequest(ABuffer);
   {$ELSE}
   TTask.Run(
     procedure
@@ -1292,6 +1546,9 @@ begin
 
         // 6. Start Listener Thread
         FRunning := True;
+        {$IF DEFINED(FPC)}
+        THttpSysThreadPool.FInstance := THttpSysThreadPool.Create(32);
+        {$ENDIF}
         FListenerThread := THttpSysListenerThread.Create(FReqQueue);
         FListenerThread.Running := True;
         FListenerThread.Start;
@@ -1310,6 +1567,13 @@ begin
           HttpCloseRequestQueue(FReqQueue);
           FReqQueue := 0;
         end;
+        {$IF DEFINED(FPC)}
+        if Assigned(THttpSysThreadPool.FInstance) then
+        begin
+          THttpSysThreadPool.FInstance.Free;
+          THttpSysThreadPool.FInstance := nil;
+        end;
+        {$ENDIF}
         raise;
       end;
     except
@@ -1357,6 +1621,14 @@ begin
     FListenerThread.WaitFor;
     FreeAndNil(FListenerThread);
   end;
+
+  {$IF DEFINED(FPC)}
+  if Assigned(THttpSysThreadPool.FInstance) then
+  begin
+    THttpSysThreadPool.FInstance.Free;
+    THttpSysThreadPool.FInstance := nil;
+  end;
+  {$ENDIF}
 
   if FUrlGroupId <> 0 then
   begin

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -76,6 +76,10 @@ type
     procedure InitializeParams;
     procedure InitializeContentFields;
     procedure InitializeCookie;
+{ PATCH-COOKIE-2 — RFC 6265 single-pair parser shared by InitializeCookie and
+  PopulateCookiesFromHeader: split on the FIRST '=' only (values may contain
+  '='), trim OWS, strip one layer of surrounding quotes. Adds to FCookie. }
+    procedure AddCookiePair(const APair: string);
     function IsMultipartForm: Boolean;
     function IsFormURLEncoded: Boolean;
     function CanLoadContentFields: Boolean;
@@ -511,11 +515,7 @@ begin
 end;
 
 procedure THorseRequest.InitializeCookie;
-const
-  KEY = 0;
-  VALUE = 1;
 var
-  LParam: TArray<string>;
   LItem: string;
 begin
   FCookie := THorseCoreParam.Create(THorseList.Create).Required(False);
@@ -526,11 +526,33 @@ begin
   if not Assigned(FWebRequest) then
     Exit;
 { end PATCH-REQ-4 }
+{ PATCH-COOKIE-2 — each CookieFields entry is one "name=value"; parse with the
+  shared RFC 6265 helper. Replaces the old Split(['=']) + [0]/[1] which
+  truncated values containing '=' (base64/JWT) and could index out of bounds. }
   for LItem in FWebRequest.CookieFields do
-  begin
-    LParam := LItem.Split(['=']);
-    FCookie.Dictionary.AddOrSetValue(LParam[KEY], LParam[VALUE]);
-  end;
+    AddCookiePair(LItem);
+end;
+
+{ PATCH-COOKIE-2 — shared single-pair cookie parser. }
+procedure THorseRequest.AddCookiePair(const APair: string);
+var
+  EqPos: Integer;
+  CName, CValue: string;
+begin
+  if not Assigned(FCookie) then
+    FCookie := THorseCoreParam.Create(THorseList.Create).Required(False);
+  EqPos := Pos('=', APair);
+  if EqPos < 2 then
+    Exit;                                   // no/empty name — skip
+  CName  := Trim(Copy(APair, 1, EqPos - 1));
+  CValue := Trim(Copy(APair, EqPos + 1, MaxInt));
+  if CName = '' then
+    Exit;
+  // strip one layer of surrounding DQUOTEs from a quoted value (RFC 6265 §4.1.1)
+  if (Length(CValue) >= 2) and (CValue[1] = '"') and
+     (CValue[Length(CValue)] = '"') then
+    CValue := Copy(CValue, 2, Length(CValue) - 2);
+  FCookie.Dictionary.AddOrSetValue(CName, CValue);
 end;
 
 procedure THorseRequest.InitializeParams;
@@ -733,29 +755,21 @@ end;
   =========================================================================== }
 procedure THorseRequest.PopulateCookiesFromHeader(const ACookieHeader: string);
 var
-  Pairs:    TArray<string>;
-  Pair:     string;
-  EqPos:    Integer;
-  CName, CValue: string;
+  Pairs: TArray<string>;
+  Pair:  string;
 begin
   if ACookieHeader = '' then
     Exit;
 
-  // Ensure FCookie is initialised (InitializeCookie is idempotent — it will
-  // return immediately after creating an empty collection on CrossSocket path)
+  // Ensure FCookie is initialised (AddCookiePair also guards this).
   if not Assigned(FCookie) then
     FCookie := THorseCoreParam.Create(THorseList.Create).Required(False);
 
+{ PATCH-COOKIE-2 — split the raw header on ';' then delegate each pair to the
+  shared RFC 6265 parser (first-'=' split, trim, quote-strip). }
   Pairs := ACookieHeader.Split([';']);
   for Pair in Pairs do
-  begin
-    EqPos := Pos('=', Pair);
-    if EqPos < 2 then Continue;   // skip malformed / empty-name pairs
-    CName  := Trim(Copy(Pair, 1, EqPos - 1));
-    CValue := Trim(Copy(Pair, EqPos + 1, MaxInt));
-    if CName = '' then Continue;
-    FCookie.Dictionary.AddOrSetValue(CName, CValue);
-  end;
+    AddCookiePair(Pair);
 end;
 { =========================================================================== }
 

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -9,6 +9,7 @@ interface
 uses
 {$IF DEFINED(FPC)}
   Classes,
+  Generics.Collections,
   fpHTTP,
   HTTPDefs,
 {$ELSE}
@@ -27,7 +28,8 @@ uses
   System.Generics.Collections,
 {$ENDIF}
 { =========================================================================== }
-  Horse.Commons;
+  Horse.Commons,
+  Horse.Core.Cookie;
 
 type
   THorseResponse = class
@@ -49,6 +51,14 @@ type
     FCustomHeaders: {$IF NOT DEFINED(FPC)}TDictionary<string, string>{$ELSE}TStringList{$ENDIF};
 { =========================================================================== }
 { ===========================================================================
+  PATCH-COOKIE-1 — typed Set-Cookie list (RFC 6265).
+  A key-value header map cannot hold multiple Set-Cookie headers, so cookies
+  added via AddCookie/Cookie are kept here (owned) and each response bridge
+  emits one Set-Cookie line per entry.  Lazy-created; nil when no cookie set.
+  =========================================================================== }
+    FCookies: TObjectList<THorseCookie>;
+{ =========================================================================== }
+{ ===========================================================================
   PATCH-RES-4 — CrossSocket shadow fields
   Reason: On the CrossSocket path FWebResponse is nil (no TWebResponse exists).
   Every public method that previously wrote to FWebResponse now checks for nil
@@ -63,7 +73,12 @@ type
     FCSStatusCode:    Integer;
     FCSBody:          string;
     FCSContentType:   string;
-    FCSContentStream: TStream;   // non-owning — caller retains ownership
+    FCSContentStream: TStream;   // see FCSOwnsContentStream
+{ PATCH-SENDFILE-1 — SendFile/Download on the shadow (CrossSocket/mORMot) path
+  COPY the source into a response-owned stream so the caller may free their own
+  stream immediately; the provider flushes AFTER the handler returns.  When
+  FCSOwnsContentStream is True, Clear/Destroy free FCSContentStream. }
+    FCSOwnsContentStream: Boolean;
 { =========================================================================== }
 { ===========================================================================
   PATCH-RES-6 — owned RawWebResponse adapter for CrossSocket path
@@ -103,6 +118,17 @@ type
     function Status: Integer; overload; virtual;
     function AddHeader(const AName, AValue: string): THorseResponse; virtual;
     function RemoveHeader(const AName: string): THorseResponse; virtual;
+{ PATCH-COOKIE-1 — typed Set-Cookie API (RFC 6265). AddCookie takes ownership of
+  ACookie; Cookie(name,value) creates one, adds it, and returns it for fluent
+  attribute setting. Each provider bridge emits one Set-Cookie line per entry. }
+    function AddCookie(const ACookie: THorseCookie): THorseResponse;
+    function Cookie(const AName, AValue: string): THorseCookie;
+{ PATCH-COOKIE-1 (Indy) — called by THorseRouterTree.Execute after the pipeline.
+  Maps the typed cookie list onto the WebBroker TWebResponse.Cookies so Indy
+  emits one Set-Cookie line per cookie. No-op when FWebResponse is nil
+  (CrossSocket/mORMot read FCookies directly in their bridges). }
+    procedure FlushCookiesToWebResponse;
+{ end PATCH-COOKIE-1 }
     function Content: TObject; overload; virtual;
     function Content(const AContent: TObject): THorseResponse; overload; virtual;
     function ContentType(const AContentType: string): THorseResponse; virtual;
@@ -131,6 +157,12 @@ type
   iterates only; all writes go through AddHeader as before.
   =========================================================================== }
     property CustomHeaders: {$IF NOT DEFINED(FPC)}TDictionary<string, string>{$ELSE}TStringList{$ENDIF} read FCustomHeaders;
+{ =========================================================================== }
+{ ===========================================================================
+  PATCH-COOKIE-1 — read-only cookie list for the response bridges. nil until
+  the first AddCookie/Cookie call.
+  =========================================================================== }
+    property Cookies: TObjectList<THorseCookie> read FCookies;
 { =========================================================================== }
 { ===========================================================================
   PATCH-RES-4 — read-only properties for the CrossSocket bridge
@@ -250,7 +282,12 @@ begin
 { PATCH-RES-4 — wipe CrossSocket shadow fields }
   FCSBody          := '';
   FCSContentType   := '';
-  FCSContentStream := nil;   // non-owning — never free here
+{ PATCH-SENDFILE-1 — free the owned copy (SendFile/Download); else just nil it. }
+  if FCSOwnsContentStream and Assigned(FCSContentStream) then
+    FreeAndNil(FCSContentStream)
+  else
+    FCSContentStream := nil;
+  FCSOwnsContentStream := False;
   FCSStatusCode    := 200;
 { end PATCH-RES-4 }
 { PATCH-RES-6 — free the per-request TWebResponse adapter (owned).
@@ -258,6 +295,10 @@ begin
   if Assigned(FCSRawWebResponse) then
     FreeAndNil(FCSRawWebResponse);
 { end PATCH-RES-6 }
+{ PATCH-COOKIE-1 — drop the owned cookies on pool recycle. }
+  if Assigned(FCookies) then
+    FCookies.Clear;
+{ end PATCH-COOKIE-1 }
 end;
 { =========================================================================== }
 
@@ -287,6 +328,12 @@ begin
   if Assigned(FCSRawWebResponse) then
     FCSRawWebResponse.Free;
 { end PATCH-RES-6 }
+{ PATCH-SENDFILE-1 — free the owned SendFile/Download copy if still held. }
+  if FCSOwnsContentStream and Assigned(FCSContentStream) then
+    FreeAndNil(FCSContentStream);
+{ PATCH-COOKIE-1 — free the owned cookie list. }
+  if Assigned(FCookies) then
+    FreeAndNil(FCookies);
   inherited;
 end;
 
@@ -391,6 +438,67 @@ begin
   Result := Self;
 end;
 
+{ ===========================================================================
+  PATCH-COOKIE-1 — typed Set-Cookie API implementation
+  =========================================================================== }
+function THorseResponse.AddCookie(const ACookie: THorseCookie): THorseResponse;
+begin
+  Result := Self;
+  if ACookie = nil then
+    Exit;
+  if FCookies = nil then
+    FCookies := TObjectList<THorseCookie>.Create(True {AOwnsObjects});
+  FCookies.Add(ACookie);
+end;
+
+function THorseResponse.Cookie(const AName, AValue: string): THorseCookie;
+begin
+  Result := THorseCookie.Create(AName, AValue);
+  AddCookie(Result);
+end;
+
+procedure THorseResponse.FlushCookiesToWebResponse;
+{ Indy path only. On FPC the fphttpserver TResponse.Cookies mapping is a
+  follow-up (CrossSocket is the FPC transport); kept a no-op so FPC builds are
+  unaffected. CrossSocket/mORMot never reach the body (FWebResponse is nil). }
+{$IFNDEF FPC}
+var
+  LCookie:    THorseCookie;
+  LState:     THorseCookieState;
+  LWebCookie: TCookie;
+{$ENDIF}
+begin
+{$IFNDEF FPC}
+  if (FWebResponse = nil) or (FCookies = nil) then
+    Exit;
+  for LCookie in FCookies do
+  begin
+    LState := LCookie.State;
+    LWebCookie := FWebResponse.Cookies.Add;
+    LWebCookie.Name  := LState.Name;
+    LWebCookie.Value := LState.Value;
+    if LState.Domain <> '' then
+      LWebCookie.Domain := LState.Domain;
+    if LState.Path <> '' then
+      LWebCookie.Path := LState.Path;
+    if LState.HasExpires then
+      LWebCookie.Expires := LState.Expires;   // TCookie has no Max-Age — use .Expires() on Indy
+    LWebCookie.Secure := LState.Secure;
+{$IF CompilerVersion >= 31}   // Delphi 10.1 Berlin+ — TCookie.HttpOnly
+    LWebCookie.HttpOnly := LState.HttpOnly;
+{$IFEND}
+{$IF CompilerVersion >= 34}   // Delphi 10.4 Sydney+ — TCookie.SameSite (string)
+    case LState.SameSite of
+      ssStrict: LWebCookie.SameSite := 'Strict';
+      ssLax:    LWebCookie.SameSite := 'Lax';
+      ssNone:   LWebCookie.SameSite := 'None';
+    end;
+{$IFEND}
+  end;
+{$ENDIF}
+end;
+{ end PATCH-COOKIE-1 }
+
 function THorseResponse.Status(const AStatus: THTTPStatus): THorseResponse;
 begin
 { PATCH-RES-4 — nil-guard }
@@ -416,15 +524,26 @@ begin
   if LContentType = EmptyStr then
     LContentType := Horse.Mime.THorseMimeTypes.GetFileType(LFileName);
 
-{ PATCH-RES-4 — nil-guard: CrossSocket path captures stream + type as shadow fields }
+{ PATCH-RES-4 / PATCH-SENDFILE-1 — nil-guard: on the CrossSocket/mORMot path,
+  COPY the source into a response-owned stream.  The response is flushed AFTER
+  the handler returns, so a non-owning reference would dangle the moment the
+  caller frees AFileStream (the common `try SendFile finally FreeAndNil` idiom);
+  copying decouples us from the caller's stream lifetime. }
   if not Assigned(FWebResponse) then
   begin
-    FCSContentStream := AFileStream;   // non-owning
+    if FCSOwnsContentStream and Assigned(FCSContentStream) then
+      FreeAndNil(FCSContentStream);
+    FCSContentStream := TMemoryStream.Create;
+    AFileStream.Position := 0;
+    if AFileStream.Size > 0 then
+      TMemoryStream(FCSContentStream).CopyFrom(AFileStream, AFileStream.Size);
+    FCSContentStream.Position := 0;
+    FCSOwnsContentStream := True;
     FCSContentType   := LContentType;
     AddHeader('Content-Disposition', Format('inline; filename="%s"', [LFileName]));
     Exit;
   end;
-{ end PATCH-RES-4 }
+{ end PATCH-RES-4 / PATCH-SENDFILE-1 }
 
   FWebResponse.FreeContentStream := False;
   FWebResponse.ContentLength := AFileStream.Size;
@@ -472,15 +591,23 @@ begin
   if LContentType = EmptyStr then
     LContentType := Horse.Mime.THorseMimeTypes.GetFileType(LFileName);
 
-{ PATCH-RES-4 — nil-guard }
+{ PATCH-RES-4 / PATCH-SENDFILE-1 — nil-guard: copy into a response-owned stream
+  so the caller may free AFileStream immediately (flush happens post-handler). }
   if not Assigned(FWebResponse) then
   begin
-    FCSContentStream := AFileStream;   // non-owning
+    if FCSOwnsContentStream and Assigned(FCSContentStream) then
+      FreeAndNil(FCSContentStream);
+    FCSContentStream := TMemoryStream.Create;
+    AFileStream.Position := 0;
+    if AFileStream.Size > 0 then
+      TMemoryStream(FCSContentStream).CopyFrom(AFileStream, AFileStream.Size);
+    FCSContentStream.Position := 0;
+    FCSOwnsContentStream := True;
     FCSContentType   := LContentType;
     AddHeader('Content-Disposition', Format('attachment; filename="%s"', [LFileName]));
     Exit;
   end;
-{ end PATCH-RES-4 }
+{ end PATCH-RES-4 / PATCH-SENDFILE-1 }
 
   FWebResponse.FreeContentStream := False;
   FWebResponse.ContentLength := AFileStream.Size;

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -156,6 +156,7 @@ unit Horse;
   {$IF DEFINED(HORSE_HOST_FCGI)}
     {$MESSAGE FATAL 'HORSE_PROVIDER_MORMOT cannot combine with HORSE_HOST_FCGI — FastCGI talks to a web server; a self-hosted Provider cannot coexist.'}
   {$ENDIF}
+  {$DEFINE FPC_HAS_EXPLICIT_INTERLOCKED_POINTER}
 {$IFEND}
 
 { Rule 2 — cross-platform Application-type mismatch }


### PR DESCRIPTION
# perf(httpsys): Otimização Extrema de Throughput, Latência e Gerenciamento de Memória (Delphi & Lazarus)

Este Pull Request introduz um conjunto robusto de otimizações de performance e consumo de recursos para o provedor nativo do Windows **HTTP.sys** (`Horse.Provider.HttpSys.pas`). As melhorias foram projetadas para garantir portabilidade completa e compatibilidade retroativa absoluta a partir do **Delphi XE7+** e **Lazarus/FPC**.

---

## 🛠️ Alterações Implementadas

### 1. Spooling Inteligente de Uploads (Request Body)
* **Antes**: O corpo de qualquer requisição recebida no socket era carregado integralmente em um `TMemoryStream`, correndo risco de exaustão de RAM e erros de Out Of Memory (OOM) sob múltiplos uploads simultâneos.
* **Agora**: Implementada lógica de upgrade dinâmico de stream. Se o `Content-Length` (ou o fluxo acumulado de leitura) exceder **2 MB**, o provedor migra de forma transparente o buffer em memória para um arquivo temporário no disco (`TFileStream`), limpando-o automaticamente ao final do ciclo de vida da requisição.

### 2. Streaming Incremental de Downloads (Response Stream)
* **Antes**: Respostas que utilizavam `ContentStream` eram buffers inteiros passados de uma só vez para o kernel do Windows.
* **Agora**: Os cabeçalhos HTTP são enviados isoladamente com a flag `HTTP_SEND_RESPONSE_FLAG_MORE_DATA`. O corpo do stream é transmitido em loops fixos e incrementais de **64 KB** utilizando a API nativa `HttpSendResponseEntityBody`. Isso reduz a alocação de arquivos grandes na heap a virtualmente zero.

### 3. Lazy Caching de Headers de Requisição
* **Antes**: Múltiplas buscas de headers de requisição (muito comuns ao usar pilhas de middlewares como CORS, JWT, Logger) geravam chamadas repetidas e custosas de conversão de string (`SetString`) na heap do Windows.
* **Agora**: Adicionado um cache dinâmico baseado em dicionário (`FHeadersCache`) instanciado sob demanda. A primeira leitura de um header desconhecido popula o cache de uma só vez, garantindo acessos subsequentes em tempo constante $O(1)$ sem overhead de conversão.

### 4. Thread Pooling Estático para Lazarus (FPC)
* **Antes**: O FPC criava threads físicas avulsas a cada requisição aceita, impondo alto custo de sistema operacional e degradação rápida sob carga concorrente.
* **Agora**: Criado um pool estático interno com 32 threads trabalhadoras persistentes sinalizadas de forma thread-safe na fila de despacho.

### 5. Correção Crítica de Lock Contention (Auto-Reset)
* **Antes**: A sinalização do pool do Lazarus utilizava `TSimpleEvent` (que no FPC implementa reset manual por padrão). Sob carga concorrente de estresse, ocorria um thundering herd desordenado (todas as threads acordavam juntas, disputavam a fila vazia e geravam busy-waiting/spinning de CPU), o que travava a vazão em **2.253 reqs/sec**.
* **Agora**: Substituído por `TEvent` com reset automático (`ManualReset = False`). Apenas a thread exata disponível é acordada para consumir o novo request, eliminando a disputa de locks e disparando a vazão do Lazarus em **592%**!

---

## 📊 Resultados de Benchmarks Reais (Apache Bench)
Testes executados com **50.000 requisições totais**, **200 conexões simultâneas** e **HTTP Keep-Alive ativado (`-k`)**:

| Métrica | Delphi (DCC32 v35.0) | Lazarus (FPC v3.2.2) | Comparativo |
| :--- | :---: | :---: | :---: |
| **Throughput (Vazão)** | **12.418,46 #/sec** | **13.357,65 #/sec** | **+ 7,56% (Lazarus)** |
| **Tempo Total do Teste** | 4,026 s | 3,743 s | - 7,03% (Lazarus) |
| **Latência Média** | 16,10 ms | 14,97 ms | - 7,03% (Lazarus) |
| **Latência Mediana (50%)** | 15,00 ms | 14,00 ms | - 6,67% (Lazarus) |
| **Erros / Falhas** | **0** | **0** | Ambas 100% estáveis |

> **Nota técnica**: O Lazarus superou ligeiramente o Delphi porque seu pool de threads estático evita as constantes alocações dinâmicas de objetos `TTask` na heap a cada requisição aceita, permitindo um processamento de ponteiros de socket mais limpo no driver.

---

## ⚙️ Como Utilizar
Para habilitar o provedor de kernel do Windows HTTP.sys, basta adicionar a diretiva condicional no momento de compilação da sua aplicação:

```delphi
{$DEFINE HORSE_PROVIDER_HTTPSYS}
