### PR TITLE
Perf/epoll zero allocation

### DIFF
--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -1726,7 +1726,11 @@ end;
 procedure THorseEpollWorker.CloseConnection(AContext: TEpollConnectionContext);
 begin
   if AContext = nil then Exit;
+  {$IFDEF FPC}
   if InterlockedCompareExchange(AContext.FClosed, 1, 0) <> 0 then
+  {$ELSE}
+  if TInterlocked.CompareExchange(AContext.FClosed, 1, 0) <> 0 then
+  {$ENDIF}
     Exit;
 
   FConnectionsSync.Enter;

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -1726,7 +1726,7 @@ end;
 procedure THorseEpollWorker.CloseConnection(AContext: TEpollConnectionContext);
 begin
   if AContext = nil then Exit;
-  if TInterlocked.CompareExchange(AContext.FClosed, 1, 0) <> 0 then
+  if InterlockedCompareExchange(AContext.FClosed, 1, 0) <> 0 then
     Exit;
 
   FConnectionsSync.Enter;

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -64,6 +64,7 @@ type
     class function FindByte(const ABuffer: TBytes; AStart, AEnd: Integer; AByte: Byte): Integer; static; inline;
     class function FindCRLF(const ABuffer: TBytes; AStart, AEnd: Integer): Integer; static; inline;
     class function CompareBytesCI(const ABuffer: TBytes; AStart, ALen: Integer; const AStr: string): Boolean; static; inline;
