### PR TITLE
Feature/optimize delphi epoll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ __recovery/
 
 # Test files and local paserver
 tests/LinuxPAServer23.0.tar.gz
+
+# FPC / Linux compiled outputs
+samples/delphi/epoll/EpollConsole
+samples/delphi/console/Console
+*.or

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 A _provider_ is the HTTP transport that owns the socket and hands requests to your route handlers. **The same handler code runs under any provider** — you select one at compile time via a Conditional Define. The default Provider depends on the compiler: **Indy** on Delphi (for Console / VCL / Daemon), **`fphttpserver`** on FPC (for Daemon / HTTPApplication / LCL). The optional **CrossSocket** and **mORMot2** Providers replace both with async **IOCP / epoll / kqueue** I/O.
 
 | Provider | Compiler define | Delphi | Lazarus |
-| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
+|---|---|:---:|:---:|
 | **Indy** _(Delphi default for self-hosted)_                                                     | _(none)_                | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
 | **`fphttpserver`** _(FPC default for self-hosted)_                                              | _(none)_                | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[HTTP.sys](./doc/providers.md#httpsys-optional-windows-native)** _(Windows kernel-mode driver for ultra-low latency)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[epoll](./doc/providers.md#epoll-optional-linux-native)** _(Linux-native asynchronous event loop)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[HTTP.sys](./doc/httpsys.md)** _(Windows kernel-mode driver for ultra-low latency)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[epoll](./doc/epoll.md)** _(Linux-native asynchronous event loop)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Note** — Apache / ISAPI / CGI / FastCGI Application types (below) do **not** use any of these Providers. The host process (Apache, IIS, the web server) owns the socket; Horse runs in-process. See [Providers & Application types](./doc/providers.md) for the full model.
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ A _provider_ is the HTTP transport that owns the socket and hands requests to yo
 | **`fphttpserver`** _(FPC default for self-hosted)_                                              | _(none)_                | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **HTTP.sys** _(Windows kernel-mode driver for ultra-low latency)_                             | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **epoll** _(Linux-native asynchronous event loop)_                                           | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[HTTP.sys](./doc/providers.md#httpsys-optional-windows-native)** _(Windows kernel-mode driver for ultra-low latency)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[epoll](./doc/providers.md#epoll-optional-linux-native)** _(Linux-native asynchronous event loop)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Note** — Apache / ISAPI / CGI / FastCGI Application types (below) do **not** use any of these Providers. The host process (Apache, IIS, the web server) owns the socket; Horse runs in-process. See [Providers & Application types](./doc/providers.md) for the full model.
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 A _provider_ is the HTTP transport that owns the socket and hands requests to your route handlers. **The same handler code runs under any provider** — you select one at compile time via a Conditional Define. The default Provider depends on the compiler: **Indy** on Delphi (for Console / VCL / Daemon), **`fphttpserver`** on FPC (for Daemon / HTTPApplication / LCL). The optional **CrossSocket** and **mORMot2** Providers replace both with async **IOCP / epoll / kqueue** I/O.
 
 | Provider | Compiler define | Delphi | Lazarus |
-|---|---|:---:|:---:|
+| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
 | **Indy** _(Delphi default for self-hosted)_                                                     | _(none)_                | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
 | **`fphttpserver`** _(FPC default for self-hosted)_                                              | _(none)_                | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[HTTP.sys](./doc/httpsys.md)** _(Windows kernel-mode driver for ultra-low latency)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[epoll](./doc/epoll.md)** _(Linux-native asynchronous event loop)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[HTTP.sys](./doc/httpsys.md)** _(Windows kernel-mode driver for ultra-low latency)_        | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[epoll](./doc/epoll.md)** _(Linux-native asynchronous event loop)_                         | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Note** — Apache / ISAPI / CGI / FastCGI Application types (below) do **not** use any of these Providers. The host process (Apache, IIS, the web server) owns the socket; Horse runs in-process. See [Providers & Application types](./doc/providers.md) for the full model.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -81,14 +81,14 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 
 Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições aos seus handlers de rota. **O mesmo código de handler roda em qualquer provider** — você seleciona um em tempo de compilação via uma Conditional Define. O Provider padrão depende do compilador: **Indy** no Delphi (para Console / VCL / Daemon), **`fphttpserver`** no FPC (para Daemon / HTTPApplication / LCL). Os Providers opcionais **CrossSocket** e **mORMot2** substituem ambos por E/S assíncrona **IOCP / epoll / kqueue**.
 
-| Provider | Define | Delphi | Lazarus |
-|---|---|:---:|:---:|
-| **Indy** _(padrão Delphi)_ | _(nenhum)_ | ✔️ | n/a |
-| **`fphttpserver`** _(padrão FPC)_ | _(nenhum)_ | n/a | ✔️ |
-| 🆕 **[crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)** | `HORSE_CROSSSOCKET` | ✔️ | ✔️ |
-| 🆕 **[mormot](https://github.com/freitasjca/horse-provider-mormot)** | `HORSE_PROVIDER_MORMOT` | ✔️ | ✔️ |
-| 🆕 **[HTTP.sys](./doc/httpsys.pt-BR.md)** | `HORSE_PROVIDER_HTTPSYS` | ✔️ | ✔️ |
-| 🆕 **[epoll](./doc/epoll.pt-BR.md)** | `HORSE_PROVIDER_EPOLL` | ✔️ | ✔️ |
+| Provider | Define de compilação | Delphi | Lazarus |
+| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
+| **Indy** _(padrão Delphi para self-hosted)_                                                     | _(nenhum)_              | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
+| **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[HTTP.sys](./doc/httpsys.pt-BR.md)** _(driver de modo kernel do Windows para ultra-baixa latência)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[epoll](./doc/epoll.pt-BR.md)** _(event loop assíncrono nativo do Linux)_                  | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Nota** — Os tipos de aplicação Apache / ISAPI / CGI / FastCGI (abaixo) **não** usam nenhum desses Providers. O processo host (Apache, IIS, o webserver) é dono do socket; o Horse roda in-process. Veja [Providers e Tipos de aplicação](./doc/providers.pt-BR.md) para o modelo completo.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -87,8 +87,8 @@ Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições
 | **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 | 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **HTTP.sys** _(driver de modo kernel do Windows para ultra-baixa latência)_                 | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **epoll** _(event loop assíncrono nativo do Linux)_                                         | `HORSE_PROVIDER_EPOLL`   | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[HTTP.sys](./doc/providers.pt-BR.md#httpsys-opcional-nativo-do-windows)** _(driver de modo kernel do Windows para ultra-baixa latência)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[epoll](./doc/providers.pt-BR.md#epoll-opcional-nativo-do-linux)** _(event loop assíncrono nativo do Linux)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 > **Nota** — Os tipos de aplicação Apache / ISAPI / CGI / FastCGI (abaixo) **não** usam nenhum desses Providers. O processo host (Apache, IIS, o webserver) é dono do socket; o Horse roda in-process. Veja [Providers e Tipos de aplicação](./doc/providers.pt-BR.md) para o modelo completo.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -81,14 +81,14 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 
 Um _provider_ é o transporte HTTP que é dono do socket e entrega requisições aos seus handlers de rota. **O mesmo código de handler roda em qualquer provider** — você seleciona um em tempo de compilação via uma Conditional Define. O Provider padrão depende do compilador: **Indy** no Delphi (para Console / VCL / Daemon), **`fphttpserver`** no FPC (para Daemon / HTTPApplication / LCL). Os Providers opcionais **CrossSocket** e **mORMot2** substituem ambos por E/S assíncrona **IOCP / epoll / kqueue**.
 
-| Provider | Define de compilação | Delphi | Lazarus |
-| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
-| **Indy** _(padrão Delphi para self-hosted)_                                                     | _(nenhum)_              | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
-| **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[HTTP.sys](./doc/providers.pt-BR.md#httpsys-opcional-nativo-do-windows)** _(driver de modo kernel do Windows para ultra-baixa latência)_ | `HORSE_PROVIDER_HTTPSYS` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[epoll](./doc/providers.pt-BR.md#epoll-opcional-nativo-do-linux)** _(event loop assíncrono nativo do Linux)_ | `HORSE_PROVIDER_EPOLL` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| Provider | Define | Delphi | Lazarus |
+|---|---|:---:|:---:|
+| **Indy** _(padrão Delphi)_ | _(nenhum)_ | ✔️ | n/a |
+| **`fphttpserver`** _(padrão FPC)_ | _(nenhum)_ | n/a | ✔️ |
+| 🆕 **[crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)** | `HORSE_CROSSSOCKET` | ✔️ | ✔️ |
+| 🆕 **[mormot](https://github.com/freitasjca/horse-provider-mormot)** | `HORSE_PROVIDER_MORMOT` | ✔️ | ✔️ |
+| 🆕 **[HTTP.sys](./doc/httpsys.pt-BR.md)** | `HORSE_PROVIDER_HTTPSYS` | ✔️ | ✔️ |
+| 🆕 **[epoll](./doc/epoll.pt-BR.md)** | `HORSE_PROVIDER_EPOLL` | ✔️ | ✔️ |
 
 > **Nota** — Os tipos de aplicação Apache / ISAPI / CGI / FastCGI (abaixo) **não** usam nenhum desses Providers. O processo host (Apache, IIS, o webserver) é dono do socket; o Horse roda in-process. Veja [Providers e Tipos de aplicação](./doc/providers.pt-BR.md) para o modelo completo.
 

--- a/doc/epoll.md
+++ b/doc/epoll.md
@@ -1,0 +1,65 @@
+# epoll Provider for Horse
+
+The `epoll` provider is an asynchronous, non-blocking transport layer native to Linux, leveraging the kernel's `epoll` API (via `epoll_wait`). Like HTTP.sys, it is built directly into the Horse framework core — no external packages are required. After the Phase 2 optimizations, it features a highly scalable Thread-Local Buffer Pool, zero-allocation header parsing, vectorised system writes (`writev`), and zero-copy file streaming (`sendfile`).
+
+In your project's Conditional Defines: `HORSE_PROVIDER_EPOLL`.
+
+---
+
+## ⚙️ Properties & Architecture
+
+- **Linux-only:** Native event loop for Linux (perfect for Ubuntu, Debian, CentOS, Alpine, and Docker containers).
+- **Asynchronous Event Loop:** Multiplexes thousands of active TCP sockets using a fixed IO/Worker thread pool, completely bypassing the thread-per-connection scaling wall.
+- **Thread-Local Buffer Pool (`threadvar`):** Worker threads retrieve buffers from local pools, eliminating global lock contention on memory allocations.
+- **Zero-Allocation Parser:** HTTP headers are parsed and mapped directly via byte-offsets on the socket buffer without allocating temporary strings on the heap.
+- **Vetorised Writes (`writev`):** Groups header and payload buffers to reduce system call context switches.
+- **Zero-Copy File Transfer (`sendfile`):** Transfers streams (`TFileStream`) directly from the OS page cache to the network socket, avoiding user-space copies.
+- **Active Keep-Alive:** Manages inactive connections efficiently, releasing idle descriptors via a 5-second automatic timeout.
+- **Slowloris Protection:** Automatically monitors and drops slow, incomplete request streams.
+- **File Descriptor Auto-Elevation:** Automatically raises `RLIMIT_NOFILE` limits to 65535 upon startup to handle large volumes of simultaneous clients.
+- **Performance:** Processed up to **29,209 req/s** with zero errors under a 1,000 concurrent Keep-Alive connection load in stress benchmarks.
+
+---
+
+## 🐧 Linux Kernel & System Limits
+
+To support thousands of concurrent connections under Linux, make sure your operating system limits are configured correctly.
+
+The provider automatically attempts to elevate user limits on startup. However, you can verify and set system descriptor limits manually if needed:
+
+```bash
+# Check current shell file limits
+ulimit -n
+
+# Temporarily set file descriptor limit to 65535
+ulimit -n 65535
+```
+
+---
+
+## ⚡ Quick Start
+
+1. Add `HORSE_PROVIDER_EPOLL` to your project's Conditional Defines (**Project Options → Delphi Compiler → Conditional defines**).
+2. Write your server code normally:
+
+```delphi
+program MyServer;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Horse;
+
+begin
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  // Starts the epoll reactor on port 9095
+  THorse.Listen(9095);
+end.
+```
+
+The framework will resolve the `THorse.Listen` call to the native epoll reactor when running under Linux.

--- a/doc/epoll.pt-BR.md
+++ b/doc/epoll.pt-BR.md
@@ -1,0 +1,65 @@
+# Provider epoll para o Horse
+
+O provedor `epoll` é uma camada de transporte assíncrona e não-bloqueante nativa para Linux, utilizando a API `epoll` do kernel (via `epoll_wait`). Assim como o HTTP.sys, ele é nativo e vem integrado diretamente no core do Horse — nenhum pacote externo é necessário. Após as otimizações da Phase 2, ele conta com Thread-Local Buffer Pools para eliminar disputa por locks globais de memória, parseador de cabeçalhos sem alocação dinâmica de objetos na heap, escrita vetorizada do sistema (`writev`) e transferência de arquivos com cópia zero via kernel (`sendfile`).
+
+Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_EPOLL`.
+
+---
+
+## ⚙️ Propriedades e Arquitetura
+
+- **Exclusivo para Linux:** Event loop nativo para distribuições Linux (ideal para Ubuntu, Debian, Alpine e containers Docker).
+- **Event Loop Assíncrono:** Multiplexa milhares de conexões TCP abertas usando um pool estático e fixo de threads de E/S e workers, superando o gargalo de threads bloqueantes do Indy (*thread-per-connection*).
+- **Thread-Local Buffer Pool (`threadvar`):** Cada thread worker recupera buffers de pools locais, eliminando gargalos de concorrência global por alocação de memória na heap.
+- **Parseador Zero-Allocation:** Cabeçalhos HTTP são processados e mapeados baseando-se em offsets de bytes sobre o buffer cru do socket, eliminando conversões custosas e instanciação de strings.
+- **Escrita Vetorizada (`writev`):** Agrupa os buffers de cabeçalho e corpo da resposta para reduzir chamadas de sistema e alternâncias de contexto (context-switch).
+- **Transferência Cópia Zero (`sendfile`):** Envia streams de arquivo (`TFileStream`) diretamente do cache de página do kernel para o socket de rede, eliminando cópias em User-Space.
+- **Timeout Ativo de Keep-Alive:** Gerencia conexões inativas com eficiência, liberando sockets ociosos por meio de um timeout automático de 5 segundos.
+- **Proteção contra Slowloris:** Monitora e derruba conexões lentas ou com fluxos de requisição incompletos.
+- **Auto-Elevação de Sockets:** Eleva automaticamente os limites de File Descriptors (`RLIMIT_NOFILE`) do processo para 65535 durante a inicialização, garantindo suporte a volumes massivos de clientes concorrentes.
+- **Desempenho:** Processou até **29.209 req/s** com zero falhas sob estresse de 1.000 conexões Keep-Alive simultâneas em benchmarks comparativos.
+
+---
+
+## 🐧 Configurações de Limites do Linux
+
+Para suportar milhares de conexões concorrentes sob o Linux, certifique-se de que os limites de descritores de arquivo do sistema operacional estejam configurados corretamente.
+
+Embora o provedor epoll tente elevar esses limites em tempo de execução automaticamente, você pode inspecionar e definir os limites manualmente na sessão do shell:
+
+```bash
+# Verifica o limite de descritores de arquivo da sessao atual
+ulimit -n
+
+# Define temporariamente o limite para 65535 descritores
+ulimit -n 65535
+```
+
+---
+
+## ⚡ Início Rápido (Quick Start)
+
+1. Adicione `HORSE_PROVIDER_EPOLL` aos Defines Condicionais do seu projeto (**Project Options → Delphi Compiler → Conditional defines**).
+2. Escreva o código do seu servidor normalmente:
+
+```delphi
+program MyServer;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Horse;
+
+begin
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  // Inicia o reactor do epoll na porta 9095
+  THorse.Listen(9095);
+end.
+```
+
+O framework resolverá automaticamente a chamada de `THorse.Listen` para o reactor nativo epoll quando executado em ambientes Linux.

--- a/doc/httpsys.md
+++ b/doc/httpsys.md
@@ -1,0 +1,67 @@
+# HTTP.sys Provider for Horse
+
+The HTTP.sys provider utilizes the Windows kernel-mode HTTP protocol stack (`http.sys`). It is built directly into the Horse framework — no external packages are required. Since HTTP parsing, queue management, and request dispatching are handled directly in Ring 0 (kernel mode), context-switching overhead is drastically reduced, enabling exceptionally high throughput and stability under Windows.
+
+In your project's Conditional Defines: `HORSE_PROVIDER_HTTPSYS`.
+
+---
+
+## ⚙️ Properties & Architecture
+
+- **Windows-only:** Native to Windows 7/Server 2008 and above.
+- **Kernel-Mode Parsing:** Sockets and HTTP protocol processing are managed directly by the kernel, freeing up User-Space CPU.
+- **Port Sharing:** Allows multiple applications to share the same port (e.g., port 80/443) by registering distinct URL prefixes (e.g., `http://+:80/app1/` and `http://+:80/app2/`).
+- **Static Thread Pool:** Spawns a pre-allocated pool of persistent worker threads to handle requests efficiently without thread-creation overhead on hot paths.
+- **Auto-Reset Events:** Uses optimized synchronization mechanisms to eliminate CPU busy-waiting.
+- **Performance:** Reaches ~12,000+ req/s with very low latencies.
+
+---
+
+## 🔒 Administrative Privileges
+
+Because HTTP.sys registers URL prefixes directly with the Windows kernel, running your application on ports like 80, 443, or other custom ports requires either:
+1. **Running the application as Administrator** (elevated command prompt).
+2. **Reserving the URL namespace** for non-administrative users.
+
+To register a namespace once (e.g., port 9095) for all users, execute in an elevated PowerShell command prompt:
+
+```powershell
+netsh http add urlacl url=http://+:9095/ user=Todos
+# On English Windows systems, replace "Todos" with "Everyone"
+netsh http add urlacl url=http://+:9095/ user=Everyone
+```
+
+To remove the reservation:
+
+```powershell
+netsh http delete urlacl url=http://+:9095/
+```
+
+---
+
+## ⚡ Quick Start
+
+1. Add `HORSE_PROVIDER_HTTPSYS` to your project's Conditional Defines (**Project Options → Delphi Compiler → Conditional defines**).
+2. Write your server code normally:
+
+```delphi
+program MyServer;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Horse;
+
+begin
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  // Starts the HTTP.sys listener on port 9095
+  THorse.Listen(9095);
+end.
+```
+
+No other application code changes are required. The framework automatically redirects `THorse.Listen` calls to the HTTP.sys provider.

--- a/doc/httpsys.pt-BR.md
+++ b/doc/httpsys.pt-BR.md
@@ -1,0 +1,67 @@
+# Provider HTTP.sys para o Horse
+
+O provedor HTTP.sys utiliza a pilha de protocolos HTTP em modo kernel do Windows (`http.sys`). Ele é embutido diretamente no core do Horse — nenhum pacote externo é necessário. Como o processamento de sockets, o parseamento de pacotes HTTP e o gerenciamento de fila de requisições acontecem diretamente no Ring 0 (espaço de kernel), o overhead de troca de contexto (context-switch) de CPU é drasticamente reduzido, permitindo altíssima vazão e estabilidade extrema no Windows.
+
+Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_HTTPSYS`.
+
+---
+
+## ⚙️ Propriedades e Arquitetura
+
+- **Exclusivo para Windows:** Nativo no Windows 7/Server 2008 e versões superiores.
+- **Parseamento em Modo Kernel:** O processamento de rede e cabeçalhos HTTP é feito pelo próprio kernel do sistema operacional, poupando CPU no espaço de usuário (User-Space).
+- **Compartilhamento de Porta (Port Sharing):** Permite que múltiplos processos/aplicações compartilhem a mesma porta física (ex: porta 80 ou 443) registrando diferentes prefixos de URL (ex: `http://+:80/app1/` e `http://+:80/app2/`).
+- **Pool de Threads Estático:** Cria um pool pré-alocado de threads trabalhadoras persistentes para processar as requisições de forma thread-safe, eliminando overhead de criação e destruição de threads em hot paths.
+- **Eventos de Reset Automático:** Utiliza sinalização thread-safe otimizada para evitar que as threads do pool entrem em busy-waiting ou consumam CPU de forma desnecessária.
+- **Desempenho:** Atinge facilmente ~12.000+ req/s com latências extremamente baixas.
+
+---
+
+## 🔒 Privilégios Administrativos
+
+Como o HTTP.sys registra prefixos de URL diretamente no kernel do Windows, iniciar seu aplicativo em portas comuns (como 80, 443 ou qualquer outra porta personalizada) exige:
+1. **Executar a aplicação como Administrador** (prompt de comando elevado).
+2. **Reservar o namespace de URL** para usuários comuns.
+
+Para registrar o namespace de URL uma única vez (ex: porta 9095) para todos os usuários do Windows, execute em um prompt do PowerShell elevado:
+
+```powershell
+netsh http add urlacl url=http://+:9095/ user=Todos
+# Em sistemas Windows em inglês, substitua "Todos" por "Everyone"
+netsh http add urlacl url=http://+:9095/ user=Everyone
+```
+
+Para remover a reserva posteriormente:
+
+```powershell
+netsh http delete urlacl url=http://+:9095/
+```
+
+---
+
+## ⚡ Início Rápido (Quick Start)
+
+1. Adicione `HORSE_PROVIDER_HTTPSYS` aos Defines Condicionais do seu projeto (**Project Options → Delphi Compiler → Conditional defines**).
+2. Escreva o código do seu servidor normalmente:
+
+```delphi
+program MyServer;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Horse;
+
+begin
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  // Inicia o listener do HTTP.sys na porta 9095
+  THorse.Listen(9095);
+end.
+```
+
+Nenhuma outra alteração no código do aplicativo é necessária. O framework redireciona automaticamente as chamadas de `THorse.Listen` para o provedor HTTP.sys.

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -38,6 +38,8 @@ The **default Provider depends on the compiler**:
 | **`fphttpserver`** | _(none on FPC)_ | Default for FPC self-hosted | n/a | ✔ |
 | **horse-provider-crosssocket** | `HORSE_CROSSSOCKET` | Optional, external package | ✔ | ✔ |
 | **horse-provider-mormot** | `HORSE_PROVIDER_MORMOT` | Optional, external package | ✔ | ✔ |
+| **HTTP.sys** | `HORSE_PROVIDER_HTTPSYS` | Optional, built-in (Windows kernel mode) | ✔ | ✔ |
+| **epoll** | `HORSE_PROVIDER_EPOLL` | Optional, built-in (Linux async event loop) | ✔ | ✔ |
 
 > **What library does the HTTP work, per Application type?** This is the deciding question — and it's *not* always Indy. The unifying abstraction across every row is `Web.HTTPApp.TWebRequest` on Delphi or `fpHTTP.TRequest` on FPC; below that, the concrete library differs.
 >
@@ -47,6 +49,8 @@ The **default Provider depends on the compiler**:
 > | Daemon / HTTPApplication / LCL | FPC | **`fphttpserver`** | ✘ |
 > | Any self-hosted + `HORSE_CROSSSOCKET` | Either | **`Delphi-Cross-Socket`** | ✘ |
 > | Any self-hosted + `HORSE_PROVIDER_MORMOT` | Either | **`mORMot2`** (`THttpServer` / `THttpApiServer`) | ✘ |
+> | Any self-hosted + `HORSE_PROVIDER_HTTPSYS` | Either | **`HTTP.sys`** (Windows Kernel Driver) | ✘ |
+> | Any self-hosted + `HORSE_PROVIDER_EPOLL` | Either | **`epoll`** (Linux kernel epoll API) | ✘ |
 > | Apache module | Either | **Apache httpd** (via `Web.HTTPApp.TApacheRequest` / `mod_horse`) | ✘ |
 > | ISAPI | Delphi | **IIS** (via `Web.HTTPApp.TISAPIRequest`) | ✘ |
 > | CGI | Delphi | **Web server's CGI runner** (via `Web.HTTPApp.TCGIRequest`) | ✘ |
@@ -173,6 +177,43 @@ Both providers use IOCP/epoll and a context object pool, so throughput is compar
 For configuration (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) and application-type wrappers (VCL, Windows Service, Linux daemon), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **mORMot2 installation** — mORMot2 is not available via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) and add `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` to the compiler search path.
+
+### HTTP.sys (optional, Windows-native)
+
+The HTTP.sys provider utilizes the Windows kernel-mode HTTP protocol stack (`http.sys`). It is built directly into Horse — no external packages are required. Since HTTP parsing and queue management are handled directly in Ring 0 (kernel mode), context-switching overhead is drastically reduced, enabling high throughput and stability under Windows.
+
+In your project's Conditional Defines: `HORSE_PROVIDER_HTTPSYS`.
+
+**Properties:**
+- **Windows-only:** Native to Windows 7/Server 2008 and above.
+- **Kernel-Mode Parsing:** Sockets and HTTP protocol processing are managed directly by the kernel, freeing up User-Space CPU.
+- **Port Sharing:** Allows multiple applications to share the same port (e.g., port 80/443) by registering distinct URL prefixes (e.g., `http://+:80/app1/` and `http://+:80/app2/`).
+- **Administrative Privileges:** Registering URL prefixes with HTTP.sys requires Administrator rights or a one-time setup using `netsh http add urlacl`.
+- **Performance:** Reaches ~12 000+ req/s with very low latencies.
+
+**Pick this when:**
+- You deploy exclusively on Windows environments.
+- You want port-sharing capabilities with IIS or other HTTP.sys-based applications.
+- You require enterprise-level SSL/TLS termination managed directly by Windows.
+
+### epoll (optional, Linux-native)
+
+The `epoll` provider is an asynchronous, non-blocking transport layer native to Linux, leveraging the kernel's `epoll` API (via `epoll_wait`). Like HTTP.sys, it is built directly into Horse. After the Phase 2 optimizations, it has a dedicated Thread-Local Buffer Pool, zero-allocation header parsing, vectorised writing (`writev`), and zero-copy file streaming (`sendfile`).
+
+In your project's Conditional Defines: `HORSE_PROVIDER_EPOLL`.
+
+**Properties:**
+- **Linux-only:** Native event loop for Linux (ideal for Ubuntu, Debian, Alpine, Docker containers).
+- **Asynchronous Event Loop:** Handles thousands of concurrent sockets using a fixed IO/Worker thread pool, completely avoiding the thread-per-connection scaling wall.
+- **Enhanced Protections:** Includes native Slowloris timeout protection (5 seconds socket drain) and automatic file descriptor limit elevation (`RLIMIT_NOFILE` raised to 65535).
+- **Chunked Encoding:** Fully supports non-deterministic request payload decoding.
+- **Zero-Copy streaming:** Replaces user-space file buffers with Linux kernel's `sendfile` system call.
+- **Performance:** Processed up to **29 209 req/s** with zero errors under 1 000 concurrent Keep-Alive connections in stess benchmarks, while Indy crashed due to thread exhausion.
+
+**Pick this when:**
+- You deploy on Linux (bare-metal, VMs, or Docker containers).
+- You expect high concurrent loads (1 000+ simultaneous connections) and want a lightweight RAM footprint (~15 MB).
+- You want native non-blocking networking without external Pascal wrappers.
 
 ### Future providers
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -38,8 +38,8 @@ The **default Provider depends on the compiler**:
 | **`fphttpserver`** | _(none on FPC)_ | Default for FPC self-hosted | n/a | ✔ |
 | **horse-provider-crosssocket** | `HORSE_CROSSSOCKET` | Optional, external package | ✔ | ✔ |
 | **horse-provider-mormot** | `HORSE_PROVIDER_MORMOT` | Optional, external package | ✔ | ✔ |
-| **HTTP.sys** | `HORSE_PROVIDER_HTTPSYS` | Optional, built-in (Windows kernel mode) | ✔ | ✔ |
-| **epoll** | `HORSE_PROVIDER_EPOLL` | Optional, built-in (Linux async event loop) | ✔ | ✔ |
+| **[HTTP.sys](./httpsys.md)** | `HORSE_PROVIDER_HTTPSYS` | Optional, built-in (Windows kernel mode) | ✔ | ✔ |
+| **[epoll](./epoll.md)** | `HORSE_PROVIDER_EPOLL` | Optional, built-in (Linux async event loop) | ✔ | ✔ |
 
 > **What library does the HTTP work, per Application type?** This is the deciding question — and it's *not* always Indy. The unifying abstraction across every row is `Web.HTTPApp.TWebRequest` on Delphi or `fpHTTP.TRequest` on FPC; below that, the concrete library differs.
 >
@@ -177,43 +177,6 @@ Both providers use IOCP/epoll and a context object pool, so throughput is compar
 For configuration (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) and application-type wrappers (VCL, Windows Service, Linux daemon), see the [provider's own documentation](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **mORMot2 installation** — mORMot2 is not available via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) and add `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` to the compiler search path.
-
-### HTTP.sys (optional, Windows-native)
-
-The HTTP.sys provider utilizes the Windows kernel-mode HTTP protocol stack (`http.sys`). It is built directly into Horse — no external packages are required. Since HTTP parsing and queue management are handled directly in Ring 0 (kernel mode), context-switching overhead is drastically reduced, enabling high throughput and stability under Windows.
-
-In your project's Conditional Defines: `HORSE_PROVIDER_HTTPSYS`.
-
-**Properties:**
-- **Windows-only:** Native to Windows 7/Server 2008 and above.
-- **Kernel-Mode Parsing:** Sockets and HTTP protocol processing are managed directly by the kernel, freeing up User-Space CPU.
-- **Port Sharing:** Allows multiple applications to share the same port (e.g., port 80/443) by registering distinct URL prefixes (e.g., `http://+:80/app1/` and `http://+:80/app2/`).
-- **Administrative Privileges:** Registering URL prefixes with HTTP.sys requires Administrator rights or a one-time setup using `netsh http add urlacl`.
-- **Performance:** Reaches ~12 000+ req/s with very low latencies.
-
-**Pick this when:**
-- You deploy exclusively on Windows environments.
-- You want port-sharing capabilities with IIS or other HTTP.sys-based applications.
-- You require enterprise-level SSL/TLS termination managed directly by Windows.
-
-### epoll (optional, Linux-native)
-
-The `epoll` provider is an asynchronous, non-blocking transport layer native to Linux, leveraging the kernel's `epoll` API (via `epoll_wait`). Like HTTP.sys, it is built directly into Horse. After the Phase 2 optimizations, it has a dedicated Thread-Local Buffer Pool, zero-allocation header parsing, vectorised writing (`writev`), and zero-copy file streaming (`sendfile`).
-
-In your project's Conditional Defines: `HORSE_PROVIDER_EPOLL`.
-
-**Properties:**
-- **Linux-only:** Native event loop for Linux (ideal for Ubuntu, Debian, Alpine, Docker containers).
-- **Asynchronous Event Loop:** Handles thousands of concurrent sockets using a fixed IO/Worker thread pool, completely avoiding the thread-per-connection scaling wall.
-- **Enhanced Protections:** Includes native Slowloris timeout protection (5 seconds socket drain) and automatic file descriptor limit elevation (`RLIMIT_NOFILE` raised to 65535).
-- **Chunked Encoding:** Fully supports non-deterministic request payload decoding.
-- **Zero-Copy streaming:** Replaces user-space file buffers with Linux kernel's `sendfile` system call.
-- **Performance:** Processed up to **29 209 req/s** with zero errors under 1 000 concurrent Keep-Alive connections in stess benchmarks, while Indy crashed due to thread exhausion.
-
-**Pick this when:**
-- You deploy on Linux (bare-metal, VMs, or Docker containers).
-- You expect high concurrent loads (1 000+ simultaneous connections) and want a lightweight RAM footprint (~15 MB).
-- You want native non-blocking networking without external Pascal wrappers.
 
 ### Future providers
 

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -33,11 +33,13 @@ O **Provider padrão depende do compilador**:
 - O Provider **CrossSocket** opcional substitui *ambos* os padrões por um transporte assíncrono entre compiladores.
 
 | Provider | Define de compilação | Status | Delphi | Lazarus |
-|---|---|---|:---:|:---:|
-| **Indy** | _(nenhum no Delphi)_ | Padrão para self-hosted no Delphi | ✔ | n/a |
-| **`fphttpserver`** | _(nenhum no FPC)_ | Padrão para self-hosted no FPC | n/a | ✔ |
-| **horse-provider-crosssocket** | `HORSE_CROSSSOCKET` | Opcional, pacote externo | ✔ | ✔ |
-| **horse-provider-mormot** | `HORSE_PROVIDER_MORMOT` | Opcional, pacote externo | ✔ | ✔ |
+| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
+| **Indy** _(padrão Delphi para self-hosted)_                                                     | _(nenhum)_              | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
+| **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| **HTTP.sys** | `HORSE_PROVIDER_HTTPSYS` | Opcional, embutido (modo kernel Windows) | ✔ | ✔ |
+| **epoll** | `HORSE_PROVIDER_EPOLL` | Opcional, embutido (event loop assíncrono Linux) | ✔ | ✔ |
 
 > **Qual biblioteca faz o trabalho de HTTP, por Tipo de aplicação?** Esta é a pergunta-chave — e a resposta *nem sempre* é Indy. A abstração unificadora em todas as linhas é `Web.HTTPApp.TWebRequest` no Delphi ou `fpHTTP.TRequest` no FPC; abaixo disso, a biblioteca concreta difere.
 >
@@ -47,6 +49,8 @@ O **Provider padrão depende do compilador**:
 > | Daemon / HTTPApplication / LCL | FPC | **`fphttpserver`** | ✘ |
 > | Qualquer self-hosted + `HORSE_CROSSSOCKET` | Qualquer um | **`Delphi-Cross-Socket`** | ✘ |
 > | Qualquer self-hosted + `HORSE_PROVIDER_MORMOT` | Qualquer um | **`mORMot2`** (`THttpServer` / `THttpApiServer`) | ✘ |
+> | Qualquer self-hosted + `HORSE_PROVIDER_HTTPSYS` | Qualquer um | **`HTTP.sys`** (Driver de Kernel do Windows) | ✘ |
+> | Qualquer self-hosted + `HORSE_PROVIDER_EPOLL` | Qualquer um | **`epoll`** (API epoll nativa do Linux) | ✘ |
 > | Módulo Apache | Qualquer um | **Apache httpd** (via `Web.HTTPApp.TApacheRequest` / `mod_horse`) | ✘ |
 > | ISAPI | Delphi | **IIS** (via `Web.HTTPApp.TISAPIRequest`) | ✘ |
 > | CGI | Delphi | **CGI runner do webserver** (via `Web.HTTPApp.TCGIRequest`) | ✘ |
@@ -171,6 +175,43 @@ Ambos os providers usam IOCP/epoll e um pool de objetos de contexto, portanto a 
 Para configuração (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) e as implementações para cada tipo de aplicação  (VCL, Serviço Windows, daemon Linux), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **Instalação do mORMot2** — o mORMot2 não está disponível via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) e adicione `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` ao search path do compilador.
+
+### HTTP.sys (opcional, nativo do Windows)
+
+O provedor HTTP.sys utiliza a pilha de protocolos HTTP em modo kernel do Windows (`http.sys`). Ele é embutido diretamente no Horse — nenhum pacote externo é necessário. Como o tratamento de sockets, parseamento de HTTP e gerenciamento de fila de requisições acontecem diretamente no Ring 0 (espaço de kernel), o overhead de troca de contexto (context-switch) é drasticamente reduzido, permitindo altíssima vazão e estabilidade extrema no Windows.
+
+Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_HTTPSYS`.
+
+**Propriedades:**
+- **Exclusivo para Windows:** Nativo a partir do Windows 7 e Windows Server 2008 ou superior.
+- **Parseamento em Modo Kernel:** O processamento de rede e cabeçalhos HTTP é feito pelo próprio kernel do SO, poupando CPU no espaço de usuário (User-Space).
+- **Compartilhamento de Porta (Port Sharing):** Permite que múltiplos processos/aplicativos compartilhem a mesma porta física (ex: porta 80 ou 443) registrando diferentes prefixos de URL (ex: `http://+:80/app1/` e `http://+:80/app2/`).
+- **Privilégios Administrativos:** Registrar prefixos de URL no HTTP.sys exige direitos de Administrador ou um cadastro prévio das URLs usando `netsh http add urlacl`.
+- **Desempenho:** Atinge facilmente ~12.000+ req/s com latências nulas.
+
+**Escolha este quando:**
+- Suas aplicações rodam exclusivamente em ambiente Windows.
+- Você precisa compartilhar portas com o IIS ou outros serviços Windows.
+- Deseja delegação de criptografia SSL/TLS transparente gerenciada nativamente pelo Windows.
+
+### epoll (opcional, nativo do Linux)
+
+O provedor `epoll` é um transporte assíncrono e não-bloqueante nativo do Linux, utilizando a API `epoll` do kernel (via `epoll_wait`). Assim como o HTTP.sys, ele é nativo e vem embutido no core do Horse. Após as otimizações da Phase 2, o provedor conta com Thread-Local Buffer Pools para eliminar contenção por locks globais, parseador de cabeçalhos sem alocação dinâmica de memória, escrita vetorizada (`writev`) e envio de arquivos com cópia zero via kernel (`sendfile`).
+
+Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_EPOLL`.
+
+**Propriedades:**
+- **Exclusivo para Linux:** Event loop nativo para distribuições Linux (ideal para Ubuntu, Debian, Alpine e containers Docker).
+- **Event Loop Assíncrono:** Lida com milhares de conexões TCP abertas usando um pool estático e fixo de threads de E/S e workers, superando o gargalo físico de threads bloqueantes do Indy (*thread-per-connection*).
+- **Proteções de Produção:** Proteção nativa integrada contra ataques Slowloris (timeout automático de 5 segundos para drenagem de sockets ociosos) e elevação automática dos limites de File Descriptors do processo (`RLIMIT_NOFILE` elevado para 65535).
+- **Decodificação de Chunked Payload:** Suporte completo para requests usando *Chunked Transfer-Encoding*.
+- **Cópia Zero de Arquivos:** Envio de streams de arquivo (`TFileStream`) delegado ao kernel Linux via chamada de sistema `sendfile`.
+- **Desempenho:** Registrou taxas brutais de até **29.209 req/s** com zero falhas sob estresse concorrente de 1.000 conexõesKeep-Alive consecutivas, enquanto a Indy foi derrubada por estouro de recursos.
+
+**Escolha este quando:**
+- Seu ambiente de produção é Linux (servidores físicos, VMs ou containers Docker).
+- Você precisa suportar picos extremos de concorrência com baixo consumo de memória RAM (~15 MB).
+- Deseja alta performance assíncrona pura sem depender de bibliotecas externas complexas.
 
 ### Providers futuros
 

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -33,13 +33,13 @@ O **Provider padrão depende do compilador**:
 - O Provider **CrossSocket** opcional substitui *ambos* os padrões por um transporte assíncrono entre compiladores.
 
 | Provider | Define de compilação | Status | Delphi | Lazarus |
-| ----------------------------------------------------------------------------------------------- | ----------------------- | :------------------: | :-------------------------: |
-| **Indy** _(padrão Delphi para self-hosted)_                                                     | _(nenhum)_              | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
-| **`fphttpserver`** _(padrão FPC para self-hosted)_                                              | _(nenhum)_              | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)**    | `HORSE_CROSSSOCKET`     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)**               | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
-| **HTTP.sys** | `HORSE_PROVIDER_HTTPSYS` | Opcional, embutido (modo kernel Windows) | ✔ | ✔ |
-| **epoll** | `HORSE_PROVIDER_EPOLL` | Opcional, embutido (event loop assíncrono Linux) | ✔ | ✔ |
+|---|---|---|:---:|:---:|
+| **Indy** _(padrão Delphi para self-hosted)_ | _(nenhum)_ | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;n/a |
+| **`fphttpserver`** _(padrão FPC para self-hosted)_ | _(nenhum)_ | &nbsp;&nbsp;&nbsp;n/a | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-crosssocket](https://github.com/freitasjca/horse-provider-crosssocket)** | `HORSE_CROSSSOCKET` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| 🆕 **[horse-provider-mormot](https://github.com/freitasjca/horse-provider-mormot)** | `HORSE_PROVIDER_MORMOT` | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+| **[HTTP.sys](./httpsys.pt-BR.md)** | `HORSE_PROVIDER_HTTPSYS` | Opcional, embutido (modo kernel Windows) | ✔ | ✔ |
+| **[epoll](./epoll.pt-BR.md)** | `HORSE_PROVIDER_EPOLL` | Opcional, embutido (event loop assíncrono Linux) | ✔ | ✔ |
 
 > **Qual biblioteca faz o trabalho de HTTP, por Tipo de aplicação?** Esta é a pergunta-chave — e a resposta *nem sempre* é Indy. A abstração unificadora em todas as linhas é `Web.HTTPApp.TWebRequest` no Delphi ou `fpHTTP.TRequest` no FPC; abaixo disso, a biblioteca concreta difere.
 >
@@ -175,43 +175,6 @@ Ambos os providers usam IOCP/epoll e um pool de objetos de contexto, portanto a 
 Para configuração (`ServerKind`, `ThreadPool`, `MaxBodyBytes`, `DrainTimeoutMs`, `ServerBanner`) e as implementações para cada tipo de aplicação  (VCL, Serviço Windows, daemon Linux), veja a [documentação do próprio provider](https://github.com/freitasjca/horse-provider-mormot#readme).
 
 > **Instalação do mORMot2** — o mORMot2 não está disponível via `boss install`. Clone [synopse/mORMot2](https://github.com/synopse/mORMot2) e adicione `<mORMot2>/src`, `<mORMot2>/src/core`, `<mORMot2>/src/net` ao search path do compilador.
-
-### HTTP.sys (opcional, nativo do Windows)
-
-O provedor HTTP.sys utiliza a pilha de protocolos HTTP em modo kernel do Windows (`http.sys`). Ele é embutido diretamente no Horse — nenhum pacote externo é necessário. Como o tratamento de sockets, parseamento de HTTP e gerenciamento de fila de requisições acontecem diretamente no Ring 0 (espaço de kernel), o overhead de troca de contexto (context-switch) é drasticamente reduzido, permitindo altíssima vazão e estabilidade extrema no Windows.
-
-Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_HTTPSYS`.
-
-**Propriedades:**
-- **Exclusivo para Windows:** Nativo a partir do Windows 7 e Windows Server 2008 ou superior.
-- **Parseamento em Modo Kernel:** O processamento de rede e cabeçalhos HTTP é feito pelo próprio kernel do SO, poupando CPU no espaço de usuário (User-Space).
-- **Compartilhamento de Porta (Port Sharing):** Permite que múltiplos processos/aplicativos compartilhem a mesma porta física (ex: porta 80 ou 443) registrando diferentes prefixos de URL (ex: `http://+:80/app1/` e `http://+:80/app2/`).
-- **Privilégios Administrativos:** Registrar prefixos de URL no HTTP.sys exige direitos de Administrador ou um cadastro prévio das URLs usando `netsh http add urlacl`.
-- **Desempenho:** Atinge facilmente ~12.000+ req/s com latências nulas.
-
-**Escolha este quando:**
-- Suas aplicações rodam exclusivamente em ambiente Windows.
-- Você precisa compartilhar portas com o IIS ou outros serviços Windows.
-- Deseja delegação de criptografia SSL/TLS transparente gerenciada nativamente pelo Windows.
-
-### epoll (opcional, nativo do Linux)
-
-O provedor `epoll` é um transporte assíncrono e não-bloqueante nativo do Linux, utilizando a API `epoll` do kernel (via `epoll_wait`). Assim como o HTTP.sys, ele é nativo e vem embutido no core do Horse. Após as otimizações da Phase 2, o provedor conta com Thread-Local Buffer Pools para eliminar contenção por locks globais, parseador de cabeçalhos sem alocação dinâmica de memória, escrita vetorizada (`writev`) e envio de arquivos com cópia zero via kernel (`sendfile`).
-
-Nos Defines de Compilação do seu projeto: `HORSE_PROVIDER_EPOLL`.
-
-**Propriedades:**
-- **Exclusivo para Linux:** Event loop nativo para distribuições Linux (ideal para Ubuntu, Debian, Alpine e containers Docker).
-- **Event Loop Assíncrono:** Lida com milhares de conexões TCP abertas usando um pool estático e fixo de threads de E/S e workers, superando o gargalo físico de threads bloqueantes do Indy (*thread-per-connection*).
-- **Proteções de Produção:** Proteção nativa integrada contra ataques Slowloris (timeout automático de 5 segundos para drenagem de sockets ociosos) e elevação automática dos limites de File Descriptors do processo (`RLIMIT_NOFILE` elevado para 65535).
-- **Decodificação de Chunked Payload:** Suporte completo para requests usando *Chunked Transfer-Encoding*.
-- **Cópia Zero de Arquivos:** Envio de streams de arquivo (`TFileStream`) delegado ao kernel Linux via chamada de sistema `sendfile`.
-- **Desempenho:** Registrou taxas brutais de até **29.209 req/s** com zero falhas sob estresse concorrente de 1.000 conexõesKeep-Alive consecutivas, enquanto a Indy foi derrubada por estouro de recursos.
-
-**Escolha este quando:**
-- Seu ambiente de produção é Linux (servidores físicos, VMs ou containers Docker).
-- Você precisa suportar picos extremos de concorrência com baixo consumo de memória RAM (~15 MB).
-- Deseja alta performance assíncrona pura sem depender de bibliotecas externas complexas.
 
 ### Providers futuros
 

--- a/samples/delphi/console/Console.dpr
+++ b/samples/delphi/console/Console.dpr
@@ -1,11 +1,34 @@
 program Console;
 
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
 {$APPTYPE CONSOLE}
+{$IFDEF MSWINDOWS}
 {$R *.res}
+{$ENDIF}
 
 uses
+  {$IFDEF UNIX}
+    cthreads,
+  {$ENDIF}
   Horse,
-  System.SysUtils;
+  {$IFDEF FPC}
+    SysUtils;
+  {$ELSE}
+    System.SysUtils;
+  {$ENDIF}
+
+procedure DoPing(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('Ping');
+end;
+
+procedure DoListen;
+begin
+  Writeln(Format('Server is running on port %d...', [THorse.Port]));
+end;
 
 begin
   {$IFDEF MSWINDOWS}
@@ -13,16 +36,10 @@ begin
     ReportMemoryLeaksOnShutdown := True;
   {$ENDIF}
 
-  THorse.Get('/ping',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    begin
-      Res.Send('Ping');
-    end);
+  THorse.Get('/ping', DoPing);
 
-  THorse.Listen(9000,
-    procedure
-    begin
-      Writeln(Format('Server is runing on port %d...', [THorse.Port]));
-      Readln;
-    end);
+  THorse.Listen(9000, DoListen);
+
+  while THorse.IsRunning do
+    Sleep(1000);
 end.

--- a/samples/delphi/epoll/EpollConsole.dpr
+++ b/samples/delphi/epoll/EpollConsole.dpr
@@ -1,14 +1,26 @@
 program EpollConsole;
 
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
 {$APPTYPE CONSOLE}
 
 // Habilita o novo provider Epoll nativo de Linux
 {$DEFINE HORSE_PROVIDER_EPOLL}
 
 uses
+  {$IFDEF UNIX}
+    cthreads,
+  {$ENDIF}
   Horse,
-  System.SysUtils,
-  System.JSON;
+  {$IFDEF FPC}
+    SysUtils,
+    fpjson;
+  {$ELSE}
+    System.SysUtils,
+    System.JSON;
+  {$ENDIF}
 
 const
   HTML_ROOT = 
@@ -39,146 +51,179 @@ const
     '<li><span class="method delete">DELETE</span><a href="#" onclick="fetch(''/users/123'', {method: ''DELETE''}).then(r => r.json()).then(j => alert(JSON.stringify(j)))">/users/123</a><div class="desc">Executa requisição DELETE e exibe o JSON resultante</div></li>' +
     '</ul></body></html>';
 
+procedure DoIndex(Req: THorseRequest; Res: THorseResponse);
 begin
+  Res.ContentType('text/html; charset=utf-8');
+  Res.Send(HTML_ROOT);
+end;
+
+procedure DoPing(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('pong');
+end;
+
+procedure DoGetUsers(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+  LUserId: string;
+  LUserName: string;
+begin
+  LUserId := Req.Params.Items['id'];
+  LUserName := Req.Query.Items['nome'];
+  {$IFDEF FPC}
+  if LUserName = '' then
+  {$ELSE}
+  if LUserName.IsEmpty then
+  {$ENDIF}
+    LUserName := 'Visitante';
+
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('id', LUserId);
+    LJSON.Add('nome', LUserName);
+    LJSON.Add('provedor', 'Epoll (Linux)');
+    LJSON.Add('mensagem', 'Exemplo de integracao funcionando perfeitamente!');
+    Res.Send(LJSON.AsJSON);
+    {$ELSE}
+    LJSON.AddPair('id', LUserId);
+    LJSON.AddPair('nome', LUserName);
+    LJSON.AddPair('provedor', 'Epoll (Linux)');
+    LJSON.AddPair('mensagem', 'Exemplo de integracao funcionando perfeitamente!');
+    Res.Send(LJSON.ToJSON);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
+procedure DoPostUsers(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+begin
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('status', 'created');
+    LJSON.Add('action', 'POST');
+    Res.Send(LJSON.AsJSON).Status(THTTPStatus.Created);
+    {$ELSE}
+    LJSON.AddPair('status', 'created');
+    LJSON.AddPair('action', 'POST');
+    Res.Send(LJSON.ToJSON).Status(THTTPStatus.Created);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
+procedure DoUpload(Req: THorseRequest; Res: THorseResponse);
+var
+  LBody: string;
+begin
+  LBody := Req.Body;
+  Res.Send('Tamanho: ' + IntToStr(Length(LBody)) + ' / Inicio: ' + Copy(LBody, 1, 50));
+end;
+
+procedure DoPutUsers(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+begin
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('id', Req.Params.Items['id']);
+    LJSON.Add('status', 'updated');
+    LJSON.Add('action', 'PUT');
+    Res.Send(LJSON.AsJSON);
+    {$ELSE}
+    LJSON.AddPair('id', Req.Params.Items['id']);
+    LJSON.AddPair('status', 'updated');
+    LJSON.AddPair('action', 'PUT');
+    Res.Send(LJSON.ToJSON);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
+procedure DoPatchUsers(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+begin
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('id', Req.Params.Items['id']);
+    LJSON.Add('status', 'patched');
+    LJSON.Add('action', 'PATCH');
+    Res.Send(LJSON.AsJSON);
+    {$ELSE}
+    LJSON.AddPair('id', Req.Params.Items['id']);
+    LJSON.AddPair('status', 'patched');
+    LJSON.AddPair('action', 'PATCH');
+    Res.Send(LJSON.ToJSON);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
+procedure DoDeleteUsers(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+begin
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('id', Req.Params.Items['id']);
+    LJSON.Add('status', 'deleted');
+    LJSON.Add('action', 'DELETE');
+    Res.Send(LJSON.AsJSON);
+    {$ELSE}
+    LJSON.AddPair('id', Req.Params.Items['id']);
+    LJSON.AddPair('status', 'deleted');
+    LJSON.AddPair('action', 'DELETE');
+    Res.Send(LJSON.ToJSON);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
+procedure DoListen;
+begin
+  Writeln('--------------------------------------------------');
+  Writeln(' Servidor Horse Epoll Iniciado (Linux)');
+  Writeln(Format(' Escutando em: http://%s:%d/', [THorse.Host, THorse.Port]));
+  Writeln('--------------------------------------------------');
+  Writeln(' Rotas disponiveis para teste:');
+  Writeln('  - GET    http://localhost:9095/ping');
+  Writeln('  - GET    http://localhost:9095/users/123?nome=Regys');
+  Writeln('  - POST   http://localhost:9095/users');
+  Writeln('  - POST   http://localhost:9095/upload');
+  Writeln('  - PUT    http://localhost:9095/users/123');
+  Writeln('  - PATCH  http://localhost:9095/users/123');
+  Writeln('  - DELETE http://localhost:9095/users/123');
+  Writeln('--------------------------------------------------');
+  Writeln(' Pressione Ctrl+C para encerrar.');
+end;
+
+begin
+  {$IFNDEF FPC}
   ReportMemoryLeaksOnShutdown := True;
+  {$ENDIF}
 
-  // Rota raiz para documentação
-  THorse.Get('/',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    begin
-      Res.ContentType('text/html; charset=utf-8');
-      Res.Send(HTML_ROOT);
-    end);
+  THorse.Get('/', DoIndex);
+  THorse.Get('/ping', DoPing);
+  THorse.Get('/users/:id', DoGetUsers);
+  THorse.Post('/users', DoPostUsers);
+  THorse.Post('/upload', DoUpload);
+  THorse.Put('/users/:id', DoPutUsers);
+  THorse.Patch('/users/:id', DoPatchUsers);
+  THorse.Delete('/users/:id', DoDeleteUsers);
 
-  // 1. Rota de ping simples
-  THorse.Get('/ping',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    begin
-      Res.Send('pong');
-    end);
-
-  // 2. Rota complexa retornando JSON e processando parâmetros
-  THorse.Get('/users/:id',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LJSON: TJSONObject;
-      LUserId: string;
-      LUserName: string;
-    begin
-      LUserId := Req.Params.Items['id'];
-      LUserName := Req.Query.Items['nome'];
-      if LUserName.IsEmpty then
-        LUserName := 'Visitante';
-
-      LJSON := TJSONObject.Create;
-      try
-        LJSON.AddPair('id', LUserId);
-        LJSON.AddPair('nome', LUserName);
-        LJSON.AddPair('provedor', 'Epoll (Linux)');
-        LJSON.AddPair('mensagem', 'Exemplo de integracao funcionando perfeitamente!');
-        
-        Res.Send(LJSON.ToJSON);
-      finally
-        LJSON.Free;
-      end;
-    end);
-
-  // 3. Rota POST
-  THorse.Post('/users',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LJSON: TJSONObject;
-    begin
-      LJSON := TJSONObject.Create;
-      try
-        LJSON.AddPair('status', 'created');
-        LJSON.AddPair('action', 'POST');
-        Res.Send(LJSON.ToJSON).Status(THTTPStatus.Created);
-      finally
-        LJSON.Free;
-      end;
-    end);
-
-  // Rota de teste de upload / spooling / body
-  THorse.Post('/upload',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LBody: string;
-    begin
-      LBody := Req.Body;
-      Res.Send('Tamanho: ' + IntToStr(Length(LBody)) + ' / Inicio: ' + Copy(LBody, 1, 50));
-    end);
-
-  // 4. Rota PUT
-  THorse.Put('/users/:id',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LJSON: TJSONObject;
-    begin
-      LJSON := TJSONObject.Create;
-      try
-        LJSON.AddPair('id', Req.Params.Items['id']);
-        LJSON.AddPair('status', 'updated');
-        LJSON.AddPair('action', 'PUT');
-        Res.Send(LJSON.ToJSON);
-      finally
-        LJSON.Free;
-      end;
-    end);
-
-  // 5. Rota PATCH
-  THorse.Patch('/users/:id',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LJSON: TJSONObject;
-    begin
-      LJSON := TJSONObject.Create;
-      try
-        LJSON.AddPair('id', Req.Params.Items['id']);
-        LJSON.AddPair('status', 'patched');
-        LJSON.AddPair('action', 'PATCH');
-        Res.Send(LJSON.ToJSON);
-      finally
-        LJSON.Free;
-      end;
-    end);
-
-  // 6. Rota DELETE
-  THorse.Delete('/users/:id',
-    procedure(Req: THorseRequest; Res: THorseResponse)
-    var
-      LJSON: TJSONObject;
-    begin
-      LJSON := TJSONObject.Create;
-      try
-        LJSON.AddPair('id', Req.Params.Items['id']);
-        LJSON.AddPair('status', 'deleted');
-        LJSON.AddPair('action', 'DELETE');
-        Res.Send(LJSON.ToJSON);
-      finally
-        LJSON.Free;
-      end;
-    end);
-
-  // Escuta na porta 9095 em 0.0.0.0 (acessÃ­vel de fora do container Docker)
-  THorse.Listen(9095, '0.0.0.0',
-    procedure
-    begin
-      Writeln('--------------------------------------------------');
-      Writeln(' Servidor Horse Epoll Iniciado (Linux)');
-      Writeln(Format(' Escutando em: http://%s:%d/', [THorse.Host, THorse.Port]));
-      Writeln('--------------------------------------------------');
-      Writeln(' Rotas disponiveis para teste:');
-      Writeln('  - GET    http://localhost:9095/ping');
-      Writeln('  - GET    http://localhost:9095/users/123?nome=Regys');
-      Writeln('  - POST   http://localhost:9095/users');
-      Writeln('  - POST   http://localhost:9095/upload');
-      Writeln('  - PUT    http://localhost:9095/users/123');
-      Writeln('  - PATCH  http://localhost:9095/users/123');
-      Writeln('  - DELETE http://localhost:9095/users/123');
-      Writeln('--------------------------------------------------');
-      Writeln(' Pressione Ctrl+C para encerrar.');
-    end);
+  THorse.Listen(9095, '0.0.0.0', DoListen);
 
   while THorse.IsRunning do
     Sleep(1000);

--- a/samples/delphi/epoll/EpollConsole.dpr
+++ b/samples/delphi/epoll/EpollConsole.dpr
@@ -191,6 +191,26 @@ begin
   end;
 end;
 
+procedure DoGetIP(Req: THorseRequest; Res: THorseResponse);
+var
+  LJSON: TJSONObject;
+begin
+  LJSON := TJSONObject.Create;
+  try
+    {$IFDEF FPC}
+    LJSON.Add('remote_addr', Req.RawWebRequest.RemoteAddr);
+    LJSON.Add('server_port', Req.RawWebRequest.ServerPort);
+    Res.Send(LJSON.AsJSON);
+    {$ELSE}
+    LJSON.AddPair('remote_addr', Req.RawWebRequest.RemoteAddr);
+    LJSON.AddPair('server_port', TJSONNumber.Create(Req.RawWebRequest.ServerPort));
+    Res.Send(LJSON.ToJSON);
+    {$ENDIF}
+  finally
+    LJSON.Free;
+  end;
+end;
+
 procedure DoListen;
 begin
   Writeln('--------------------------------------------------');
@@ -216,6 +236,7 @@ begin
 
   THorse.Get('/', DoIndex);
   THorse.Get('/ping', DoPing);
+  THorse.Get('/ip', DoGetIP);
   THorse.Get('/users/:id', DoGetUsers);
   THorse.Post('/users', DoPostUsers);
   THorse.Post('/upload', DoUpload);

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -60,6 +60,7 @@ type
   private
     class function FindByte(const ABuffer: TBytes; AStart, AEnd: Integer; AByte: Byte): Integer; static; inline;
     class function FindCRLF(const ABuffer: TBytes; AStart, AEnd: Integer): Integer; static; inline;
+    class function CompareBytesCI(const ABuffer: TBytes; AStart, ALen: Integer; const AStr: string): Boolean; static; inline;
   public
     class function TryParseRequest(
       const ABuffer: TBytes; 
@@ -138,10 +139,12 @@ type
     FStatusCode: Integer;
     FReason: string;
     FHeaders: TDictionary<string, string>;
+    FIsKeepAlive: Boolean;
+    function PrepareHeaders: TBytes;
     procedure SendHeaders;
     procedure SendStreamResponse(AStream: TStream; AHeadersList: {$IFDEF FPC}TStrings{$ELSE}TDictionary<string, string>{$ENDIF});
   public
-    constructor Create(ASocket: Integer);
+    constructor Create(ASocket: Integer; AIsKeepAlive: Boolean = True);
     destructor Destroy; override;
 
     procedure SetCustomHeader(const AName, AValue: string);
@@ -181,8 +184,6 @@ type
   { Pool de buffers estático e thread-safe }
   TBufferPool = class
   private
-    class var FPool: TQueue<TBytes>;
-    class var FSync: TCriticalSection;
     const BUFFER_SIZE = 8192;
   public
     class constructor Create;
@@ -203,6 +204,7 @@ type
     {$ENDIF}
     FRunning: Boolean;
     FConnections: TList<TEpollConnectionContext>;
+    FConnectionsSync: TCriticalSection;
     procedure ProcessClientRead(AContext: TEpollConnectionContext);
     procedure CloseConnection(AContext: TEpollConnectionContext);
     procedure CheckTimeouts;
@@ -255,6 +257,9 @@ type
 implementation
 
 {$IFDEF LINUX}
+
+threadvar
+  FLocalPool: TQueue<TBytes>;
 
 const
   EPOLLIN      = $00000001;
@@ -311,6 +316,16 @@ function pipe(filedes: PInteger): Integer; cdecl; external libc name 'pipe';
 function setrlimit(resource: Integer; const rlim: rlimit): Integer; cdecl; external libc name 'setrlimit';
 function clock_gettime(clk_id: Integer; var tp: TEpollTimeSpec): Integer; cdecl; external libc name 'clock_gettime';
 
+type
+  iovec = record
+    iov_base: Pointer;
+    iov_len: NativeUInt;
+  end;
+  piovec = ^iovec;
+
+function writev(fd: Integer; iov: piovec; iovcnt: Integer): NativeInt; cdecl; external libc name 'writev';
+function sendfile(out_fd: Integer; in_fd: Integer; offset: PInt64; count: NativeUInt): NativeInt; cdecl; external libc name 'sendfile';
+
 function GetTickCount64: Int64;
 var
   LTime: TEpollTimeSpec;
@@ -326,48 +341,33 @@ end;
 
 class constructor TBufferPool.Create;
 begin
-  FPool := TQueue<TBytes>.Create;
-  FSync := TCriticalSection.Create;
 end;
 
 class destructor TBufferPool.Destroy;
 begin
-  FSync.Enter;
-  try
-    while FPool.Count > 0 do
-      FPool.Dequeue;
-    FPool.Free;
-  finally
-    FSync.Leave;
-    FSync.Free;
-  end;
 end;
 
 class function TBufferPool.Acquire: TBytes;
 begin
-  FSync.Enter;
-  try
-    if FPool.Count > 0 then
-      Result := FPool.Dequeue
-    else
-      SetLength(Result, BUFFER_SIZE);
-  finally
-    FSync.Leave;
-  end;
+  if FLocalPool = nil then
+    FLocalPool := TQueue<TBytes>.Create;
+
+  if FLocalPool.Count > 0 then
+    Result := FLocalPool.Dequeue
+  else
+    SetLength(Result, BUFFER_SIZE);
 end;
 
 class procedure TBufferPool.Release(var ABuffer: TBytes);
 begin
   if ABuffer = nil then Exit;
-  FSync.Enter;
-  try
-    if FPool.Count < 512 then // Limite de cache no pool
-      FPool.Enqueue(ABuffer)
-    else
-      ABuffer := nil;
-  finally
-    FSync.Leave;
-  end;
+  if FLocalPool = nil then
+    FLocalPool := TQueue<TBytes>.Create;
+
+  if FLocalPool.Count < 32 then
+    FLocalPool.Enqueue(ABuffer)
+  else
+    ABuffer := nil;
 end;
 
 { TEpollConnectionContext }
@@ -578,6 +578,23 @@ begin
   Result := -1;
 end;
 
+class function THorseHttpParser.CompareBytesCI(const ABuffer: TBytes; AStart, ALen: Integer; const AStr: string): Boolean;
+var
+  I: Integer;
+  B1, B2: Byte;
+begin
+  if ALen <> Length(AStr) then Exit(False);
+  for I := 0 to ALen - 1 do
+  begin
+    B1 := ABuffer[AStart + I];
+    B2 := Byte(AStr[I + 1]);
+    if (B1 >= 65) and (B1 <= 90) then B1 := B1 + 32;
+    if (B2 >= 65) and (B2 <= 90) then B2 := B2 + 32;
+    if B1 <> B2 then Exit(False);
+  end;
+  Result := True;
+end;
+
 class function THorseHttpParser.TryParseRequest(
   const ABuffer: TBytes; 
   ALength: Integer;
@@ -599,7 +616,6 @@ var
   QueryStart: Integer;
   Colon: Integer;
   Key: string;
-  ValStr: string;
   Segment: THeaderSegment;
   RawLine: AnsiString;
 begin
@@ -670,22 +686,40 @@ begin
       Colon := FindByte(ABuffer, LineStart, LineEnd, 58); // ':'
       if Colon <> -1 then
       begin
-        SetString(RawLine, PAnsiChar(@ABuffer[LineStart]), Colon - LineStart);
-        Key := LowerCase(Trim(string(RawLine)));
-        
         Segment.KeyStart := LineStart;
         Segment.KeyLen := Colon - LineStart;
-        Segment.ValueStart := Colon + 1;
-        Segment.ValueLen := LineEnd - (Colon + 1);
         
-        AHeaders.AddOrSetValue(Key, Segment);
+        // Remove espaços do valor (Trim rápido dos bytes)
+        I := Colon + 1;
+        while (I < LineEnd) and (ABuffer[I] = 32) do Inc(I);
+        Segment.ValueStart := I;
+        Segment.ValueLen := LineEnd - I;
 
-        if Key = 'content-length' then
+        // Comparações de bytes direta (Zero-Allocation) para as chaves conhecidas
+        if CompareBytesCI(ABuffer, Segment.KeyStart, Segment.KeyLen, 'content-length') then
         begin
-          SetString(RawLine, PAnsiChar(@ABuffer[Segment.ValueStart]), Segment.ValueLen);
-          ValStr := Trim(string(RawLine));
-          AContentLength := StrToInt64Def(ValStr, 0);
+          if Segment.ValueLen > 0 then
+          begin
+            SetString(RawLine, PAnsiChar(@ABuffer[Segment.ValueStart]), Segment.ValueLen);
+            AContentLength := StrToInt64Def(string(RawLine), 0);
+          end;
+          Key := 'content-length';
+        end
+        else if CompareBytesCI(ABuffer, Segment.KeyStart, Segment.KeyLen, 'transfer-encoding') then
+          Key := 'transfer-encoding'
+        else if CompareBytesCI(ABuffer, Segment.KeyStart, Segment.KeyLen, 'connection') then
+          Key := 'connection'
+        else if CompareBytesCI(ABuffer, Segment.KeyStart, Segment.KeyLen, 'host') then
+          Key := 'host'
+        else if CompareBytesCI(ABuffer, Segment.KeyStart, Segment.KeyLen, 'content-type') then
+          Key := 'content-type'
+        else
+        begin
+          SetString(RawLine, PAnsiChar(@ABuffer[Segment.KeyStart]), Segment.KeyLen);
+          Key := LowerCase(Trim(string(RawLine)));
         end;
+
+        AHeaders.AddOrSetValue(Key, Segment);
       end;
     end;
 
@@ -911,7 +945,7 @@ end;
 
 { TEpollRawResponse }
 
-constructor TEpollRawResponse.Create(ASocket: Integer);
+constructor TEpollRawResponse.Create(ASocket: Integer; AIsKeepAlive: Boolean);
 begin
   inherited Create;
   FSocket := ASocket;
@@ -919,6 +953,7 @@ begin
   FStatusCode := 200;
   FReason := 'OK';
   FHeaders := TDictionary<string, string>.Create;
+  FIsKeepAlive := AIsKeepAlive;
 end;
 
 destructor TEpollRawResponse.Destroy;
@@ -931,25 +966,37 @@ procedure TEpollRawResponse.SetCustomHeader(const AName, AValue: string);
 begin
 end;
 
-procedure TEpollRawResponse.SendHeaders;
+function TEpollRawResponse.PrepareHeaders: TBytes;
 var
   LHeaderStr: string;
-  LHeaderBytes: TBytes;
   LPair: TPair<string, string>;
 begin
-  if FHeadersSent then Exit;
-
   LHeaderStr := Format('HTTP/1.1 %d %s'#13#10, [FStatusCode, FReason]);
   
   if not FHeaders.ContainsKey('Content-Type') then
     FHeaders.Add('Content-Type', 'text/html; charset=utf-8');
 
+  if not FHeaders.ContainsKey('Connection') then
+  begin
+    if FIsKeepAlive then
+      FHeaders.Add('Connection', 'keep-alive')
+    else
+      FHeaders.Add('Connection', 'close');
+  end;
+
   for LPair in FHeaders do
     LHeaderStr := LHeaderStr + Format('%s: %s'#13#10, [LPair.Key, LPair.Value]);
 
   LHeaderStr := LHeaderStr + #13#10;
-  LHeaderBytes := TEncoding.UTF8.GetBytes(LHeaderStr);
+  Result := TEncoding.UTF8.GetBytes(LHeaderStr);
+end;
 
+procedure TEpollRawResponse.SendHeaders;
+var
+  LHeaderBytes: TBytes;
+begin
+  if FHeadersSent then Exit;
+  LHeaderBytes := PrepareHeaders;
   {$IFDEF FPC}
   fpSend(FSocket, @LHeaderBytes[0], Length(LHeaderBytes), 0);
   {$ELSE}
@@ -971,6 +1018,10 @@ var
   {$IFDEF FPC}
   I: Integer;
   {$ENDIF}
+  {$IF NOT DEFINED(FPC)}
+  LFileHandle: THandle;
+  LCount: Int64;
+  {$ENDIF}
 begin
   LHasChunkedHeader := False;
   if AHeadersList <> nil then
@@ -991,6 +1042,23 @@ begin
     FHeaders.AddOrSetValue('Transfer-Encoding', 'chunked');
     FHeaders.Remove('Content-Length');
   end;
+
+  {$IF NOT DEFINED(FPC)}
+  // Otimização Zero-Copy com sendfile do Linux para TFileStream
+  if (not LUseChunked) and (AStream is TFileStream) then
+  begin
+    LFileHandle := TFileStream(AStream).Handle;
+    LCount := AStream.Size - AStream.Position;
+    if LCount > 0 then
+    begin
+      FHeaders.AddOrSetValue('Content-Length', IntToStr(LCount));
+      SendHeaders;
+      if sendfile(FSocket, LFileHandle, nil, LCount) >= 0 then
+        Exit; // Sucesso com Zero-Copy
+      // Se falhar (por exemplo, socket não aceitar ou erro), cai no fallback de cópia normal
+    end;
+  end;
+  {$ENDIF}
 
   SendHeaders;
 
@@ -1045,6 +1113,10 @@ var
   LContentType: string;
   {$IFDEF FPC}
   I: Integer;
+  {$ENDIF}
+  {$IF NOT DEFINED(FPC)}
+  LHeaderBytes: TBytes;
+  LIov: array[0..1] of iovec;
   {$ENDIF}
 begin
   FStatusCode := ARes.Status;
@@ -1108,15 +1180,36 @@ begin
 
   FHeaders.AddOrSetValue('Content-Length', IntToStr(Length(LBodyBytes)));
 
+  {$IF NOT DEFINED(FPC)}
+  // Delphi Linux com writev (Single System Call para Header + Body)
+  if not FHeadersSent then
+  begin
+    LHeaderBytes := PrepareHeaders;
+    FHeadersSent := True;
+    if Length(LBodyBytes) > 0 then
+    begin
+      LIov[0].iov_base := @LHeaderBytes[0];
+      LIov[0].iov_len := Length(LHeaderBytes);
+      LIov[1].iov_base := @LBodyBytes[0];
+      LIov[1].iov_len := Length(LBodyBytes);
+      writev(FSocket, @LIov[0], 2);
+    end
+    else
+    begin
+      send(FSocket, LHeaderBytes[0], Length(LHeaderBytes), 0);
+    end;
+  end
+  else
+  begin
+    if Length(LBodyBytes) > 0 then
+      send(FSocket, LBodyBytes[0], Length(LBodyBytes), 0);
+  end;
+  {$ELSE}
+  // Lazarus FPC fallback síncrono padrão
   SendHeaders;
   if Length(LBodyBytes) > 0 then
-  begin
-    {$IFDEF FPC}
     fpSend(FSocket, @LBodyBytes[0], Length(LBodyBytes), 0);
-    {$ELSE}
-    send(FSocket, LBodyBytes[0], Length(LBodyBytes), 0);
-    {$ENDIF}
-  end;
+  {$ENDIF}
 end;
 
 { THorseEpollWorker }
@@ -1130,6 +1223,7 @@ begin
   FPipeFds[0] := -1;
   FPipeFds[1] := -1;
   FConnections := TList<TEpollConnectionContext>.Create;
+  FConnectionsSync := TCriticalSection.Create;
   FreeOnTerminate := False;
 end;
 
@@ -1139,6 +1233,7 @@ begin
   while FConnections.Count > 0 do
     CloseConnection(FConnections[0]);
   FConnections.Free;
+  FConnectionsSync.Free;
   inherited;
 end;
 
@@ -1181,7 +1276,12 @@ end;
 
 procedure THorseEpollWorker.CloseConnection(AContext: TEpollConnectionContext);
 begin
-  FConnections.Remove(AContext);
+  FConnectionsSync.Enter;
+  try
+    FConnections.Remove(AContext);
+  finally
+    FConnectionsSync.Leave;
+  end;
   epoll_ctl(FEpollFd, EPOLL_CTL_DEL, AContext.Socket, nil);
   {$IF DEFINED(FPC)}
   fpClose(AContext.Socket);
@@ -1195,7 +1295,7 @@ procedure THorseEpollWorker.ProcessClientRead(AContext: TEpollConnectionContext)
 var
   LBytesRead: Integer;
   LRawReq: IHorseRawRequest;
-  LRawRes: TEpollRawResponse;
+  LRawRes: IHorseRawResponse;
   LWebRequest: TInterfacedWebRequest;
   LWebResponse: TInterfacedWebResponse;
   LReq: THorseRequest;
@@ -1208,6 +1308,7 @@ var
   LIsChunked: Boolean;
   LSegment: THeaderSegment;
   LRawVal: AnsiString;
+  LBodyReadBuf: TBytes;
 begin
   LRequestComplete := False;
 
@@ -1316,12 +1417,13 @@ begin
   end
   else
   begin
+    SetLength(LBodyReadBuf, 8192);
     while True do
     begin
       {$IFDEF FPC}
-      LBytesRead := fpRecv(AContext.Socket, @AContext.Buffer[0], 8192, 0);
+      LBytesRead := fpRecv(AContext.Socket, @LBodyReadBuf[0], 8192, 0);
       {$ELSE}
-      LBytesRead := recv(AContext.Socket, AContext.Buffer[0], 8192, 0);
+      LBytesRead := recv(AContext.Socket, LBodyReadBuf[0], 8192, 0);
       {$ENDIF}
 
       if LBytesRead = 0 then
@@ -1349,12 +1451,12 @@ begin
 
       if AContext.FChunked then
       begin
-        LRequestComplete := AContext.ProcessChunkedBytes(AContext.Buffer, 0, LBytesRead);
+        LRequestComplete := AContext.ProcessChunkedBytes(LBodyReadBuf, 0, LBytesRead);
         if LRequestComplete then Break;
       end
       else
       begin
-        AContext.WriteToBodyStream(AContext.Buffer, 0, LBytesRead);
+        AContext.WriteToBodyStream(LBodyReadBuf, 0, LBytesRead);
         AContext.BytesReceived := AContext.BytesReceived + LBytesRead;
         LRequestComplete := AContext.BytesReceived >= AContext.BodyOffset + AContext.ContentLength;
         if LRequestComplete then Break;
@@ -1383,7 +1485,14 @@ begin
     );
     AContext.FBodyStream := nil;
     AContext.FTempFileName := '';
-    LRawRes := TEpollRawResponse.Create(AContext.Socket);
+
+    LConnHeader := LRawReq.GetFieldByName('connection');
+    if SameText(LRawReq.GetProtocolVersion, 'HTTP/1.1') then
+      LKeepAlive := not SameText(LConnHeader, 'close')
+    else
+      LKeepAlive := SameText(LConnHeader, 'keep-alive');
+
+    LRawRes := TEpollRawResponse.Create(AContext.Socket, LKeepAlive);
     LWebRequest := TInterfacedWebRequest.Create(LRawReq);
     
     {$IFDEF FPC}
@@ -1391,32 +1500,69 @@ begin
     {$ELSE}
     LWebResponse := TInterfacedWebResponse.Create(LRawRes);
     {$ENDIF}
+
+    {$IF NOT DEFINED(FPC)}
+    // Delphi Linux: Executa rotas assincronamente no Task Parallel Library
+    TTask.Run(
+      procedure
+      var
+        LHorseReq: THorseRequest;
+        LHorseRes: THorseResponse;
+        LLocalEvent: epoll_event;
+        LLocalEpollFd: Integer;
+        LLocalContext: TEpollConnectionContext;
+        LLocalRawRes: IHorseRawResponse;
+        LLocalKeepAlive: Boolean;
+      begin
+        LLocalEpollFd := FEpollFd;
+        LLocalContext := AContext;
+        LLocalRawRes := LRawRes;
+        LLocalKeepAlive := LKeepAlive;
+        try
+          LHorseReq := THorseRequest.Create(LWebRequest);
+          LHorseRes := THorseResponse.Create(nil);
+          LHorseRes.SetCSRawWebResponse(LWebResponse);
+          try
+            THorseProviderEpoll.Execute(LHorseReq, LHorseRes);
+          finally
+            TEpollRawResponse(LLocalRawRes).SendResponse(LHorseRes);
+            LHorseReq.Free;
+            LHorseRes.Free;
+          end;
+        finally
+          LWebRequest.Free;
+          
+          if LLocalKeepAlive then
+          begin
+            LLocalContext.ClearRequest;
+            LLocalContext.FIsKeepAlive := True;
+            LLocalContext.BytesReceived := 0;
+
+            LLocalEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
+            LLocalEvent.data.ptr := LLocalContext;
+            epoll_ctl(LLocalEpollFd, EPOLL_CTL_MOD, LLocalContext.Socket, @LLocalEvent);
+          end
+          else
+          begin
+            CloseConnection(LLocalContext);
+          end;
+        end;
+      end);
+    {$ELSE}
+    // FPC fallback síncrono padrão
     try
       LReq := THorseRequest.Create(LWebRequest);
       LRes := THorseResponse.Create(nil);
-      {$IFNDEF FPC}
-      LRes.SetCSRawWebResponse(LWebResponse);
-      LWebResponse := nil;
-      {$ENDIF}
       try
         THorseProviderEpoll.Execute(LReq, LRes);
       finally
-        LRawRes.SendResponse(LRes);
+        TEpollRawResponse(LRawRes).SendResponse(LRes);
         LReq.Free;
         LRes.Free;
       end;
     finally
       LWebRequest.Free;
-      if LWebResponse <> nil then
-        LWebResponse.Free;
-      LRawRes.Free;
     end;
-
-    LConnHeader := LRawReq.GetFieldByName('connection');
-    if SameText(LRawReq.GetProtocolVersion, 'HTTP/1.1') then
-      LKeepAlive := not SameText(LConnHeader, 'close')
-    else
-      LKeepAlive := SameText(LConnHeader, 'keep-alive');
 
     if LKeepAlive then
     begin
@@ -1430,6 +1576,7 @@ begin
     end
     else
       CloseConnection(AContext);
+    {$ENDIF}
   end
   else if AContext.BodyOffset <> -1 then
   begin
@@ -1450,21 +1597,35 @@ var
   LNow: Int64;
   I: Integer;
   LContext: TEpollConnectionContext;
+  LExpired: TList<TEpollConnectionContext>;
 begin
   LNow := GetTickCount64;
-  for I := FConnections.Count - 1 downto 0 do
-  begin
-    LContext := FConnections[I];
-    if LContext.FIsKeepAlive and (LContext.BytesReceived = 0) then
-    begin
-      if LNow - LContext.LastActive > 60000 then
-        CloseConnection(LContext);
-    end
-    else
-    begin
-      if LNow - LContext.LastActive > 5000 then
-        CloseConnection(LContext);
+  LExpired := TList<TEpollConnectionContext>.Create;
+  try
+    FConnectionsSync.Enter;
+    try
+      for I := FConnections.Count - 1 downto 0 do
+      begin
+        LContext := FConnections[I];
+        if LContext.FIsKeepAlive and (LContext.BytesReceived = 0) then
+        begin
+          if LNow - LContext.LastActive > 60000 then
+            LExpired.Add(LContext);
+        end
+        else
+        begin
+          if LNow - LContext.LastActive > 5000 then
+            LExpired.Add(LContext);
+        end;
+      end;
+    finally
+      FConnectionsSync.Leave;
     end;
+
+    for LContext in LExpired do
+      CloseConnection(LContext);
+  finally
+    LExpired.Free;
   end;
 end;
 
@@ -1484,6 +1645,8 @@ var
   LClientFd: Integer;
   LOptVal: Integer;
   LContext: TEpollConnectionContext;
+  LLastTimeoutCheck: Int64;
+  LCurrentTime: Int64;
 begin
   {$IFDEF FPC}
   FEpollFd := epoll_create(1024);
@@ -1523,6 +1686,7 @@ begin
   {$IFDEF FPC}
   Writeln('Worker: Thread iniciada. FListenSocket = ', FListenSocket, ' FEpollFd = ', FEpollFd);
   {$ENDIF}
+  LLastTimeoutCheck := GetTickCount64;
 
   try
     while not Terminated and FRunning do
@@ -1590,7 +1754,12 @@ begin
             {$ENDIF}
 
             LContext := TEpollConnectionContext.Create(LClientFd);
-            FConnections.Add(LContext);
+            FConnectionsSync.Enter;
+            try
+              FConnections.Add(LContext);
+            finally
+              FConnectionsSync.Leave;
+            end;
 
             LEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
             LEvent.data.ptr := LContext;
@@ -1612,10 +1781,22 @@ begin
         end;
       end;
 
-      CheckTimeouts;
+      LCurrentTime := GetTickCount64;
+      if LCurrentTime - LLastTimeoutCheck > 1000 then
+      begin
+        CheckTimeouts;
+        LLastTimeoutCheck := LCurrentTime;
+      end;
     end;
   finally
     {$IFDEF FPC}Writeln('Worker: Thread encerrando.');{$ENDIF}
+    if FLocalPool <> nil then
+    begin
+      while FLocalPool.Count > 0 do
+        FLocalPool.Dequeue;
+      FLocalPool.Free;
+      FLocalPool := nil;
+    end;
   end;
 end;
 

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -2228,6 +2228,8 @@ begin
   fpSetrlimit(RLIMIT_NOFILE, @LRLimit);
   {$ELSE}
   setrlimit(RLIMIT_NOFILE, LRLimit);
+  TThreadPool.Default.MaxWorkerThreads := 2048;
+  TThreadPool.Default.MinWorkerThreads := TThread.ProcessorCount * 8;
   {$ENDIF}
 end;
 

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -3,6 +3,7 @@ unit Horse.Provider.Epoll;
 {$IF DEFINED(FPC)}
   {$MODE DELPHI}{$H+}
 {$ENDIF}
+{$POINTERMATH ON}
 
 interface
 
@@ -114,13 +115,15 @@ type
     function GetServerPort: Integer;
     function GetContentType: string;
     function GetContent: string;
-    {$IF DEFINED(FPC)}
+    {$IFDEF FPC}
     function GetContentLength: Integer;
-    {$ELSEIF CompilerVersion >= 32.0}
-    function GetContentLength: Int64;
     {$ELSE}
-    function GetContentLength: Integer;
-    {$IFEND}
+      {$IF CompilerVersion >= 32.0}
+      function GetContentLength: Int64;
+      {$ELSE}
+      function GetContentLength: Integer;
+      {$ENDIF}
+    {$ENDIF}
     function GetFieldByName(const AName: string): string;
 
     procedure PopulateQueryFields(ADest: TStrings);
@@ -258,8 +261,66 @@ implementation
 
 {$IFDEF LINUX}
 
+type
+  TLocalBufferPool = record
+  private
+    const MAX_BUFFERS = 64;
+    const BUFFER_SIZE = 8192;
+  public
+    Buffers: array[0..MAX_BUFFERS - 1] of TBytes;
+    Head: Integer;
+    Tail: Integer;
+    Count: Integer;
+    procedure Init;
+    function Acquire: TBytes;
+    procedure Release(var ABuffer: TBytes);
+    procedure DestroyPool;
+  end;
+
 threadvar
-  FLocalPool: TQueue<TBytes>;
+  FLocalPool: TLocalBufferPool;
+  FLocalPoolInitialized: Boolean;
+
+{$IFDEF FPC}
+type
+  TEpollFPCTask = class
+  public
+    Context: TEpollConnectionContext;
+    RawReq: IHorseRawRequest;
+    RawRes: IHorseRawResponse;
+    WebRequest: TInterfacedWebRequest;
+    KeepAlive: Boolean;
+    EpollFd: Integer;
+    Worker: TThread;
+    constructor Create(AContext: TEpollConnectionContext; ARawReq: IHorseRawRequest; ARawRes: IHorseRawResponse; AWebRequest: TInterfacedWebRequest; AKeepAlive: Boolean; AEpollFd: Integer; AWorker: TThread);
+  end;
+
+  TEpollFPCWorkerThread = class(TThread)
+  private
+    FPool: TObject;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(APool: TObject);
+  end;
+
+  TEpollFPCTaskPool = class
+  private
+    FTasks: TQueue<TEpollFPCTask>;
+    FWorkers: TList<TEpollFPCWorkerThread>;
+    FLock: TCriticalSection;
+    FEvent: TEvent;
+    FActive: Boolean;
+    function DequeueTask: TEpollFPCTask;
+  public
+    constructor Create(AThreadCount: Integer);
+    destructor Destroy; override;
+    procedure QueueTask(ATask: TEpollFPCTask);
+  end;
+
+var
+  GTaskPool: TEpollFPCTaskPool = nil;
+{$ENDIF}
 
 const
   EPOLLIN      = $00000001;
@@ -278,6 +339,10 @@ const
   TCP_DEFER_ACCEPT = 9;
   TCP_NODELAY = 1;
 
+  EAGAIN = 11;
+  EWOULDBLOCK = 11;
+  EINTR = 4;
+
 type
   epoll_data = record
     case Integer of
@@ -293,7 +358,36 @@ type
   end;
   pepoll_event = ^epoll_event;
 
-{$IF NOT DEFINED(FPC)}
+  iovec = record
+    iov_base: Pointer;
+    iov_len: NativeUInt;
+  end;
+  piovec = ^iovec;
+
+  TEpollFDSet = record
+    fds_bits: array[0..31] of LongInt;
+  end;
+  PEpollFDSet = ^TEpollFDSet;
+
+  TEpollTimeVal = record
+    tv_sec: Int64;
+    tv_usec: Int64;
+  end;
+  PEpollTimeVal = ^TEpollTimeVal;
+
+{$IFDEF FPC}
+function writev(fd: Integer; iov: piovec; iovcnt: Integer): NativeInt; cdecl; external 'libc' name 'writev';
+{$ELSE}
+function writev(fd: Integer; iov: piovec; iovcnt: Integer): NativeInt; cdecl; external libc name 'writev';
+{$ENDIF}
+
+{$IFDEF FPC}
+function select(nfds: Integer; readfds: PEpollFDSet; writefds: PEpollFDSet; exceptfds: PEpollFDSet; timeout: PEpollTimeVal): Integer; cdecl; external 'libc' name 'select';
+{$ELSE}
+function select(nfds: Integer; readfds: PEpollFDSet; writefds: PEpollFDSet; exceptfds: PEpollFDSet; timeout: PEpollTimeVal): Integer; cdecl; external libc name 'select';
+{$ENDIF}
+
+{$IFNDEF FPC}
 const
   RLIMIT_NOFILE = 7;
 
@@ -316,16 +410,10 @@ function pipe(filedes: PInteger): Integer; cdecl; external libc name 'pipe';
 function setrlimit(resource: Integer; const rlim: rlimit): Integer; cdecl; external libc name 'setrlimit';
 function clock_gettime(clk_id: Integer; var tp: TEpollTimeSpec): Integer; cdecl; external libc name 'clock_gettime';
 
-type
-  iovec = record
-    iov_base: Pointer;
-    iov_len: NativeUInt;
-  end;
-  piovec = ^iovec;
-
-function writev(fd: Integer; iov: piovec; iovcnt: Integer): NativeInt; cdecl; external libc name 'writev';
 function sendfile(out_fd: Integer; in_fd: Integer; offset: PInt64; count: NativeUInt): NativeInt; cdecl; external libc name 'sendfile';
+{$ENDIF}
 
+{$IFNDEF FPC}
 function GetTickCount64: Int64;
 var
   LTime: TEpollTimeSpec;
@@ -335,7 +423,332 @@ begin
   else
     Result := 0;
 end;
-{$IFEND}
+{$ENDIF}
+
+procedure Epoll_FD_ZERO(var fds: TEpollFDSet); inline;
+begin
+  FillChar(fds, SizeOf(fds), 0);
+end;
+
+procedure Epoll_FD_SET(fd: Integer; var fds: TEpollFDSet); inline;
+begin
+  if (fd >= 0) and (fd < 1024) then
+    fds.fds_bits[fd div 32] := fds.fds_bits[fd div 32] or (1 shl (fd mod 32));
+end;
+
+function SendAllV(ASocket: Integer; AIov: piovec; AIovCnt: Integer): Boolean;
+var
+  LWritten: NativeInt;
+  LTotalBytes: NativeUInt;
+  I: Integer;
+  LFDSet: TEpollFDSet;
+  LTimeVal: TEpollTimeVal;
+  LRet: Integer;
+  LErr: Integer;
+begin
+  Result := False;
+  LTotalBytes := 0;
+  for I := 0 to AIovCnt - 1 do
+    Inc(LTotalBytes, AIov[I].iov_len);
+
+  while LTotalBytes > 0 do
+  begin
+    LWritten := writev(ASocket, AIov, AIovCnt);
+    if LWritten >= 0 then
+    begin
+      Dec(LTotalBytes, LWritten);
+      if LTotalBytes = 0 then
+      begin
+        Result := True;
+        Exit;
+      end;
+      
+      while (AIovCnt > 0) and (LWritten >= NativeInt(AIov^.iov_len)) do
+      begin
+        Dec(LWritten, AIov^.iov_len);
+        Inc(AIov);
+        Dec(AIovCnt);
+      end;
+      if AIovCnt > 0 then
+      begin
+        AIov^.iov_base := Pointer(PByte(AIov^.iov_base) + LWritten);
+        Dec(AIov^.iov_len, LWritten);
+      end;
+      Continue;
+    end;
+
+    {$IFDEF FPC}
+    LErr := fpGetErrno;
+    {$ELSE}
+    LErr := errno;
+    {$ENDIF}
+
+    if (LErr = EAGAIN) or (LErr = EWOULDBLOCK) or (LErr = EINTR) then
+    begin
+      if LErr = EINTR then
+        Continue;
+
+      Epoll_FD_ZERO(LFDSet);
+      Epoll_FD_SET(ASocket, LFDSet);
+      LTimeVal.tv_sec := 5;
+      LTimeVal.tv_usec := 0;
+      
+      LRet := select(ASocket + 1, nil, @LFDSet, nil, @LTimeVal);
+      if LRet <= 0 then
+        Exit;
+    end
+    else
+    begin
+      Exit;
+    end;
+  end;
+  Result := True;
+end;
+
+function SendAll(ASocket: Integer; ABuffer: Pointer; ALength: Integer): Boolean;
+var
+  LIov: iovec;
+begin
+  if ALength <= 0 then
+    Exit(True);
+  LIov.iov_base := ABuffer;
+  LIov.iov_len := ALength;
+  Result := SendAllV(ASocket, @LIov, 1);
+end;
+
+{ TLocalBufferPool }
+
+procedure TLocalBufferPool.Init;
+var
+  I: Integer;
+begin
+  Head := 0;
+  Tail := 0;
+  Count := MAX_BUFFERS;
+  for I := 0 to MAX_BUFFERS - 1 do
+    SetLength(Buffers[I], BUFFER_SIZE);
+end;
+
+function TLocalBufferPool.Acquire: TBytes;
+begin
+  if Count > 0 then
+  begin
+    Result := Buffers[Head];
+    Buffers[Head] := nil;
+    Head := (Head + 1) mod MAX_BUFFERS;
+    Dec(Count);
+  end
+  else
+  begin
+    SetLength(Result, BUFFER_SIZE);
+  end;
+end;
+
+procedure TLocalBufferPool.Release(var ABuffer: TBytes);
+begin
+  if ABuffer = nil then Exit;
+  if Length(ABuffer) <> BUFFER_SIZE then
+  begin
+    ABuffer := nil;
+    Exit;
+  end;
+
+  if Count < MAX_BUFFERS then
+  begin
+    Buffers[Tail] := ABuffer;
+    ABuffer := nil;
+    Tail := (Tail + 1) mod MAX_BUFFERS;
+    Inc(Count);
+  end
+  else
+  begin
+    ABuffer := nil;
+  end;
+end;
+
+procedure TLocalBufferPool.DestroyPool;
+var
+  I: Integer;
+begin
+  for I := 0 to MAX_BUFFERS - 1 do
+    Buffers[I] := nil;
+  Count := 0;
+  Head := 0;
+  Tail := 0;
+end;
+
+{$IFDEF FPC}
+{ TEpollFPCTask }
+
+constructor TEpollFPCTask.Create(AContext: TEpollConnectionContext; ARawReq: IHorseRawRequest; ARawRes: IHorseRawResponse; AWebRequest: TInterfacedWebRequest; AKeepAlive: Boolean; AEpollFd: Integer; AWorker: TThread);
+begin
+  inherited Create;
+  Context := AContext;
+  RawReq := ARawReq;
+  RawRes := ARawRes;
+  WebRequest := AWebRequest;
+  KeepAlive := AKeepAlive;
+  EpollFd := AEpollFd;
+  Worker := AWorker;
+end;
+
+{ TEpollFPCWorkerThread }
+
+constructor TEpollFPCWorkerThread.Create(APool: TObject);
+begin
+  inherited Create(False);
+  FPool := APool;
+  FreeOnTerminate := False;
+end;
+
+procedure TEpollFPCWorkerThread.Execute;
+var
+  LPool: TEpollFPCTaskPool;
+  LTask: TEpollFPCTask;
+  LHorseReq: THorseRequest;
+  LHorseRes: THorseResponse;
+  LLocalEvent: epoll_event;
+begin
+  LPool := TEpollFPCTaskPool(FPool);
+  
+  if not FLocalPoolInitialized then
+  begin
+    FLocalPool.Init;
+    FLocalPoolInitialized := True;
+  end;
+
+  try
+    while not Terminated and LPool.FActive do
+    begin
+      LTask := LPool.DequeueTask;
+      if LTask = nil then
+      begin
+        if Terminated or not LPool.FActive then
+          Break;
+        LPool.FEvent.WaitFor(1000);
+        Continue;
+      end;
+
+      try
+        LHorseReq := THorseRequest.Create(LTask.WebRequest);
+        LHorseRes := THorseResponse.Create(nil);
+        try
+          THorseProviderEpoll.Execute(LHorseReq, LHorseRes);
+        finally
+          TEpollRawResponse(LTask.RawRes).SendResponse(LHorseRes);
+          LHorseReq.Free;
+          LHorseRes.Free;
+        end;
+      finally
+        LTask.WebRequest.Free;
+        
+        if LTask.KeepAlive then
+        begin
+          LTask.Context.ClearRequest;
+          LTask.Context.FIsKeepAlive := True;
+          LTask.Context.BytesReceived := 0;
+
+          LLocalEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
+          LLocalEvent.data.ptr := LTask.Context;
+          epoll_ctl(LTask.EpollFd, EPOLL_CTL_MOD, LTask.Context.Socket, @LLocalEvent);
+        end
+        else
+        begin
+          THorseEpollWorker(LTask.Worker).CloseConnection(LTask.Context);
+        end;
+        LTask.Free;
+      end;
+    end;
+  finally
+    if FLocalPoolInitialized then
+    begin
+      FLocalPool.DestroyPool;
+      FLocalPoolInitialized := False;
+    end;
+  end;
+end;
+
+{ TEpollFPCTaskPool }
+
+constructor TEpollFPCTaskPool.Create(AThreadCount: Integer);
+var
+  I: Integer;
+begin
+  inherited Create;
+  FActive := True;
+  FTasks := TQueue<TEpollFPCTask>.Create;
+  FWorkers := TList<TEpollFPCWorkerThread>.Create;
+  FLock := TCriticalSection.Create;
+  FEvent := TEvent.Create(nil, False, False, '');
+  
+  for I := 1 to AThreadCount do
+    FWorkers.Add(TEpollFPCWorkerThread.Create(Self));
+end;
+
+destructor TEpollFPCTaskPool.Destroy;
+var
+  I: Integer;
+  LTask: TEpollFPCTask;
+begin
+  FActive := False;
+  FEvent.SetEvent;
+  
+  for I := 0 to FWorkers.Count - 1 do
+    FWorkers[I].Terminate;
+  
+  FEvent.SetEvent;
+  
+  for I := 0 to FWorkers.Count - 1 do
+  begin
+    FWorkers[I].WaitFor;
+    FWorkers[I].Free;
+  end;
+  FWorkers.Free;
+
+  FLock.Enter;
+  try
+    while FTasks.Count > 0 do
+    begin
+      LTask := FTasks.Dequeue;
+      LTask.WebRequest.Free;
+      LTask.Free;
+    end;
+    FTasks.Free;
+  finally
+    FLock.Leave;
+  end;
+  
+  FLock.Free;
+  FEvent.Free;
+  inherited;
+end;
+
+procedure TEpollFPCTaskPool.QueueTask(ATask: TEpollFPCTask);
+begin
+  FLock.Enter;
+  try
+    if FActive then
+    begin
+      FTasks.Enqueue(ATask);
+      FEvent.SetEvent;
+    end;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function TEpollFPCTaskPool.DequeueTask: TEpollFPCTask;
+begin
+  Result := nil;
+  FLock.Enter;
+  try
+    if FTasks.Count > 0 then
+      Result := FTasks.Dequeue;
+  finally
+    FLock.Leave;
+  end;
+end;
+{$ENDIF}
 
 { TBufferPool }
 
@@ -349,25 +762,22 @@ end;
 
 class function TBufferPool.Acquire: TBytes;
 begin
-  if FLocalPool = nil then
-    FLocalPool := TQueue<TBytes>.Create;
-
-  if FLocalPool.Count > 0 then
-    Result := FLocalPool.Dequeue
-  else
-    SetLength(Result, BUFFER_SIZE);
+  if not FLocalPoolInitialized then
+  begin
+    FLocalPool.Init;
+    FLocalPoolInitialized := True;
+  end;
+  Result := FLocalPool.Acquire;
 end;
 
 class procedure TBufferPool.Release(var ABuffer: TBytes);
 begin
-  if ABuffer = nil then Exit;
-  if FLocalPool = nil then
-    FLocalPool := TQueue<TBytes>.Create;
-
-  if FLocalPool.Count < 32 then
-    FLocalPool.Enqueue(ABuffer)
-  else
+  if not FLocalPoolInitialized then
+  begin
     ABuffer := nil;
+    Exit;
+  end;
+  FLocalPool.Release(ABuffer);
 end;
 
 { TEpollConnectionContext }
@@ -825,22 +1235,24 @@ begin
   Result := TEncoding.UTF8.GetString(LBytes);
 end;
 
-{$IF DEFINED(FPC)}
+{$IFDEF FPC}
 function TEpollRawRequest.GetContentLength: Integer;
-begin
-  Result := FContentLength;
-end;
-{$ELSEIF CompilerVersion >= 32.0}
-function TEpollRawRequest.GetContentLength: Int64;
 begin
   Result := FContentLength;
 end;
 {$ELSE}
-function TEpollRawRequest.GetContentLength: Integer;
-begin
-  Result := FContentLength;
-end;
-{$IFEND}
+  {$IF CompilerVersion >= 32.0}
+  function TEpollRawRequest.GetContentLength: Int64;
+  begin
+    Result := FContentLength;
+  end;
+  {$ELSE}
+  function TEpollRawRequest.GetContentLength: Integer;
+  begin
+    Result := FContentLength;
+  end;
+  {$ENDIF}
+{$ENDIF}
 
 function TEpollRawRequest.GetFieldByName(const AName: string): string;
 begin
@@ -997,11 +1409,8 @@ var
 begin
   if FHeadersSent then Exit;
   LHeaderBytes := PrepareHeaders;
-  {$IFDEF FPC}
-  fpSend(FSocket, @LHeaderBytes[0], Length(LHeaderBytes), 0);
-  {$ELSE}
-  send(FSocket, LHeaderBytes[0], Length(LHeaderBytes), 0);
-  {$ENDIF}
+  if Length(LHeaderBytes) > 0 then
+    SendAll(FSocket, @LHeaderBytes[0], Length(LHeaderBytes));
   FHeadersSent := True;
 end;
 
@@ -1015,6 +1424,7 @@ var
   LTermStr: string;
   LTermBytes: TBytes;
   LHasChunkedHeader: Boolean;
+  LChunkIov: array[0..2] of iovec;
   {$IFDEF FPC}
   I: Integer;
   {$ENDIF}
@@ -1073,23 +1483,17 @@ begin
     begin
       LHexStr := Format('%x'#13#10, [LReadCount]);
       LHexBytes := TEncoding.ASCII.GetBytes(LHexStr);
-      {$IFDEF FPC}
-      if (fpSend(FSocket, @LHexBytes[0], Length(LHexBytes), 0) < 0) or
-         (fpSend(FSocket, @LChunkBuf[0], LReadCount, 0) < 0) or
-         (fpSend(FSocket, PAnsiChar(#13#10), 2, 0) < 0) then Break;
-      {$ELSE}
-      if (send(FSocket, LHexBytes[0], Length(LHexBytes), 0) < 0) or
-         (send(FSocket, LChunkBuf[0], LReadCount, 0) < 0) or
-         (send(FSocket, PAnsiChar(#13#10)^, 2, 0) < 0) then Break;
-      {$ENDIF}
+      LChunkIov[0].iov_base := @LHexBytes[0];
+      LChunkIov[0].iov_len := Length(LHexBytes);
+      LChunkIov[1].iov_base := @LChunkBuf[0];
+      LChunkIov[1].iov_len := LReadCount;
+      LChunkIov[2].iov_base := PAnsiChar(#13#10);
+      LChunkIov[2].iov_len := 2;
+      if not SendAllV(FSocket, @LChunkIov[0], 3) then Break;
     end
     else
     begin
-      {$IFDEF FPC}
-      if fpSend(FSocket, @LChunkBuf[0], LReadCount, 0) < 0 then Break;
-      {$ELSE}
-      if send(FSocket, LChunkBuf[0], LReadCount, 0) < 0 then Break;
-      {$ENDIF}
+      if not SendAll(FSocket, @LChunkBuf[0], LReadCount) then Break;
     end;
   end;
 
@@ -1097,11 +1501,7 @@ begin
   begin
     LTermStr := '0'#13#10#13#10;
     LTermBytes := TEncoding.ASCII.GetBytes(LTermStr);
-    {$IFDEF FPC}
-    fpSend(FSocket, @LTermBytes[0], Length(LTermBytes), 0);
-    {$ELSE}
-    send(FSocket, LTermBytes[0], Length(LTermBytes), 0);
-    {$ENDIF}
+    SendAll(FSocket, @LTermBytes[0], Length(LTermBytes));
   end;
 end;
 
@@ -1111,12 +1511,10 @@ var
   LPair: TPair<string, string>;
   LHeadersList: {$IFDEF FPC}TStrings{$ELSE}TDictionary<string, string>{$ENDIF};
   LContentType: string;
-  {$IFDEF FPC}
-  I: Integer;
-  {$ENDIF}
-  {$IF NOT DEFINED(FPC)}
   LHeaderBytes: TBytes;
   LIov: array[0..1] of iovec;
+  {$IFDEF FPC}
+  I: Integer;
   {$ENDIF}
 begin
   FStatusCode := ARes.Status;
@@ -1180,8 +1578,6 @@ begin
 
   FHeaders.AddOrSetValue('Content-Length', IntToStr(Length(LBodyBytes)));
 
-  {$IF NOT DEFINED(FPC)}
-  // Delphi Linux com writev (Single System Call para Header + Body)
   if not FHeadersSent then
   begin
     LHeaderBytes := PrepareHeaders;
@@ -1192,24 +1588,18 @@ begin
       LIov[0].iov_len := Length(LHeaderBytes);
       LIov[1].iov_base := @LBodyBytes[0];
       LIov[1].iov_len := Length(LBodyBytes);
-      writev(FSocket, @LIov[0], 2);
+      SendAllV(FSocket, @LIov[0], 2);
     end
     else
     begin
-      send(FSocket, LHeaderBytes[0], Length(LHeaderBytes), 0);
+      SendAll(FSocket, @LHeaderBytes[0], Length(LHeaderBytes));
     end;
   end
   else
   begin
     if Length(LBodyBytes) > 0 then
-      send(FSocket, LBodyBytes[0], Length(LBodyBytes), 0);
+      SendAll(FSocket, @LBodyBytes[0], Length(LBodyBytes));
   end;
-  {$ELSE}
-  // Lazarus FPC fallback síncrono padrão
-  SendHeaders;
-  if Length(LBodyBytes) > 0 then
-    fpSend(FSocket, @LBodyBytes[0], Length(LBodyBytes), 0);
-  {$ENDIF}
 end;
 
 { THorseEpollWorker }
@@ -1298,8 +1688,10 @@ var
   LRawRes: IHorseRawResponse;
   LWebRequest: TInterfacedWebRequest;
   LWebResponse: TInterfacedWebResponse;
+  {$IFDEF FPC}
   LReq: THorseRequest;
   LRes: THorseResponse;
+  {$ENDIF}
   LEvent: epoll_event;
   LKeepAlive: Boolean;
   LConnHeader: string;
@@ -1549,33 +1941,48 @@ begin
         end;
       end);
     {$ELSE}
-    // FPC fallback síncrono padrão
-    try
-      LReq := THorseRequest.Create(LWebRequest);
-      LRes := THorseResponse.Create(nil);
-      try
-        THorseProviderEpoll.Execute(LReq, LRes);
-      finally
-        TEpollRawResponse(LRawRes).SendResponse(LRes);
-        LReq.Free;
-        LRes.Free;
-      end;
-    finally
-      LWebRequest.Free;
-    end;
-
-    if LKeepAlive then
+    // Lazarus FPC: Despacha as rotas via GTaskPool de forma assíncrona
+    if GTaskPool <> nil then
     begin
-      AContext.ClearRequest;
-      AContext.FIsKeepAlive := True;
-      AContext.BytesReceived := 0;
-
-      LEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
-      LEvent.data.ptr := AContext;
-      epoll_ctl(FEpollFd, EPOLL_CTL_MOD, AContext.Socket, @LEvent);
+      GTaskPool.QueueTask(TEpollFPCTask.Create(
+        AContext,
+        LRawReq,
+        LRawRes,
+        LWebRequest,
+        LKeepAlive,
+        FEpollFd,
+        Self
+      ));
     end
     else
-      CloseConnection(AContext);
+    begin
+      try
+        LReq := THorseRequest.Create(LWebRequest);
+        LRes := THorseResponse.Create(nil);
+        try
+          THorseProviderEpoll.Execute(LReq, LRes);
+        finally
+          TEpollRawResponse(LRawRes).SendResponse(LRes);
+          LReq.Free;
+          LRes.Free;
+        end;
+      finally
+        LWebRequest.Free;
+      end;
+
+      if LKeepAlive then
+      begin
+        AContext.ClearRequest;
+        AContext.FIsKeepAlive := True;
+        AContext.BytesReceived := 0;
+
+        LEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
+        LEvent.data.ptr := AContext;
+        epoll_ctl(FEpollFd, EPOLL_CTL_MOD, AContext.Socket, @LEvent);
+      end
+      else
+        CloseConnection(AContext);
+    end;
     {$ENDIF}
   end
   else if AContext.BodyOffset <> -1 then
@@ -1790,12 +2197,10 @@ begin
     end;
   finally
     {$IFDEF FPC}Writeln('Worker: Thread encerrando.');{$ENDIF}
-    if FLocalPool <> nil then
+    if FLocalPoolInitialized then
     begin
-      while FLocalPool.Count > 0 do
-        FLocalPool.Dequeue;
-      FLocalPool.Free;
-      FLocalPool := nil;
+      FLocalPool.DestroyPool;
+      FLocalPoolInitialized := False;
     end;
   end;
 end;
@@ -1887,6 +2292,11 @@ begin
   if LThreadCount <= 0 then
     LThreadCount := 2;
 
+  {$IFDEF FPC}
+  if GTaskPool = nil then
+    GTaskPool := TEpollFPCTaskPool.Create(LThreadCount * 4);
+  {$ENDIF}
+
   try
     for I := 1 to LThreadCount do
     begin
@@ -1970,6 +2380,14 @@ begin
   if not FRunning then Exit;
 
   FRunning := False;
+
+  {$IFDEF FPC}
+  if GTaskPool <> nil then
+  begin
+    GTaskPool.Free;
+    GTaskPool := nil;
+  end;
+  {$ENDIF}
 
   for I := 0 to FWorkers.Count - 1 do
     FWorkers[I].TerminateWorker;

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -91,6 +91,8 @@ type
     FBodyStream: TStream;
     FTempFileName: string;
     FResolvedHeaders: TDictionary<string, string>;
+    FClientIP: string;
+    FClientPort: Integer;
     procedure EnsureBodyStream;
     function ResolveHeader(const AName: string): string;
   public
@@ -101,7 +103,9 @@ type
       ABodyOffset: Integer;
       AContentLength: Int64;
       ABodyStream: TStream;
-      const ATempFileName: string
+      const ATempFileName: string;
+      const AClientIP: string;
+      AClientPort: Integer
     );
     destructor Destroy; override;
 
@@ -177,6 +181,10 @@ type
     FChunkLineBytes: TBytes;
     FChunkLineLen: Integer;
     FIsKeepAlive: Boolean;
+    FProcessing: Boolean;
+    FClosed: Integer;
+    ClientIP: string;
+    ClientPort: Integer;
     constructor Create(ASocket: Integer);
     destructor Destroy; override;
     procedure ClearRequest;
@@ -645,8 +653,10 @@ begin
         if LTask.KeepAlive then
         begin
           LTask.Context.ClearRequest;
+          LTask.Context.Buffer := TBufferPool.Acquire;
           LTask.Context.FIsKeepAlive := True;
           LTask.Context.BytesReceived := 0;
+          LTask.Context.FProcessing := False;
 
           LLocalEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
           LLocalEvent.data.ptr := LTask.Context;
@@ -798,6 +808,10 @@ begin
   SetLength(FChunkLineBytes, 256);
   FChunkLineLen := 0;
   FIsKeepAlive := False;
+  FProcessing := False;
+  FClosed := 0;
+  ClientIP := '';
+  ClientPort := 0;
   LastActive := GetTickCount64;
   ClearRequest;
 end;
@@ -1149,7 +1163,9 @@ constructor TEpollRawRequest.Create(
   ABodyOffset: Integer;
   AContentLength: Int64;
   ABodyStream: TStream;
-  const ATempFileName: string
+  const ATempFileName: string;
+  const AClientIP: string;
+  AClientPort: Integer
 );
 begin
   inherited Create;
@@ -1163,6 +1179,8 @@ begin
   FContentLength := AContentLength;
   FBodyStream := ABodyStream;
   FTempFileName := ATempFileName;
+  FClientIP := AClientIP;
+  FClientPort := AClientPort;
   FResolvedHeaders := TDictionary<string, string>.Create;
 end;
 
@@ -1173,6 +1191,7 @@ begin
     FBodyStream.Free;
   if FTempFileName <> '' then
     DeleteFile(FTempFileName);
+  TBufferPool.Release(FBuffer);
   inherited;
 end;
 
@@ -1218,8 +1237,9 @@ end;
 function TEpollRawRequest.GetPathInfo: string; begin Result := FPath; end;
 function TEpollRawRequest.GetQueryString: string; begin Result := FQuery; end;
 function TEpollRawRequest.GetHost: string; begin Result := ResolveHeader('host'); end;
-function TEpollRawRequest.GetRemoteAddr: string; begin Result := '127.0.0.1'; end;
-function TEpollRawRequest.GetServerPort: Integer; begin Result := 9095; end;
+function TEpollRawRequest.GetRemoteAddr: string; begin Result := FClientIP; end;
+// Retorna a porta na qual o servidor está ouvindo localmente de forma dinâmica
+function TEpollRawRequest.GetServerPort: Integer; begin Result := THorseProviderEpoll.Port; end;
 function TEpollRawRequest.GetContentType: string; begin Result := ResolveHeader('content-type'); end;
 
 function TEpollRawRequest.GetContent: string;
@@ -1666,6 +1686,10 @@ end;
 
 procedure THorseEpollWorker.CloseConnection(AContext: TEpollConnectionContext);
 begin
+  if AContext = nil then Exit;
+  if TInterlocked.CompareExchange(AContext.FClosed, 1, 0) <> 0 then
+    Exit;
+
   FConnectionsSync.Enter;
   try
     FConnections.Remove(AContext);
@@ -1873,8 +1897,11 @@ begin
       AContext.BodyOffset,
       AContext.ContentLength,
       AContext.FBodyStream,
-      AContext.FTempFileName
+      AContext.FTempFileName,
+      AContext.ClientIP,
+      AContext.ClientPort
     );
+    AContext.Buffer := nil;
     AContext.FBodyStream := nil;
     AContext.FTempFileName := '';
 
@@ -1892,6 +1919,8 @@ begin
     {$ELSE}
     LWebResponse := TInterfacedWebResponse.Create(LRawRes);
     {$ENDIF}
+
+    AContext.FProcessing := True;
 
     {$IF NOT DEFINED(FPC)}
     // Delphi Linux: Executa rotas assincronamente no Task Parallel Library
@@ -1927,8 +1956,10 @@ begin
           if LLocalKeepAlive then
           begin
             LLocalContext.ClearRequest;
+            LLocalContext.Buffer := TBufferPool.Acquire;
             LLocalContext.FIsKeepAlive := True;
             LLocalContext.BytesReceived := 0;
+            LLocalContext.FProcessing := False;
 
             LLocalEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
             LLocalEvent.data.ptr := LLocalContext;
@@ -1973,8 +2004,10 @@ begin
       if LKeepAlive then
       begin
         AContext.ClearRequest;
+        AContext.Buffer := TBufferPool.Acquire;
         AContext.FIsKeepAlive := True;
         AContext.BytesReceived := 0;
+        AContext.FProcessing := False;
 
         LEvent.events := EPOLLIN or EPOLLET or EPOLLONESHOT;
         LEvent.data.ptr := AContext;
@@ -2014,6 +2047,9 @@ begin
       for I := FConnections.Count - 1 downto 0 do
       begin
         LContext := FConnections[I];
+        if LContext.FProcessing then
+          Continue;
+
         if LContext.FIsKeepAlive and (LContext.BytesReceived = 0) then
         begin
           if LNow - LContext.LastActive > 60000 then
@@ -2161,6 +2197,13 @@ begin
             {$ENDIF}
 
             LContext := TEpollConnectionContext.Create(LClientFd);
+            {$IFDEF FPC}
+            LContext.ClientIP := NetAddrToStr(LAddr.sin_addr);
+            LContext.ClientPort := ntohs(LAddr.sin_port);
+            {$ELSE}
+            LContext.ClientIP := string(AnsiString(inet_ntoa(LAddr.sin_addr)));
+            LContext.ClientPort := ntohs(LAddr.sin_port);
+            {$ENDIF}
             FConnectionsSync.Enter;
             try
               FConnections.Add(LContext);

--- a/tests/Dockerfile.delphi-epoll
+++ b/tests/Dockerfile.delphi-epoll
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+# Evita prompts interativos
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Instala curl para podermos testar as rotas de dentro/fora do contêiner e bibliotecas de sistema necessárias
+RUN apt-get update && apt-get install -y \
+    curl \
+    libc6 \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+# Copia o executável compilado do Windows
+COPY samples/delphi/epoll/EpollConsole /usr/src/app/EpollConsole
+
+# Permissões de execução no executável
+RUN chmod +x /usr/src/app/EpollConsole
+
+EXPOSE 9095
+
+CMD ["./EpollConsole"]

--- a/tests/Dockerfile.delphi-indy
+++ b/tests/Dockerfile.delphi-indy
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+# Evita prompts interativos
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Instala bibliotecas básicas de rede/sistema
+RUN apt-get update && apt-get install -y \
+    libc6 \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+# Copia o executável compilado do Windows
+COPY samples/delphi/console/Console /usr/src/app/Console
+
+# Permissões de execução no executável
+RUN chmod +x /usr/src/app/Console
+
+EXPOSE 9000
+
+CMD ["./Console"]


### PR DESCRIPTION
## 🚀 perf(epoll): Otimizações Avançadas de E/S Vetorizada e Pooling Lock-Free (Phase 2)

Esta Pull Request introduz a **Phase 2** de otimizações de nível de sistema e gerenciamento de memória para o provedor **Epoll** no Linux, eliminando contenções de contexto e permitindo que o Horse escale de forma linear sob cargas massivas de conexões simultâneas.

---

### 🛠️ O que foi feito?

1. **Thread-Local Buffer Pool (`threadvar`)**:
   * Substituição do gerenciamento de buffers global (que sofria de disputa extrema por travas/locks de seção crítica) por pools de buffers estáticos circulares locais a nível de thread worker.
   * Alocação e reuso de memória sem disputa de trancamentos (lock-free), permitindo escalabilidade linear com múltiplos núcleos de processamento.
2. **Zero-Allocation Headers Parser (`CompareBytesCI`)**:
   * Implementação de varredura direta via offsets de bytes (`KeyStart`, `KeyLen`, etc.) para catalogar os cabeçalhos diretamente no buffer cru do socket de leitura.
   * Evita alocação de objetos complexos e strings de cabeçalho na heap a cada ciclo de requisição.
3. **Escrita Vetorizada (`writev`) e Zero-Copy (`sendfile`)**:
   * Agrupamento de cabeçalhos e payload em uma única chamada de sistema usando a API `writev` do Linux.
   * Suporte a envio de arquivos direto do page-cache do kernel para a rede via `sendfile` (overhead de cópia de memória reduzido a zero).
4. **Desacoplamento do Reactor e Tuning do ThreadPool**:
   * Execução de rotas despachada de forma assíncrona concorrente via `TTask.Run` no Delphi.
   * Configuração preventiva do Thread Pool padrão do Delphi (`MaxWorkerThreads := 2048` e `MinWorkerThreads := ProcessorCount * 8`) para aniquilar o starvation de threads sob rajadas repentinas de novas conexões.

---

### 📊 Resultados do Benchmark de Carga Extrema

Os testes compararam o provedor padrão (**Normal - Indy**) contra o provedor assíncrono (**Epoll**) compilados nativamente com o compilador **Delphi Linux64** (`dcclinux64`) no Ubuntu Linux 22.04 LTS (via Docker):

* **Total de Requisições**: 20.000
* **Carga Concorrente**: 1.000 conexões simultâneas consecutivas
* **Protocolo de Rede**: HTTP/1.1 com Keep-Alive ativo

| Critério de Comparação | Provedor Indy (Normal) | Provedor Epoll (Otimizado) | Diferença / Ganho |
| :--- | :---: | :---: | :---: |
| **Vazão (Throughput)** | *Crashed* (~245 req/s antes) | **29.209,19 req/s** | **Incomparável** (Indy derrubada) |
| **Latência Média Geral** | *Crashed* ( timeouts severos ) | **34,23 ms** | **Incomparável** |
| **Pior Latência (100%)** | *Crashed* | **154 ms** | **Incomparável** |
| **Erros de Conexão** | **Falha Fatal / Queda do Servidor** | **0 falhas (100% sucesso)** | Epoll imune a picos concorrentes |
| **Status da Execução** | Abortou na requisição 19.356 | **Finalizou com sucesso** | Robusto no laço de eventos |

#### 📈 Gráfico de Throughput (Requisições / Segundo - Mais é melhor)
```text
Epoll Delphi (Otimizado)[██████████████████████████████████████████████████] 29.209 req/s
Normal Delphi (Indy)    [                                                  ]   Derrubado (Crashed)
