### PR TITLE
Fix issues 411 343

### DIFF
--- a/doc/providers.md
+++ b/doc/providers.md
@@ -943,18 +943,19 @@ The classic downside of `TCP_NODELAY` — many tiny per-response socket writes b
 
 > The FPC `fphttpserver` family and host-managed types (Apache / ISAPI / CGI / FastCGI) are **not** changed: `fphttpserver` exposes no clean per-connection hook, and host-managed deployments don't own the HTTP accept socket — the front web server's own Nagle policy applies.
 
-### 10.2 Indy provider connection defaults — `MaxConnections` & `ListenQueue`
+### 10.2 Indy provider connection defaults — `MaxConnections`, `ListenQueue` & `ReadTimeout`
 
-The Indy self-hosted providers (Console / Daemon / VCL) now apply two **safe defaults** when you
+The Indy self-hosted providers (Console / Daemon / VCL) now apply safe defaults when you
 don't set them explicitly:
 
 | Property | Old effective default | New default | Why |
 |---|---|---|---|
 | `THorse.MaxConnections` | **32** (WebBroker's `Web.WebReq.TWebRequestHandler` module-pool cap) | **1024** | The 32 cap returns **~60 % HTTP 500** (`EWebBrokerException: "Maximum number of concurrent connections exceeded"`) under **keep-alive + response-header middleware + concurrency ≥ ~40**. Raising the module-pool ceiling makes the out-of-the-box build safe. |
 | `THorse.ListenQueue` | **15** (Indy's `IdListenQueueDefault`) | **511** | 15 is too small for concurrent connection bursts → dropped/refused connections. 511 mirrors nginx's backlog (the OS clamps it to `net.core.somaxconn` / `SOMAXCONN`). |
+| `THorse.ReadTimeout` | **0** (no timeout, blocks indefinitely) | **0** | The timeout in milliseconds for socket read operations on accepted connections. Setting this (e.g. to `10000` for 10 seconds) prevents slow or hung clients from holding server sockets and threads open indefinitely. (Indy only). |
 
 **Behaviour & compatibility.** These are applied **only when the value is left unset** — if you
-already call `THorse.MaxConnections := N` or `THorse.ListenQueue := N` before `Listen`, your value
+already call `THorse.MaxConnections := N`, `THorse.ListenQueue := N` or `THorse.ReadTimeout := N` before `Listen`, your value
 wins, unchanged. The `MaxConnections` default raises **only** the WebBroker module-pool ceiling
 (the thing that produced the 500s); it does **not** impose an Indy TCP connection cap unless you set
 one. Tune both up for very high concurrency (e.g. `1000`+ at c≈500).
@@ -962,6 +963,7 @@ one. Tune both up for very high concurrency (e.g. `1000`+ at c≈500).
 ```pascal
 THorse.MaxConnections := 4096;   // optional — overrides the 1024 default
 THorse.ListenQueue    := 1024;   // optional — overrides the 511 default
+THorse.ReadTimeout    := 10000;  // optional — sets connection read timeout to 10 seconds
 THorse.Listen(9000);
 ```
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -967,11 +967,10 @@ THorse.ReadTimeout    := 10000;  // optional — sets connection read timeout to
 THorse.Listen(9000);
 ```
 
-> **Provider scope:** this applies to the **Indy** providers only — they're the ones backed by
-> WebBroker. CrossSocket and mORMot have no WebBroker module pool (they never produced these 500s);
-> CrossSocket connection limits live in `THorseCrossSocketConfig.MaxConnections`, and mORMot sizes
-> its own fixed thread pool (`THorseMormotConfig.ThreadPool`, default 32). The constants live in
-> `Horse.Provider.Config` (`DEFAULT_MAX_CONNECTIONS`, `DEFAULT_LISTEN_QUEUE`).
+> **Provider scope:** connection settings like `MaxConnections`, `ListenQueue`, and `ReadTimeout` apply to the self-hosted **Indy** providers only (Console / Daemon / VCL). 
+> - **Host-managed types** (Apache, ISAPI, CGI, FastCGI) delegate connection lifecycle and timeouts to the host web server configuration (IIS/Apache). 
+> - **HttpSys** configures connection timeouts at the Windows kernel level (via registry or `netsh`). 
+> - **CrossSocket and mORMot** manage their own thread pools and network I/O; CrossSocket connection limits live in `THorseCrossSocketConfig.MaxConnections`, and mORMot sizes its own fixed thread pool (`THorseMormotConfig.ThreadPool`, default 32). The constants live in `Horse.Provider.Config` (`DEFAULT_MAX_CONNECTIONS`, `DEFAULT_LISTEN_QUEUE`).
 
 #### How to size them — and why they're **not** derived from CPU count
 

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -956,11 +956,10 @@ THorse.ReadTimeout    := 10000;  // opcional — define o timeout de leitura de 
 THorse.Listen(9000);
 ```
 
-> **Escopo do provider:** vale apenas para os providers **Indy** — são os apoiados no WebBroker.
-> CrossSocket e mORMot não têm pool de módulos do WebBroker (nunca produziram esses 500); os limites
-> de conexão do CrossSocket ficam em `THorseCrossSocketConfig.MaxConnections`, e o mORMot dimensiona
-> seu próprio pool fixo de threads (`THorseMormotConfig.ThreadPool`, default 32). As constantes ficam
-> em `Horse.Provider.Config` (`DEFAULT_MAX_CONNECTIONS`, `DEFAULT_LISTEN_QUEUE`).
+> **Escopo do provider:** configurações de conexão como `MaxConnections`, `ListenQueue` e `ReadTimeout` aplicam-se apenas aos provedores self-hosted do **Indy** (Console / Daemon / VCL).
+> - **Tipos gerenciados por host** (Apache, ISAPI, CGI, FastCGI) delegam o ciclo de vida e os timeouts das conexões para a configuração do próprio servidor web hospedeiro (IIS/Apache).
+> - **HttpSys** configura os timeouts de conexão a nível de kernel do Windows (via registro ou `netsh`).
+> - **CrossSocket e mORMot** gerenciam seus próprios pools de threads e I/O de rede; os limites de conexão do CrossSocket ficam em `THorseCrossSocketConfig.MaxConnections`, e o mORMot dimensiona seu próprio pool fixo de threads (`THorseMormotConfig.ThreadPool`, default 32). As constantes ficam em `Horse.Provider.Config` (`DEFAULT_MAX_CONNECTIONS`, `DEFAULT_LISTEN_QUEUE`).
 
 #### Como dimensioná-los — e por que **não** derivam da contagem de CPUs
 

--- a/doc/providers.pt-BR.md
+++ b/doc/providers.pt-BR.md
@@ -932,18 +932,19 @@ A desvantagem clássica do `TCP_NODELAY` — muitas gravações minúsculas por 
 
 > A família `fphttpserver` do FPC e os tipos host-managed (Apache / ISAPI / CGI / FastCGI) **não** são alterados: o `fphttpserver` não expõe um hook por conexão adequado, e implantações host-managed não são donas do socket de aceitação HTTP — vale a política de Nagle do próprio servidor web da frente.
 
-### 10.2 Defaults de conexão do provider Indy — `MaxConnections` e `ListenQueue`
+### 10.2 Defaults de conexão do provider Indy — `MaxConnections`, `ListenQueue` e `ReadTimeout`
 
-Os providers Indy self-hosted (Console / Daemon / VCL) agora aplicam dois **defaults seguros**
+Os providers Indy self-hosted (Console / Daemon / VCL) agora aplicam defaults seguros
 quando você não os define explicitamente:
 
 | Propriedade | Default efetivo antigo | Novo default | Por quê |
 |---|---|---|---|
 | `THorse.MaxConnections` | **32** (limite do pool de módulos do WebBroker em `Web.WebReq.TWebRequestHandler`) | **1024** | O limite de 32 retorna **~60 % de HTTP 500** (`EWebBrokerException: "Maximum number of concurrent connections exceeded"`) sob **keep-alive + middleware de cabeçalhos de resposta + concorrência ≥ ~40**. Elevar o teto do pool de módulos torna o build pronto-para-uso seguro. |
 | `THorse.ListenQueue` | **15** (o `IdListenQueueDefault` do Indy) | **511** | 15 é pequeno demais para rajadas de conexões concorrentes → conexões recusadas/descartadas. 511 espelha o backlog do nginx (o SO limita ao `net.core.somaxconn` / `SOMAXCONN`). |
+| `THorse.ReadTimeout` | **0** (sem timeout, aguarda indefinidamente) | **0** | O tempo limite em milissegundos para operações de leitura de socket nas conexões aceitas. Definir este valor (ex.: `10000` para 10 segundos) evita que clientes lentos ou travados mantenham sockets e threads do servidor abertos indefinidamente. (Apenas Indy). |
 
 **Comportamento e compatibilidade.** Aplicados **apenas quando o valor é deixado em branco** — se
-você já chama `THorse.MaxConnections := N` ou `THorse.ListenQueue := N` antes do `Listen`, o seu
+você já chama `THorse.MaxConnections := N`, `THorse.ListenQueue := N` ou `THorse.ReadTimeout := N` antes do `Listen`, o seu
 valor prevalece, sem mudança. O default de `MaxConnections` eleva **somente** o teto do pool de
 módulos do WebBroker (a causa dos 500); **não** impõe um limite de conexões TCP do Indy a menos que
 você defina um. Aumente os dois para concorrência muito alta (ex.: `1000`+ em c≈500).
@@ -951,6 +952,7 @@ você defina um. Aumente os dois para concorrência muito alta (ex.: `1000`+ em 
 ```pascal
 THorse.MaxConnections := 4096;   // opcional — sobrescreve o default de 1024
 THorse.ListenQueue    := 1024;   // opcional — sobrescreve o default de 511
+THorse.ReadTimeout    := 10000;  // opcional — define o timeout de leitura de conexões para 10 segundos
 THorse.Listen(9000);
 ```
 

--- a/src/Horse.Provider.Abstract.pas
+++ b/src/Horse.Provider.Abstract.pas
@@ -1,4 +1,4 @@
-﻿unit Horse.Provider.Abstract;
+unit Horse.Provider.Abstract;
 
 {$IF DEFINED(FPC)}
   {$MODE DELPHI}{$H+}
@@ -48,6 +48,9 @@ type
     class var FMaxConnections: Integer;
     class function GetMaxConnections: Integer; static;
     class procedure SetMaxConnections(const AValue: Integer); static;
+    class var FReadTimeout: Integer;
+    class function GetReadTimeout: Integer; static;
+    class procedure SetReadTimeout(const AValue: Integer); static;
 { =========================================================================== }
   protected
     class function GetOnListen: TProc; static;
@@ -60,6 +63,7 @@ type
     class property OnStopListen: TProc read GetOnStopListen write SetOnStopListen;
 { PATCH-ABS-4 }
     class property MaxConnections: Integer read GetMaxConnections write SetMaxConnections;
+    class property ReadTimeout: Integer read GetReadTimeout write SetReadTimeout;
 { end PATCH-ABS-4 }
     class procedure Listen; virtual; abstract;
     class procedure StopListen; virtual;
@@ -139,6 +143,16 @@ end;
 class procedure THorseProviderAbstract.SetMaxConnections(const AValue: Integer);
 begin
   FMaxConnections := AValue;
+end;
+
+class function THorseProviderAbstract.GetReadTimeout: Integer;
+begin
+  Result := FReadTimeout;
+end;
+
+class procedure THorseProviderAbstract.SetReadTimeout(const AValue: Integer);
+begin
+  FReadTimeout := AValue;
 end;
 { =========================================================================== }
 

--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -1,13 +1,13 @@
 unit Horse.Provider.Console;
 
 { ===========================================================================
-  PATCH-CONSOLE-1 — ListenWithConfig override
+  PATCH-CONSOLE-1 â€” ListenWithConfig override
   Without this, THorseProviderAbstract.ListenWithConfig just calls the no-arg
   Listen, which enters InternalListen with FPort = 0 and falls back to
   DEFAULT_PORT (9000), silently ignoring the caller-supplied APort.
   Fix: override ListenWithConfig in THorseProvider (Console) so that it sets
   Console's own FPort via SetPort before calling InternalListen.
-  AConfig is intentionally ignored — Console/Indy has no use for
+  AConfig is intentionally ignored â€” Console/Indy has no use for
   THorseCrossSocketConfig; only CrossSocket overrides ListenWithConfig fully.
   =========================================================================== }
 
@@ -75,7 +75,7 @@ type
     class procedure Listen(const AHost: string; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
 { ===========================================================================
-  PATCH-CONSOLE-1 — ListenWithConfig declaration
+  PATCH-CONSOLE-1 â€” ListenWithConfig declaration
   =========================================================================== }
     class procedure ListenWithConfig(const APort: Integer;
       const AConfig: THorseCrossSocketConfig); override;
@@ -94,7 +94,8 @@ uses
   IdCustomTCPServer,
   Horse.Constants,
   Horse.Provider.IOHandleSSL,
-  IdSSLOpenSSL;
+  IdSSLOpenSSL,
+  System.Classes;
 
 class function THorseProvider.GetDefaultHTTPWebBroker: TIdHTTPWebBrokerBridge;
 begin
@@ -121,10 +122,12 @@ end;
 { Disable Nagle (TCP_NODELAY) on each accepted connection. Without it, on Linux
   loopback the keep-alive request/response ping-pong collides with the ~40 ms
   delayed-ACK timer -> a flat ~44 ms/request floor that cripples throughput.
-  Harmless (beneficial) on Windows. See bench-analysis-report.md §7.5. }
+  Harmless (beneficial) on Windows. See bench-analysis-report.md Â§7.5. }
 class procedure THorseProvider.OnConnect(AContext: TIdContext);
 begin
   AContext.Binding.UseNagle := False;
+  if THorseProviderAbstract.ReadTimeout > 0 then
+    AContext.Connection.Socket.ReadTimeout := THorseProviderAbstract.ReadTimeout;
 end;
 
 class function THorseProvider.GetDefaultEvent: TEvent;
@@ -268,10 +271,28 @@ begin
 end;
 
 class procedure THorseProvider.InternalStopListen;
+var
+  LContexts: TList;
+  I: Integer;
 begin
   if not HTTPWebBrokerIsNil then
   begin
     GetDefaultHTTPWebBroker.StopListening;
+    try
+      LContexts := GetDefaultHTTPWebBroker.Contexts.LockList;
+      try
+        for I := LContexts.Count - 1 downto 0 do
+        begin
+          try
+            TIdContext(LContexts[I]).Connection.Disconnect;
+          except
+          end;
+        end;
+      finally
+        GetDefaultHTTPWebBroker.Contexts.UnlockList;
+      end;
+    except
+    end;
     GetDefaultHTTPWebBroker.Active := False;
     DoOnStopListen;
     FRunning := False;
@@ -317,10 +338,10 @@ begin
 end;
 
 { ===========================================================================
-  PATCH-CONSOLE-1 — ListenWithConfig implementation
+  PATCH-CONSOLE-1 â€” ListenWithConfig implementation
   Sets Console's own FPort before starting, so the port is honoured even when
   the caller goes through the abstract ListenWithConfig entry point.
-  AConfig is intentionally ignored — Indy/Console has no use for CrossSocket
+  AConfig is intentionally ignored â€” Indy/Console has no use for CrossSocket
   configuration. CrossSocket overrides ListenWithConfig completely.
   =========================================================================== }
 class procedure THorseProvider.ListenWithConfig(const APort: Integer;

--- a/src/Horse.Provider.Daemon.pas
+++ b/src/Horse.Provider.Daemon.pas
@@ -1,10 +1,10 @@
 unit Horse.Provider.Daemon;
 
-{ PATCH-DAEMON-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1.
+{ PATCH-DAEMON-1: ListenWithConfig override â€” same root cause as PATCH-CONSOLE-1.
   THorseProviderAbstract.ListenWithConfig calls the no-arg Listen, entering
   InternalListen with FPort = 0 - DEFAULT_PORT (9000).  Fix: override
   ListenWithConfig here so it calls SetPort(APort) before InternalListen.
-  AConfig is intentionally ignored — Daemon/Indy has no use for CrossSocket config. }
+  AConfig is intentionally ignored â€” Daemon/Indy has no use for CrossSocket config. }
 
 interface
 
@@ -99,7 +99,8 @@ uses
   Posix.Unistd,
   Posix.Signal,
   Posix.Fcntl,
-  ThirdParty.Posix.Syslog;
+  ThirdParty.Posix.Syslog,
+  System.Classes;
 
 procedure HandleSignals(SigNum: Integer); cdecl;
 begin
@@ -151,10 +152,12 @@ end;
 { Disable Nagle (TCP_NODELAY) on each accepted connection. Without it, on Linux
   loopback the keep-alive request/response ping-pong collides with the ~40 ms
   delayed-ACK timer -> a flat ~44 ms/request floor that cripples throughput.
-  Harmless (beneficial) on Windows. See bench-analysis-report.md §7.5. }
+  Harmless (beneficial) on Windows. See bench-analysis-report.md Â§7.5. }
 class procedure THorseProvider.OnConnect(AContext: TIdContext);
 begin
   AContext.Binding.UseNagle := False;
+  if THorseProviderAbstract.ReadTimeout > 0 then
+    AContext.Connection.Socket.ReadTimeout := THorseProviderAbstract.ReadTimeout;
 end;
 
 class function THorseProvider.GetDefaultHorseProviderIOHandleSSL: IHorseProviderIOHandleSSL;
@@ -301,10 +304,28 @@ begin
 end;
 
 class procedure THorseProvider.InternalStopListen;
+var
+  LContexts: TList;
+  I: Integer;
 begin
   if not HTTPWebBrokerIsNil then
   begin
     GetDefaultHTTPWebBroker.StopListening;
+    try
+      LContexts := GetDefaultHTTPWebBroker.Contexts.LockList;
+      try
+        for I := LContexts.Count - 1 downto 0 do
+        begin
+          try
+            TIdContext(LContexts[I]).Connection.Disconnect;
+          except
+          end;
+        end;
+      finally
+        GetDefaultHTTPWebBroker.Contexts.UnlockList;
+      end;
+    except
+    end;
     GetDefaultHTTPWebBroker.Active := False;
     DoOnStopListen;
     FRunning := False;

--- a/src/Horse.Provider.VCL.pas
+++ b/src/Horse.Provider.VCL.pas
@@ -1,6 +1,6 @@
 unit Horse.Provider.VCL;
 
-{ PATCH-VCL-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
+{ PATCH-VCL-1: ListenWithConfig override â€” same root cause as PATCH-CONSOLE-1. }
 
 interface
 
@@ -79,7 +79,8 @@ implementation
 uses
   Web.WebReq,
   Horse.WebModule,
-  IdCustomTCPServer;
+  IdCustomTCPServer,
+  System.Classes;
 
 class function THorseProvider.IsRunning: Boolean;
 begin
@@ -121,10 +122,12 @@ end;
 { Disable Nagle (TCP_NODELAY) on each accepted connection. Without it, on Linux
   loopback the keep-alive request/response ping-pong collides with the ~40 ms
   delayed-ACK timer -> a flat ~44 ms/request floor that cripples throughput.
-  Harmless (beneficial) on Windows. See bench-analysis-report.md §7.5. }
+  Harmless (beneficial) on Windows. See bench-analysis-report.md Â§7.5. }
 class procedure THorseProvider.OnConnect(AContext: TIdContext);
 begin
   AContext.Binding.UseNagle := False;
+  if THorseProviderAbstract.ReadTimeout > 0 then
+    AContext.Connection.Socket.ReadTimeout := THorseProviderAbstract.ReadTimeout;
 end;
 
 class function THorseProvider.GetDefaultHorseProviderIOHandleSSL: IHorseProviderIOHandleSSL;
@@ -230,13 +233,31 @@ begin
 end;
 
 class procedure THorseProvider.InternalStopListen;
+var
+  LContexts: TList;
+  I: Integer;
 begin
   if not HTTPWebBrokerIsNil then
   begin
+    GetDefaultHTTPWebBroker.StopListening;
+    try
+      LContexts := GetDefaultHTTPWebBroker.Contexts.LockList;
+      try
+        for I := LContexts.Count - 1 downto 0 do
+        begin
+          try
+            TIdContext(LContexts[I]).Connection.Disconnect;
+          except
+          end;
+        end;
+      finally
+        GetDefaultHTTPWebBroker.Contexts.UnlockList;
+      end;
+    except
+    end;
     GetDefaultHTTPWebBroker.Active := False;
     FRunning := False;
     DoOnStopListen;
-    GetDefaultHTTPWebBroker.StopListening;
   end
   else
     raise Exception.Create('Horse not listen');

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -74,8 +74,10 @@ uses
   Tests.Integration.HttpMethods in 'tests\Tests.Integration.HttpMethods.pas',
   Tests.Integration.KeepAlive in 'tests\Tests.Integration.KeepAlive.pas',
   Tests.Integration.LargePayload in 'tests\Tests.Integration.LargePayload.pas',
+  Tests.Integration.ReadTimeout in 'tests\Tests.Integration.ReadTimeout.pas',
   Tests.Integration.Query in 'tests\Tests.Integration.Query.pas',
   Horse.Mime in '..\..\src\Horse.Mime.pas',
+  Horse.Utils in '..\..\src\Horse.Utils.pas',
   Horse.Provider.Config in '..\..\src\Horse.Provider.Config.pas',
   Horse.Provider.IOHandleSSL.Contract in '..\..\src\Horse.Provider.IOHandleSSL.Contract.pas';
 

--- a/tests/src/tests/Tests.Integration.ReadTimeout.pas
+++ b/tests/src/tests/Tests.Integration.ReadTimeout.pas
@@ -1,0 +1,110 @@
+unit Tests.Integration.ReadTimeout;
+
+interface
+
+uses
+  DUnitX.TestFramework, Horse, Horse.Commons, System.SysUtils, System.Classes,
+  System.Threading, IdTCPClient, System.Net.HttpClient, Tests.CleanupHelper;
+
+type
+  [TestFixture]
+  TTestIntegrationReadTimeout = class
+  private
+    const TEST_PORT = 9099;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test]
+    procedure TestReadTimeoutClosesConnection;
+  end;
+
+implementation
+
+uses
+  System.Diagnostics;
+
+{ TTestIntegrationReadTimeout }
+
+procedure TTestIntegrationReadTimeout.SetupFixture;
+begin
+  // Configura o ReadTimeout do Horse (em milissegundos para o Indy)
+  // O Indy herda este valor e aplica nas conexões aceitas
+  THorse.ReadTimeout := 1000; // 1 segundo
+
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('pong');
+    end);
+
+  TThread.CreateAnonymousThread(
+    procedure
+    begin
+      THorse.Listen(TEST_PORT);
+    end).Start;
+
+  Sleep(1500);
+end;
+
+procedure TTestIntegrationReadTimeout.TearDownFixture;
+begin
+  ClearGlobalState;
+  Sleep(500);
+end;
+
+procedure TTestIntegrationReadTimeout.TestReadTimeoutClosesConnection;
+var
+  LConnected: Boolean;
+  LDisconnected: Boolean;
+  LClient: TIdTCPClient;
+  LStopWatch: TStopwatch;
+begin
+  LDisconnected := False;
+  LClient := TIdTCPClient.Create(nil);
+  try
+    LClient.Host := '127.0.0.1';
+    LClient.Port := TEST_PORT;
+    LClient.ConnectTimeout := 2000; 
+    
+    LClient.Connect;
+    LConnected := LClient.Connected;
+    Assert.IsTrue(LConnected, 'Should connect to the server');
+
+    // Conectou. Agora ficamos inativos sem enviar nenhuma requisição HTTP.
+    // O servidor deve nos desconectar após o ReadTimeout (1 segundo).
+    LStopWatch := TStopwatch.StartNew;
+    while (LStopWatch.ElapsedMilliseconds < 3000) and (not LDisconnected) do
+    begin
+      try
+        // CheckForDataOnSource verifica se há dados no socket com timeout de 100ms.
+        // Se a conexão cair, LClient.Connected será atualizado para False
+        // ou levantará uma exceção de socket.
+        LClient.IOHandler.CheckForDataOnSource(100);
+        if not LClient.Connected then
+        begin
+          LDisconnected := True;
+          Break;
+        end;
+      except
+        LDisconnected := True;
+        Break;
+      end;
+      Sleep(100);
+    end;
+
+    Assert.IsTrue(LDisconnected, 'Server should actively disconnect the connection after the read timeout.');
+    Assert.IsTrue(LStopWatch.ElapsedMilliseconds >= 900, 'Server should wait approximately the read timeout limit.');
+  finally
+    LClient.Free;
+  end;
+end;
+
+initialization
+{$IFDEF MSWINDOWS}
+  TDUnitX.RegisterTestFixture(TTestIntegrationReadTimeout);
+{$ENDIF}
+
+end.


### PR DESCRIPTION
# Resolvidos issues  #411 e #343

Este Pull Request resolve dois problemas nos provedores Indy (Console, Daemon e VCL) relacionados ao gerenciamento de conexões:

1. **Issue #411 (Implementação de ReadTimeout)**: Implementa suporte para definir um tempo limite de leitura (`ReadTimeout`) nas conexões de socket recebidas, evitando que conexões travadas ou clientes lentos mantenham sockets e threads abertos indefinidamente.
2. **Issue #343 (StopListen travando no Linux)**: Resolve o travamento ao chamar `THorse.StopListen` no Linux (FPC/Indy) quando conexões HTTP Keep-Alive ativas permaneciam abertas nos sockets dos clientes.

---

## Alterações Propostas

### Core & Provedores
* **`Horse.Provider.Abstract.pas`**: Declarada a propriedade pública de classe `ReadTimeout` em `THorseProviderAbstract`.
* **`Horse.Provider.Console.pas`, `Horse.Provider.Daemon.pas`, `Horse.Provider.VCL.pas`**:
  * Configurado o `ReadTimeout` no socket do cliente dentro do evento `OnConnect`:
    ```delphi
    if THorseProviderAbstract.ReadTimeout > 0 then
      AContext.Connection.Socket.ReadTimeout := THorseProviderAbstract.ReadTimeout;
    ```
  * Atualizado o método `InternalStopListen` para iterar nas conexões ativas do Indy (`Contexts.LockList`) e desconectá-las ativamente antes de desativar o servidor (`Active := False`), evitando o congelamento na finalização do servidor no Linux.

### Testes
* **`Tests.Integration.ReadTimeout.pas`** [NOVO]: Nova suíte de testes de integração validando o comportamento de `ReadTimeout`. O teste inicia o servidor com timeout de 1 segundo, conecta um cliente Indy cru, permanece inativo e valida se o servidor desconecta o cliente após o tempo estipulado.
* O teste foi condicionado para ser registrado **apenas no Windows** (`{$IFDEF MSWINDOWS}`).

### Documentação
* Atualizada a documentação em inglês (`doc/providers.md`) e português (`doc/providers.pt-BR.md`) na seção **10.2 Defaults de conexão do provider Indy** para detalhar a propriedade `THorse.ReadTimeout` e explicar a aplicabilidade da mesma apenas no escopo do Indy.

---

## Validação e Testes

* Compilação realizada com sucesso usando o compilador **Delphi 22.0** (`dcc32` via MSBuild).
* Execução dos testes integrados via DUnitX concluída com **sucesso em todos os 135 testes** no Windows.

Resolve #411
Resolve #343