+    class function GetMethodString(const ABuffer: TBytes; AStart, ALen: Integer): string; static; inline;
   public
     class function TryParseRequest(
       const ABuffer: TBytes; 
@@ -99,7 +100,7 @@ type
     function ResolveHeader(const AName: string): string;
   public
     constructor Create(
-      const ABuffer: TBytes;
+      var ABuffer: TBytes;
       const AMethod, APath, AQuery, AVersion: string;
       AHeaders: THeaderSegments;
       ABodyOffset: Integer;
@@ -1023,6 +1024,32 @@ begin
   Result := True;
 end;
 
+class function THorseHttpParser.GetMethodString(const ABuffer: TBytes; AStart, ALen: Integer): string;
+begin
+  case ALen of
+    3:
+      if (ABuffer[AStart] = 71) and (ABuffer[AStart+1] = 69) and (ABuffer[AStart+2] = 84) then
+        Exit('GET')
+      else if (ABuffer[AStart] = 80) and (ABuffer[AStart+1] = 85) and (ABuffer[AStart+2] = 84) then
+        Exit('PUT');
+    4:
+      if (ABuffer[AStart] = 80) and (ABuffer[AStart+1] = 79) and (ABuffer[AStart+2] = 83) and (ABuffer[AStart+3] = 84) then
+        Exit('POST')
+      else if (ABuffer[AStart] = 72) and (ABuffer[AStart+1] = 69) and (ABuffer[AStart+2] = 65) and (ABuffer[AStart+3] = 68) then
+        Exit('HEAD');
+    5:
+      if (ABuffer[AStart] = 80) and (ABuffer[AStart+1] = 65) and (ABuffer[AStart+2] = 84) and (ABuffer[AStart+3] = 67) and (ABuffer[AStart+4] = 72) then
+        Exit('PATCH');
+    6:
+      if (ABuffer[AStart] = 68) and (ABuffer[AStart+1] = 69) and (ABuffer[AStart+2] = 76) and (ABuffer[AStart+3] = 69) and (ABuffer[AStart+4] = 84) and (ABuffer[AStart+5] = 69) then
+        Exit('DELETE');
+    7:
+      if (ABuffer[AStart] = 79) and (ABuffer[AStart+1] = 80) and (ABuffer[AStart+2] = 84) and (ABuffer[AStart+3] = 73) and (ABuffer[AStart+4] = 79) and (ABuffer[AStart+5] = 78) and (ABuffer[AStart+6] = 83) then
+        Exit('OPTIONS');
+  end;
+  Result := TEncoding.UTF8.GetString(ABuffer, AStart, ALen);
+end;
+
 class function THorseHttpParser.TryParseRequest(
   const ABuffer: TBytes; 
   ALength: Integer;
@@ -1045,7 +1072,6 @@ var
   Colon: Integer;
   Segment: THeaderSegment;
   SegCount: Integer;
-  RawLine: AnsiString;
 begin
   AMethod := '';
   APath := '';
@@ -1082,23 +1108,28 @@ begin
   Space2 := FindByte(ABuffer, Space1 + 1, LineEnd, 32);
   if Space2 = -1 then Exit(False);
 
-  // Extração rápida de Método, Path, Query e Versão
-  SetString(RawLine, PAnsiChar(@ABuffer[0]), LineEnd);
-  AMethod := string(Copy(RawLine, 1, Space1));
+  // Method (cached/optimized)
+  AMethod := GetMethodString(ABuffer, 0, Space1);
   
   QueryStart := FindByte(ABuffer, Space1 + 1, Space2, 63); // '?'
   if QueryStart <> -1 then
   begin
-    APath := string(Copy(RawLine, Space1 + 2, QueryStart - (Space1 + 1)));
-    AQuery := string(Copy(RawLine, QueryStart + 1, Space2 - QueryStart));
+    if (QueryStart - (Space1 + 1) = 1) and (ABuffer[Space1 + 1] = 47) then
+      APath := '/'
+    else
+      APath := TEncoding.UTF8.GetString(ABuffer, Space1 + 1, QueryStart - (Space1 + 1));
+    AQuery := TEncoding.UTF8.GetString(ABuffer, QueryStart + 1, Space2 - (QueryStart + 1));
   end
   else
   begin
-    APath := string(Copy(RawLine, Space1 + 2, Space2 - (Space1 + 1)));
+    if (Space2 - (Space1 + 1) = 1) and (ABuffer[Space1 + 1] = 47) then
+      APath := '/'
+    else
+      APath := TEncoding.UTF8.GetString(ABuffer, Space1 + 1, Space2 - (Space1 + 1));
     AQuery := '';
   end;
 
-  AVersion := string(Copy(RawLine, Space2 + 2, LineEnd - (Space2 + 1)));
+  AVersion := TEncoding.UTF8.GetString(ABuffer, Space2 + 1, LineEnd - (Space2 + 1));
 
   // 3. Processa os cabeçalhos linha a linha indexando os offsets
   SegCount := 0;
@@ -1154,7 +1185,7 @@ end;
 { TEpollRawRequest }
 
 constructor TEpollRawRequest.Create(
-  const ABuffer: TBytes;
+  var ABuffer: TBytes;
   const AMethod, APath, AQuery, AVersion: string;
   AHeaders: THeaderSegments;
   ABodyOffset: Integer;
@@ -1166,7 +1197,13 @@ constructor TEpollRawRequest.Create(
 );
 begin
   inherited Create;
-  FBuffer := ABuffer;
+  if ABodyOffset > 0 then
+    FBuffer := Copy(ABuffer, 0, ABodyOffset)
+  else
+    FBuffer := nil;
+
+  TBufferPool.Release(ABuffer);
+
   FMethod := AMethod;
   FPath := APath;
   FQuery := AQuery;
@@ -1188,7 +1225,6 @@ begin
     FBodyStream.Free;
   if FTempFileName <> '' then
     DeleteFile(FTempFileName);
-  TBufferPool.Release(FBuffer);
   inherited;
 end;
 


### PR DESCRIPTION
# perf(epoll): otimização de memória do request e parser HTTP zero-allocation

## Descrição
Este PR porta melhorias de performance e redução de consumo de memória heap do driver Epoll do framework **Dext** para o provider Epoll do **Horse** (`Horse.Provider.Epoll.pas`).

As mudanças focam em diminuir o footprint de memória de cada conexão ativa sob alta carga concorrente e mitigar o *allocation churn* de strings na heap durante o parsing da Request Line.

---

## Mudanças Introduzidas

### 1. Otimização de Memória no Epoll Request (`TEpollRawRequest`)
- **Liberação Antecipada de Buffers**: Modificamos o construtor `Create` para aceitar o buffer de conexão como parâmetro `var` e clonar estritamente a parte útil do cabeçalho (`ABodyOffset`). 
- Logo após a cópia, chamamos `TBufferPool.Release(ABuffer)` imediatamente de dentro do construtor, devolvendo o buffer original de 8KB ao pool estático de forma imediata (segundos antes da conclusão do processamento da rota do usuário).
- **Redução do Heap no Request**: O request agora mantém apenas os bytes do cabeçalho sob medida na heap, em vez de prender o buffer de leitura de 8KB inteiro. A liberação no destruidor foi removida, deixando a gerência do array sob responsabilidade da runtime do Delphi/FPC.

### 2. Otimização do HTTP Parser (`THorseHttpParser` - Zero-Allocation)
- **Métodos HTTP Otimizados (`GetMethodString`)**: Introduzimos casamento de padrões direto nos bytes do buffer para os verbos mais comuns (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, `OPTIONS`), retornando strings constantes e evitando chamadas de decodificação UTF-8 (`TEncoding.UTF8.GetString`) na heap.
- **Eliminação do `RawLine`**: Removemos a string temporária `RawLine: AnsiString` e as chamadas ao método `Copy` do Delphi, extraindo `APath`, `AQuery` e `AVersion` via `TEncoding.UTF8.GetString` diretamente sobre os offsets reais do buffer.
- **Fast-Path para Path Raiz (`/`)**: Requisições direcionadas para o path raiz `/` agora recebem o literal estático `'/'` sem alocar nenhuma string.

### 3. Compatibilidade Cross-Compiler (Delphi 12 & FPC)
- Adicionamos diretivas condicionais de compilador no método `CloseConnection` para manter a compatibilidade de Linker e compilação do `TInterlocked` nativo em ambos os ambientes:
  ```delphi
  {$IFDEF FPC}
  if InterlockedCompareExchange(AContext.FClosed, 1, 0) <> 0 then
  {$ELSE}
  if TInterlocked.CompareExchange(AContext.FClosed, 1, 0) <> 0 then
  {$ENDIF}
