### PR TITLE
Feature/issue 366 wildcard routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 | **Choosing a transport provider** — Indy (default), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.md) |
 | **Deploy** as Console / VCL / Daemon / Windows Service / LCL / HTTPApplication — one-page recipe | [**Deployment Cheatsheet**](./doc/deployment.md) |
 | Full middleware catalogue with extended descriptions | [Middleware Ecosystem](./doc/middleware-ecosystem.md) |
+| Automated integration, resilience (Access Violation) and SO limit testing | [Integrity Testing](./doc/integrity-testing.md) |
 | Supported Delphi / FPC versions and platforms | [Compiler Support](./doc/compiler-support.md) |
 
 ## 🔌 Providers (transport layer)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -75,6 +75,7 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 | **Escolher um provider de transporte** — Indy (padrão), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.pt-BR.md) |
 | **Deploy** como Console / VCL / Daemon / Serviço Windows / LCL / HTTPApplication — receita de uma página | [**Cheatsheet de Deploy**](./doc/deployment.pt-BR.md) |
 | Catálogo completo de middlewares com descrições estendidas | [Ecossistema de Middlewares](./doc/middleware-ecosystem.pt-BR.md) |
+| Testes de integração automatizados, resiliência (Access Violation) e limites de Stack | [Testes de Integridade](./doc/integrity-testing.pt-BR.md) |
 | Versões suportadas de Delphi / FPC e plataformas | [Suporte de Compilador](./doc/compiler-support.pt-BR.md) |
 
 ## 🔌 Providers (camada de transporte)

--- a/doc/index.md
+++ b/doc/index.md
@@ -29,6 +29,7 @@ If you're new, start with [Getting Started](./getting-started.md). If you have a
 | [Middleware Ecosystem](./middleware-ecosystem.md) | Official `HashLoad/*` packages and the community-maintained list. |
 | [Compiler Support](./compiler-support.md) | Tested Delphi releases, FPC versions, target platforms, compiler-version guards. |
 | [Deployment Cheatsheet](./deployment.md) | One-page reference for shipping a CrossSocket or mORMot2 binary as any of the seven Application shapes (Console / VCL / Daemon / Windows Service / FPC daemon / LCL / FPC HTTPApplication). |
+| [Integrity Testing](./integrity-testing.md) | Automated integration, resilience (Access Violation) and SO limit testing. |
 
 ## How the docs are organised
 
@@ -42,6 +43,7 @@ doc/
 ├── middleware.md              ← chaining handlers
 ├── providers.md               ← choosing a transport
 ├── middleware-ecosystem.md    ← package catalogue
+├── integrity-testing.md       ← integrity and resilience testing
 └── compiler-support.md        ← versions / platforms
 ```
 

--- a/doc/index.pt-BR.md
+++ b/doc/index.pt-BR.md
@@ -29,6 +29,7 @@ Se você é novo por aqui, comece por [Primeiros passos](./getting-started.pt-BR
 | [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md) | Pacotes oficiais `HashLoad/*` e a lista mantida pela comunidade. |
 | [Suporte de Compilador](./compiler-support.pt-BR.md) | Versões testadas do Delphi, versões do FPC, plataformas-alvo, guards de versão de compilador. |
 | [Cheatsheet de Deploy](./deployment.pt-BR.md) | Referência de uma página pra entregar um binário CrossSocket ou mORMot2 como qualquer um dos sete formatos de Aplicação (Console / VCL / Daemon / Serviço Windows / daemon FPC / LCL / HTTPApplication FPC). |
+| [Testes de Integridade](./integrity-testing.pt-BR.md) | Testes de integração automatizados, resiliência (Access Violation) e limites de Stack. |
 
 ## Como a documentação está organizada
 
@@ -42,6 +43,7 @@ doc/
 ├── middleware.*.md            ← encadeamento de handlers
 ├── providers.*.md             ← escolha de transporte
 ├── middleware-ecosystem.*.md  ← catálogo de pacotes
+├── integrity-testing.*.md     ← testes de integridade e resiliência
 └── compiler-support.*.md      ← versões / plataformas
 ```
 

--- a/doc/integrity-testing.md
+++ b/doc/integrity-testing.md
@@ -20,7 +20,7 @@ They are extremely useful for:
 
 ## What is Tested?
 
-The integrity test script ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) compiles the sample server ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) and performs the following real HTTP requests using `Invoke-RestMethod` and `curl`:
+The integrity test script ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) runs two consecutive validation passes: one compiling the sample server ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) with the **Default Router** (`RouterTree`), and another with the **Radix Router** (`RadixRouter`). Each pass performs the following real HTTP requests using `Invoke-RestMethod` and `curl`:
 
 1. **GET /ping**: Basic request flow and quick ping-pong verification.
 2. **GET /resource/:id**: Validates URL parameter extraction, query strings, and case-insensitive authorization headers.
@@ -75,4 +75,4 @@ cd samples/delphi/console_complete
 .\test_integrity.ps1
 ```
 
-The script manages compilation using the Delphi compiler (`dcc32`), runs the background process, runs the validation requests, terminates the server, and prints a final success/failure summary.
+The script manages the compilation of both routers using the Delphi compiler (`dcc32`), launches the background process for each scenario, executes the validation requests, terminates the servers, and prints a final combined success/failure summary.

--- a/doc/integrity-testing.md
+++ b/doc/integrity-testing.md
@@ -1,0 +1,78 @@
+# Horse Integrity and Resilience Testing
+
+Horse includes an automated suite of integrity tests designed to validate the framework's behavior in real network scenarios, as well as analyze its resilience under fatal system failures and critical memory overflows.
+
+These tests reside in the folder: `samples/delphi/console_complete/`
+
+---
+
+## Why are Integrity Tests Useful?
+
+Unlike traditional unit tests (which test individual classes and methods in isolation), integrity tests simulate a real HTTP client consuming an active Horse API over the network.
+
+They are extremely useful for:
+- **Preventing Regressions**: Guaranteeing that changes in the HTTP parser, router, middleware, or memory buffers do not break the expected behavior of real network calls.
+- **Validating Verbs and Headers**: Verifying correct parsing of query strings, route parameters, case-insensitive headers, and the custom `QUERY` HTTP verb.
+- **Testing real uploads**: Validating actual file transmissions sent as `multipart/form-data`.
+- **Resilience Analysis (Robustness)**: Assessing how the Horse server handles fatal errors inside the application logic (such as null pointers) without crashing the service.
+
+---
+
+## What is Tested?
+
+The integrity test script ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) compiles the sample server ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) and performs the following real HTTP requests using `Invoke-RestMethod` and `curl`:
+
+1. **GET /ping**: Basic request flow and quick ping-pong verification.
+2. **GET /resource/:id**: Validates URL parameter extraction, query strings, and case-insensitive authorization headers.
+3. **POST /resource**: Transmission of raw payload inside the request body.
+4. **PUT, PATCH, DELETE /resource/:id**: RESTful verbs for resource modification and deletion.
+5. **QUERY /search**: Custom `QUERY` verb sending search payloads.
+6. **POST /upload**: Actual multipart file upload.
+7. **GET /error-trigger**: Clean, formatted exceptions raised using `EHorseException`.
+8. **GET /clientes, GET /pessoas, GET /qualquercoisa**: Route matching priority, checking that exact paths are resolved before fallback wildcard (`*`) matching.
+
+---
+
+## Resilience and Limitations (Fatal System Failures)
+
+The integrity suite includes specific endpoints to trigger catastrophic crashes and analyze the Horse server's resilience:
+
+### 1. Intercepting Access Violations (AV)
+Accessing `/av-trigger` intentionally performs a write operation on a null pointer reference:
+```delphi
+var
+  LPointer: PInteger;
+begin
+  LPointer := nil;
+  LPointer^ := 42; // Access Violation!
+end;
+```
+* **Horse Behavior**: Horse successfully intercepts the violation on the request handler thread level. It blocks the main executable from crashing, returns an HTTP `500 Internal Server Error` message, and keeps the server active to continue handling other requests.
+
+### 2. Stack Overflow
+Accessing `/stack-trigger` triggers an infinite recursion that consumes the thread's memory stack allocation limit:
+```delphi
+var
+  LRecurse: TProc;
+begin
+  LRecurse := procedure
+    begin
+      LRecurse();
+    end;
+  LRecurse(); // Stack Overflow!
+end;
+```
+* **SO Limitations**: A Stack Overflow represents a hardware/OS-level resource limit. When the thread memory stack size limit is exceeded, the OS intervenes and terminates the server process immediately for stability. The integrity script correctly logs and handles this crash scenario.
+
+---
+
+## Running Locally
+
+To run the integrity tests locally in a Windows environment using PowerShell:
+
+```powershell
+cd samples/delphi/console_complete
+.\test_integrity.ps1
+```
+
+The script manages compilation using the Delphi compiler (`dcc32`), runs the background process, runs the validation requests, terminates the server, and prints a final success/failure summary.

--- a/doc/integrity-testing.pt-BR.md
+++ b/doc/integrity-testing.pt-BR.md
@@ -20,7 +20,7 @@ Eles são extremamente úteis para:
 
 ## O que é Testado?
 
-O script de teste de integridade ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) compila o servidor exemplo ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) e realiza as seguintes chamadas HTTP reais via `Invoke-RestMethod` e `curl`:
+O script de teste de integridade ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) realiza duas rodadas consecutivas de testes: uma compilando o servidor exemplo ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) com o **Roteador Padrão** (`RouterTree`), e outra com o **Radix Router** (`RadixRouter`). Cada rodada executa as seguintes chamadas HTTP reais via `Invoke-RestMethod` e `curl`:
 
 1. **GET /ping**: Testa o fluxo básico e a resposta simples.
 2. **GET /resource/:id**: Valida o parse de parâmetros na URL, query strings e cabeçalhos de autorização case-insensitive.
@@ -75,4 +75,4 @@ cd samples/delphi/console_complete
 .\test_integrity.ps1
 ```
 
-O script cuidará de toda a compilação no compilador Delphi (`dcc32`), inicialização em background, chamadas, limpeza e relatório de falhas.
+O script cuidará de todo o processo de compilação dos dois roteadores com o compilador Delphi (`dcc32`), inicialização em background para cada um, chamadas HTTP de testes, limpeza e relatório final de falhas de ambos.

--- a/doc/integrity-testing.pt-BR.md
+++ b/doc/integrity-testing.pt-BR.md
@@ -1,0 +1,78 @@
+# Testes de Integridade e Resiliência do Horse
+
+O Horse possui um conjunto de testes de integridade automatizados projetados para validar o funcionamento do framework em cenários reais de rede, bem como analisar a sua resiliência perante falhas graves de sistema e estouros críticos.
+
+Esses testes residem na pasta: `samples/delphi/console_complete/`
+
+---
+
+## Por que os Testes de Integridade são Úteis?
+
+Diferente de testes unitários tradicionais (que testam métodos e classes isolados), os testes de integridade simulam o comportamento de um cliente real consumindo uma API Horse ativa na rede. 
+
+Eles são extremamente úteis para:
+- **Evitar Regressões**: Garantir que alterações no parser de HTTP, roteamento, middlewares ou buffers não quebrem o comportamento esperado das chamadas reais de rede.
+- **Validar Verbos e Cabeçalhos**: Testar o parse correto de query strings, parâmetros de rota, cabeçalhos (*headers*) case-insensitive e o verbo customizado `QUERY`.
+- **Testar uploads reais**: Validar transmissões em formato `multipart/form-data`.
+- **Análise de Resiliência (Robustez)**: Avaliar como o servidor Horse lida com falhas fatais no código da aplicação (como referências nulas) sem comprometer o serviço.
+
+---
+
+## O que é Testado?
+
+O script de teste de integridade ([test_integrity.ps1](file:///d:/Delphi/horse/samples/delphi/console_complete/test_integrity.ps1)) compila o servidor exemplo ([ConsoleComplete.dpr](file:///d:/Delphi/horse/samples/delphi/console_complete/ConsoleComplete.dpr)) e realiza as seguintes chamadas HTTP reais via `Invoke-RestMethod` e `curl`:
+
+1. **GET /ping**: Testa o fluxo básico e a resposta simples.
+2. **GET /resource/:id**: Valida o parse de parâmetros na URL, query strings e cabeçalhos de autorização case-insensitive.
+3. **POST /resource**: Envio de dados no corpo (payload) do request.
+4. **PUT, PATCH, DELETE /resource/:id**: Testes de verbos RESTful de atualização e remoção.
+5. **QUERY /search**: Envio de payloads de pesquisa complexos usando o verbo customizado `QUERY`.
+6. **POST /upload**: Upload real de arquivos simulando `multipart/form-data`.
+7. **GET /error-trigger**: Fluxo de exceção tratada limpa através da classe `EHorseException`.
+8. **GET /clientes, GET /pessoas, GET /qualquercoisa**: Prioridade de correspondência de rotas exatas em relação a rotas coringa (`*` ou wildcard).
+
+---
+
+## Resiliência e Limitações do Horse (Erros Graves)
+
+Os testes de integridade incluem endpoints específicos para forçar falhas catastróficas e analisar a integridade do processo do servidor:
+
+### 1. Interceptação de Access Violation (AV)
+Ao acessar o endpoint `/av-trigger`, um erro de escrita em ponteiro nulo (de propósito) é disparado:
+```delphi
+var
+  LPointer: PInteger;
+begin
+  LPointer := nil;
+  LPointer^ := 42; // Access Violation!
+end;
+```
+* **Comportamento do Horse**: O Horse intercepta a violação de acesso em nível de thread/requisição, impede a queda do executável principal, responde ao cliente com um erro HTTP `500 Internal Server Error` e mantém o servidor ativo para continuar atendendo a outras conexões normalmente.
+
+### 2. Estouro de Pilha (Stack Overflow)
+Ao acessar o endpoint `/stack-trigger`, uma recursão infinita estoura o limite de pilha de memória:
+```delphi
+var
+  LRecurse: TProc;
+begin
+  LRecurse := procedure
+    begin
+      LRecurse();
+    end;
+  LRecurse(); // Stack Overflow!
+end;
+```
+* **Comportamento e Limites**: O Stack Overflow representa um limite de resiliência a nível de hardware/SO. Quando a thread estoura a quantidade reservada de memória física para stack (pilha), o sistema operacional intervém e encerra o processo do servidor imediatamente para autoproteção. O script de integridade captura essa queda de forma segura.
+
+---
+
+## Como Executar Localmente
+
+Para rodar os testes de integridade em ambiente local Windows com o PowerShell, basta navegar até a pasta e iniciar o script:
+
+```powershell
+cd samples/delphi/console_complete
+.\test_integrity.ps1
+```
+
+O script cuidará de toda a compilação no compilador Delphi (`dcc32`), inicialização em background, chamadas, limpeza e relatório de falhas.

--- a/samples/delphi/console_complete/ConsoleComplete.dpr
+++ b/samples/delphi/console_complete/ConsoleComplete.dpr
@@ -107,6 +107,50 @@ begin
       raise EHorseException.Create.Status(THTTPStatus.BadRequest).Error('{"error":"Erro de Negocio Simulado"}');
     end);
 
+  // 10. GET /clientes -> Rota exata para testar prioridade de wildcard (*)
+  THorse.Get('/clientes',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('clientes');
+    end);
+
+  // 11. GET /pessoas -> Rota exata para testar prioridade de wildcard (*)
+  THorse.Get('/pessoas',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('pessoas');
+    end);
+
+  // 12. GET * -> Rota wildcard genérica (coringão)
+  THorse.Get('*',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('coringao');
+    end);
+
+  // 13. GET /av-trigger -> Simula Access Violation (AV) de propósito
+  THorse.Get('/av-trigger',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    var
+      LPointer: PInteger;
+    begin
+      LPointer := nil;
+      LPointer^ := 42;
+    end);
+
+  // 14. GET /stack-trigger -> Simula estouro de pilha (Stack Overflow)
+  THorse.Get('/stack-trigger',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    var
+      LRecurse: TProc;
+    begin
+      LRecurse := procedure
+        begin
+          LRecurse();
+        end;
+      LRecurse();
+    end);
+
   THorse.Listen(9085,
     procedure
     begin

--- a/samples/delphi/console_complete/test_integrity.ps1
+++ b/samples/delphi/console_complete/test_integrity.ps1
@@ -1,145 +1,159 @@
 # Script de Validacao de Integridade do Horse - Console Complete
 $ErrorActionPreference = "Stop"
 
-Write-Host "==================================================" -ForegroundColor Cyan
-Write-Host "   INICIANDO TESTE DE INTEGRIDADE DO HORSE        " -ForegroundColor Cyan
-Write-Host "==================================================" -ForegroundColor Cyan
+function Run-IntegrityTest($RouterName, $Define) {
+    Write-Host "==================================================" -ForegroundColor Cyan
+    Write-Host "   TESTANDO INTEGRIDADE: $RouterName" -ForegroundColor Cyan
+    Write-Host "==================================================" -ForegroundColor Cyan
 
-# 1. Compilando o Exemplo
-Write-Host "[1/5] Compilando ConsoleComplete.dpr..." -ForegroundColor Yellow
-$compileCmd = "dcc32 -B -Q -U`"../../../src`" -NS`"System;System.Win;Winapi;Data;Web`" ConsoleComplete.dpr"
-Invoke-Expression $compileCmd
-
-if (-not (Test-Path "ConsoleComplete.exe")) {
-    Write-Error "Falha na compilacao! Executavel nao gerado."
-}
-Write-Host "Compilado com sucesso!" -ForegroundColor Green
-
-# 2. Executando o servidor em background
-Write-Host "[2/5] Iniciando o servidor na porta 9085 em segundo plano..." -ForegroundColor Yellow
-$serverProcess = Start-Process -FilePath ".\ConsoleComplete.exe" -NoNewWindow -PassThru
-Start-Sleep -Seconds 2
-
-# 3. Executando chamadas e validacoes
-Write-Host "[3/5] Executando chamadas HTTP..." -ForegroundColor Yellow
-$errors = 0
-
-# Funcao helper de validacao
-function Assert-Response($TestName, $Actual, $Expected) {
-    if ($Actual -like $Expected) {
-        Write-Host "  [OK] $TestName" -ForegroundColor Green
-    } else {
-        Write-Host "  [FALHA] $TestName" -ForegroundColor Red
-        Write-Host "    Esperado: $Expected" -ForegroundColor DarkRed
-        Write-Host "    Obtido: $Actual" -ForegroundColor DarkRed
-        $global:errors++
+    # 1. Compilando o Exemplo
+    Write-Host "[1/5] Compilando ConsoleComplete.dpr..." -ForegroundColor Yellow
+    $defineFlag = ""
+    if ($Define -ne "") {
+        $defineFlag = "-D`"$Define`""
     }
-}
+    $compileCmd = "dcc32 -B -Q -U`"../../../src`" -NS`"System;System.Win;Winapi;Data;Web`" $defineFlag ConsoleComplete.dpr"
+    Invoke-Expression $compileCmd
 
-try {
-    # GET /ping
-    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/ping"
-    Assert-Response "GET /ping" $res "pong"
-
-    # GET /resource/:id (com query e header case-insensitive)
-    $headers = @{ "authorization" = "Bearer JWT_123" }
-    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/resource/abc?q=busca" -Headers $headers
-    $expected = '*abc*busca*Bearer JWT_123*'
-    Assert-Response "GET /resource/:id (Params, Query, Header)" (ConvertTo-Json $res -Compress) $expected
-
-    # POST /resource
-    $res = Invoke-RestMethod -Method Post -Uri "http://localhost:9085/resource" -Body "Ola_Horse" -ContentType "text/plain"
-    Assert-Response "POST /resource (Body)" $res "POST OK: Ola_Horse"
-
-    # PUT /resource/:id
-    $res = Invoke-RestMethod -Method Put -Uri "http://localhost:9085/resource/123"
-    Assert-Response "PUT /resource/:id" (ConvertTo-Json $res -Compress) '*Updated*123*'
-
-    # PATCH /resource/:id
-    $res = Invoke-RestMethod -Method Patch -Uri "http://localhost:9085/resource/123"
-    Assert-Response "PATCH /resource/:id" (ConvertTo-Json $res -Compress) '*Patched*123*'
-
-    # DELETE /resource/:id
-    $res = Invoke-RestMethod -Method Delete -Uri "http://localhost:9085/resource/123"
-    Assert-Response "DELETE /resource/:id" (ConvertTo-Json $res -Compress) '*Deleted*123*'
-
-    # QUERY /search (Novo Verbo)
-    $res = curl.exe -s -X QUERY -d "filtro_busca" http://localhost:9085/search
-    Assert-Response "QUERY /search (Body)" $res "SEARCH RESULT FOR: filtro_busca"
-
-    # POST /upload (Multipart/Form-Data)
-    Set-Content -Path "temp_sample_upload.txt" -Value "Conteudo de amostra de upload para o sample."
-    $resUpload = curl.exe -s -X POST -F "file=@temp_sample_upload.txt" http://localhost:9085/upload
-    Assert-Response "POST /upload (Multipart/Form-Data)" $resUpload '*Upload OK*temp_sample_upload.txt*'
-    Remove-Item -Path "temp_sample_upload.txt" -Force -ErrorAction SilentlyContinue
-
-    $resErr = curl.exe -s -i http://localhost:9085/error-trigger
-    if ($resErr -match '400 Bad Request' -and $resErr -match 'Erro de Negocio Simulado') {
-        Write-Host "  [OK] GET /error-trigger (Clean JSON Exception)" -ForegroundColor Green
-    } else {
-        Write-Host "  [FALHA] GET /error-trigger (Clean JSON Exception)" -ForegroundColor Red
-        Write-Host "    Obtido: $resErr" -ForegroundColor DarkRed
-        $global:errors++
+    if (-not (Test-Path "ConsoleComplete.exe")) {
+        Write-Error "Falha na compilacao! Executavel nao gerado."
     }
+    Write-Host "Compilado com sucesso!" -ForegroundColor Green
 
-    # Testes do Roteamento de Wildcard (*) e prioridade de rotas
-    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/clientes"
-    Assert-Response "GET /clientes (Prioridade Wildcard)" $res "clientes"
+    # 2. Executando o servidor em background
+    Write-Host "[2/5] Iniciando o servidor na porta 9085 em segundo plano..." -ForegroundColor Yellow
+    $serverProcess = Start-Process -FilePath ".\ConsoleComplete.exe" -NoNewWindow -PassThru
+    Start-Sleep -Seconds 2
 
-    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/pessoas"
-    Assert-Response "GET /pessoas (Prioridade Wildcard)" $res "pessoas"
+    # 3. Executando chamadas e validacoes
+    Write-Host "[3/5] Executando chamadas HTTP..." -ForegroundColor Yellow
+    $errors = 0
 
-    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/qualquercoisa"
-    Assert-Response "GET /qualquercoisa (Cai no Wildcard)" $res "coringao"
-
-    # Teste de Resiliencia: Access Violation Simulado (esperamos HTTP 500 sem cair o servidor)
-    try {
-        $resErr = curl.exe -s -i "http://localhost:9085/av-trigger"
-        if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
-            Write-Host "  [OK] GET /av-trigger (Access Violation Handled)" -ForegroundColor Green
+    # Funcao helper de validacao
+    function Assert-Response($TestName, $Actual, $Expected) {
+        if ($Actual -like $Expected) {
+            Write-Host "  [OK] $TestName" -ForegroundColor Green
         } else {
-            Write-Host "  [FALHA] GET /av-trigger (Access Violation Handled)" -ForegroundColor Red
-            Write-Host "    Obtido: $resErr" -ForegroundColor DarkRed
+            Write-Host "  [FALHA] $TestName" -ForegroundColor Red
+            Write-Host "    Esperado: $Expected" -ForegroundColor DarkRed
+            Write-Host "    Obtido: $Actual" -ForegroundColor DarkRed
             $global:errors++
         }
-    } catch {
-        Write-Host "  [FALHA] GET /av-trigger falhou ou causou excecao nao tratada no PowerShell: $_" -ForegroundColor Red
-        $global:errors++
     }
 
-    # Teste de Resiliencia: Stack Overflow Simulado (estouro de limite de pilha)
     try {
-        $resErr = curl.exe -s -i --max-time 5 "http://localhost:9085/stack-trigger"
-        if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
-            Write-Host "  [OK] GET /stack-trigger (Stack Overflow Handled)" -ForegroundColor Green
+        # GET /ping
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/ping"
+        Assert-Response "GET /ping" $res "pong"
+
+        # GET /resource/:id (com query e header case-insensitive)
+        $headers = @{ "authorization" = "Bearer JWT_123" }
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/resource/abc?q=busca" -Headers $headers
+        $expected = '*abc*busca*Bearer JWT_123*'
+        Assert-Response "GET /resource/:id (Params, Query, Header)" (ConvertTo-Json $res -Compress) $expected
+
+        # POST /resource
+        $res = Invoke-RestMethod -Method Post -Uri "http://localhost:9085/resource" -Body "Ola_Horse" -ContentType "text/plain"
+        Assert-Response "POST /resource (Body)" $res "POST OK: Ola_Horse"
+
+        # PUT /resource/:id
+        $res = Invoke-RestMethod -Method Put -Uri "http://localhost:9085/resource/123"
+        Assert-Response "PUT /resource/:id" (ConvertTo-Json $res -Compress) '*Updated*123*'
+
+        # PATCH /resource/:id
+        $res = Invoke-RestMethod -Method Patch -Uri "http://localhost:9085/resource/123"
+        Assert-Response "PATCH /resource/:id" (ConvertTo-Json $res -Compress) '*Patched*123*'
+
+        # DELETE /resource/:id
+        $res = Invoke-RestMethod -Method Delete -Uri "http://localhost:9085/resource/123"
+        Assert-Response "DELETE /resource/:id" (ConvertTo-Json $res -Compress) '*Deleted*123*'
+
+        # QUERY /search (Novo Verbo)
+        $res = curl.exe -s -X QUERY -d "filtro_busca" http://localhost:9085/search
+        Assert-Response "QUERY /search (Body)" $res "SEARCH RESULT FOR: filtro_busca"
+
+        # POST /upload (Multipart/Form-Data)
+        Set-Content -Path "temp_sample_upload.txt" -Value "Conteudo de amostra de upload para o sample."
+        $resUpload = curl.exe -s -X POST -F "file=@temp_sample_upload.txt" http://localhost:9085/upload
+        Assert-Response "POST /upload (Multipart/Form-Data)" $resUpload '*Upload OK*temp_sample_upload.txt*'
+        Remove-Item -Path "temp_sample_upload.txt" -Force -ErrorAction SilentlyContinue
+
+        $resErr = curl.exe -s -i http://localhost:9085/error-trigger
+        if ($resErr -match '400 Bad Request' -and $resErr -match 'Erro de Negocio Simulado') {
+            Write-Host "  [OK] GET /error-trigger (Clean JSON Exception)" -ForegroundColor Green
         } else {
-            Write-Host "  [INFO] GET /stack-trigger retornou codigo inesperado (limite de Stack): $resErr" -ForegroundColor Cyan
+            Write-Host "  [FALHA] GET /error-trigger (Clean JSON Exception)" -ForegroundColor Red
+            Write-Host "    Obtido: $resErr" -ForegroundColor DarkRed
+            $errors++
         }
+
+        # Testes do Roteamento de Wildcard (*) e prioridade de rotas
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/clientes"
+        Assert-Response "GET /clientes (Prioridade Wildcard)" $res "clientes"
+
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/pessoas"
+        Assert-Response "GET /pessoas (Prioridade Wildcard)" $res "pessoas"
+
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/qualquercoisa"
+        Assert-Response "GET /qualquercoisa (Cai no Wildcard)" $res "coringao"
+
+        # Teste de Resiliencia: Access Violation Simulado (esperamos HTTP 500 sem cair o servidor)
+        try {
+            $resErr = curl.exe -s -i "http://localhost:9085/av-trigger"
+            if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
+                Write-Host "  [OK] GET /av-trigger (Access Violation Handled)" -ForegroundColor Green
+            } else {
+                Write-Host "  [FALHA] GET /av-trigger (Access Violation Handled)" -ForegroundColor Red
+                Write-Host "    Obtido: $resErr" -ForegroundColor DarkRed
+                $errors++
+            }
+        } catch {
+            Write-Host "  [FALHA] GET /av-trigger falhou ou causou excecao nao tratada no PowerShell: $_" -ForegroundColor Red
+            $errors++
+        }
+
+        # Teste de Resiliencia: Stack Overflow Simulado (estouro de limite de pilha)
+        try {
+            $resErr = curl.exe -s -i --max-time 5 "http://localhost:9085/stack-trigger"
+            if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
+                Write-Host "  [OK] GET /stack-trigger (Stack Overflow Handled)" -ForegroundColor Green
+            } else {
+                Write-Host "  [INFO] GET /stack-trigger retornou codigo inesperado (limite de Stack): $resErr" -ForegroundColor Cyan
+            }
+        } catch {
+            Write-Host "  [INFO] GET /stack-trigger derrubou o servidor ou estourou (comportamento esperado do limite do SO): $_" -ForegroundColor Cyan
+        }
+
     } catch {
-        Write-Host "  [INFO] GET /stack-trigger derrubou o servidor ou estourou (comportamento esperado do limite do SO): $_" -ForegroundColor Cyan
+        Write-Host "Erro inesperado ao realizar chamadas HTTP: $_" -ForegroundColor Red
+        $errors++
     }
 
-} catch {
-    Write-Host "Erro inesperado ao realizar chamadas HTTP: $_" -ForegroundColor Red
-    $global:errors++
+    # 4. Finalizando o Servidor
+    Write-Host "[4/5] Finalizando processo do servidor..." -ForegroundColor Yellow
+    $serverProcess | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+
+    # 5. Limpeza de arquivos gerados
+    Write-Host "[5/5] Limpando executavel e arquivos temporarios..." -ForegroundColor Yellow
+    Remove-Item -Path "ConsoleComplete.exe", "ConsoleComplete.dcu" -Force -ErrorAction SilentlyContinue
+
+    return $errors
 }
 
-# 4. Finalizando o Servidor
-Write-Host "[4/5] Finalizando processo do servidor..." -ForegroundColor Yellow
-$serverProcess | Stop-Process -Force -ErrorAction SilentlyContinue
-Start-Sleep -Seconds 1
+# Executando rodadas de teste
+$totalErrors = 0
+$errorsDefault = Run-IntegrityTest -RouterName "Default Router (RouterTree)" -Define ""
+$errorsRadix = Run-IntegrityTest -RouterName "Radix Router (RadixRouter)" -Define "HORSE_RADIX_ROUTER"
 
-# 5. Limpeza de arquivos gerados
-Write-Host "[5/5] Limpando executavel e arquivos temporarios..." -ForegroundColor Yellow
-Remove-Item -Path "ConsoleComplete.exe", "ConsoleComplete.dcu" -Force -ErrorAction SilentlyContinue
+$totalErrors = $errorsDefault + $errorsRadix
 
-# Conclusao
 Write-Host "==================================================" -ForegroundColor Cyan
-if ($errors -eq 0) {
+if ($totalErrors -eq 0) {
     Write-Host "      TODOS OS TESTES DE INTEGRIDADE PASSARAM!     " -ForegroundColor Green
     Write-Host "==================================================" -ForegroundColor Green
 } else {
-    Write-Host "      OCORRERAM $errors FALHA(S) NO TESTE!         " -ForegroundColor Red
+    Write-Host "      OCORRERAM $totalErrors FALHA(S) NO TOTAL DOS TESTES!  " -ForegroundColor Red
     Write-Host "==================================================" -ForegroundColor Red
     exit 1
 }

--- a/samples/delphi/console_complete/test_integrity.ps1
+++ b/samples/delphi/console_complete/test_integrity.ps1
@@ -82,6 +82,43 @@ try {
         $global:errors++
     }
 
+    # Testes do Roteamento de Wildcard (*) e prioridade de rotas
+    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/clientes"
+    Assert-Response "GET /clientes (Prioridade Wildcard)" $res "clientes"
+
+    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/pessoas"
+    Assert-Response "GET /pessoas (Prioridade Wildcard)" $res "pessoas"
+
+    $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/qualquercoisa"
+    Assert-Response "GET /qualquercoisa (Cai no Wildcard)" $res "coringao"
+
+    # Teste de Resiliencia: Access Violation Simulado (esperamos HTTP 500 sem cair o servidor)
+    try {
+        $resErr = curl.exe -s -i "http://localhost:9085/av-trigger"
+        if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
+            Write-Host "  [OK] GET /av-trigger (Access Violation Handled)" -ForegroundColor Green
+        } else {
+            Write-Host "  [FALHA] GET /av-trigger (Access Violation Handled)" -ForegroundColor Red
+            Write-Host "    Obtido: $resErr" -ForegroundColor DarkRed
+            $global:errors++
+        }
+    } catch {
+        Write-Host "  [FALHA] GET /av-trigger falhou ou causou excecao nao tratada no PowerShell: $_" -ForegroundColor Red
+        $global:errors++
+    }
+
+    # Teste de Resiliencia: Stack Overflow Simulado (estouro de limite de pilha)
+    try {
+        $resErr = curl.exe -s -i --max-time 5 "http://localhost:9085/stack-trigger"
+        if ($resErr -match '500 Internal Server Error' -or $resErr -match '500 Internal Application Error') {
+            Write-Host "  [OK] GET /stack-trigger (Stack Overflow Handled)" -ForegroundColor Green
+        } else {
+            Write-Host "  [INFO] GET /stack-trigger retornou codigo inesperado (limite de Stack): $resErr" -ForegroundColor Cyan
+        }
+    } catch {
+        Write-Host "  [INFO] GET /stack-trigger derrubou o servidor ou estourou (comportamento esperado do limite do SO): $_" -ForegroundColor Cyan
+    }
+
 } catch {
     Write-Host "Erro inesperado ao realizar chamadas HTTP: $_" -ForegroundColor Red
     $global:errors++

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -170,12 +170,17 @@ begin
   LAcceptable := nil;
   for LPair in FRoute do
   begin
-    if LCurrent.Compare(LPair.Key) or (LPair.Key = '*') then
+    if (LPair.Key <> '*') and LCurrent.Compare(LPair.Key) then
     begin
       LAcceptable := LPair.Value;
       LFound := True;
       Break;
     end;
+  end;
+
+  if not LFound then
+  begin
+    LFound := FRoute.TryGetValue('*', LAcceptable);
   end;
 
   if (not LFound) then

--- a/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
+++ b/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
@@ -42,6 +42,8 @@ type
     procedure ExecuteRouteWithTwoConsecutiveParams;
     [Test]
     procedure ExecuteRouteWithMiddlewares;
+    [Test]
+    procedure ExecuteRouteWithCoringaoPriority;
   end;
 
 implementation
@@ -271,6 +273,65 @@ begin
   FRequest.Populate('GET', mtGet, '/test', '', '');
   Assert.IsTrue(FRouter.Execute(FRequest, FResponse));
   Assert.AreEqual(4, LStep);
+end;
+
+procedure TTestHorseCoreRouterRadix.ExecuteRouteWithCoringaoPriority;
+var
+  LClientesCalled: Boolean;
+  LPessoasCalled: Boolean;
+  LCoringaoCalled: Boolean;
+begin
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+
+  FRouter.RegisterRoute(mtGet, '/clientes',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LClientesCalled := True;
+    end);
+
+  FRouter.RegisterRoute(mtGet, '/pessoas',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LPessoasCalled := True;
+    end);
+
+  FRouter.RegisterRoute(mtGet, '*',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LCoringaoCalled := True;
+    end);
+
+  // Testando rota exata /clientes
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/clientes', '', '');
+  Assert.IsTrue(FRouter.Execute(FRequest, FResponse));
+  Assert.IsTrue(LClientesCalled);
+  Assert.IsFalse(LPessoasCalled);
+  Assert.IsFalse(LCoringaoCalled);
+
+  // Testando rota exata /pessoas
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/pessoas', '', '');
+  Assert.IsTrue(FRouter.Execute(FRequest, FResponse));
+  Assert.IsFalse(LClientesCalled);
+  Assert.IsTrue(LPessoasCalled);
+  Assert.IsFalse(LCoringaoCalled);
+
+  // Testando rota genérica (wildcard)
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/qualquercoisa', '', '');
+  Assert.IsTrue(FRouter.Execute(FRequest, FResponse));
+  Assert.IsFalse(LClientesCalled);
+  Assert.IsFalse(LPessoasCalled);
+  Assert.IsTrue(LCoringaoCalled);
 end;
 
 initialization

--- a/tests/src/tests/Tests.Horse.Core.RouterTree.pas
+++ b/tests/src/tests/Tests.Horse.Core.RouterTree.pas
@@ -60,6 +60,8 @@ type
     procedure ExecuteRouteWithCoringaoMiddlePath;
     [Test]
     procedure ExecuteRouteWithTwoConsecutiveCoringao;
+    [Test]
+    procedure ExecuteRouteWithCoringaoPriority;
   end;
 
 implementation
@@ -412,6 +414,65 @@ begin
   FRequest.Populate('GET', mtGet, '/users/any/random', '', '');
   Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
   Assert.IsTrue(LCalled);
+end;
+
+procedure TTestHorseCoreRouterTree.ExecuteRouteWithCoringaoPriority;
+var
+  LClientesCalled: Boolean;
+  LPessoasCalled: Boolean;
+  LCoringaoCalled: Boolean;
+begin
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+
+  FRouterTree.RegisterRoute(mtGet, '/clientes',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LClientesCalled := True;
+    end);
+
+  FRouterTree.RegisterRoute(mtGet, '/pessoas',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LPessoasCalled := True;
+    end);
+
+  FRouterTree.RegisterRoute(mtGet, '*',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LCoringaoCalled := True;
+    end);
+
+  // Testando rota exata /clientes
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/clientes', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsTrue(LClientesCalled);
+  Assert.IsFalse(LPessoasCalled);
+  Assert.IsFalse(LCoringaoCalled);
+
+  // Testando rota exata /pessoas
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/pessoas', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsFalse(LClientesCalled);
+  Assert.IsTrue(LPessoasCalled);
+  Assert.IsFalse(LCoringaoCalled);
+
+  // Testando rota genérica (wildcard)
+  LClientesCalled := False;
+  LPessoasCalled := False;
+  LCoringaoCalled := False;
+  FRequest.Populate('GET', mtGet, '/qualquercoisa', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsFalse(LClientesCalled);
+  Assert.IsFalse(LPessoasCalled);
+  Assert.IsTrue(LCoringaoCalled);
 end;
 
 initialization


### PR DESCRIPTION
# Resolve a issue #366

Este Pull Request corrige problemas de prioridade de roteamento onde rotas coringas (`*` ou `/*`) capturavam incorretamente chamadas destinadas a rotas exatas (conforme reportado na issue #366). O PR também adiciona cobertura de testes unitários para a priorização de wildcards, aprimora a suíte de testes de integridade e documenta o comportamento de resiliência e limites físicos do framework.

Corrige a issue #366

## O que foi alterado?
1. **RouterTree (`Horse.Core.RouterTree.pas`)**:
   - Ajustada a lógica de busca de rotas filhas em `CallNextPath` para separar a varredura em duas passadas. Agora tenta correspondência exata primeiro. Caso nenhuma coincida, o coringa `*` é consultado como fallback. Isso corrige o comportamento imprevisível causado pela ordem de iteração indeterminada de chaves no dicionário `TObjectDictionary`.
2. **Testes Unitários**:
   - Implementado o teste `ExecuteRouteWithCoringaoPriority` em `Tests.Horse.Core.RouterTree.pas` e `Tests.Horse.Core.Router.Radix.pas` para garantir que o comportamento prioritário seja idêntico e correto nos dois roteadores.
3. **Testes de Integridade (Exemplo `ConsoleComplete`)**:
   - Adicionados endpoints no servidor `ConsoleComplete.dpr` e asserções HTTP correspondentes em `test_integrity.ps1` cobrindo o roteamento coringa.
   - Refatorado o script `test_integrity.ps1` para executar dois testes completos consecutivos em produção real: um usando o RouterTree e outro usando o RadixRouter (via define `HORSE_RADIX_ROUTER`).
   - Inclusão de testes de estresse e resiliência (gatilhos de Access Violation e Stack Overflow) para monitorar os limites do framework.
4. **Documentação**:
   - Criação de guias bilíngues detalhando o script de testes de integridade, sua utilidade prática na prevenção de regressões e as limitações de resiliência a nível de SO (recuperação de AV em threads vs. estouro de limite físico de stack):
     - `doc/integrity-testing.md` (EN)
     - `doc/integrity-testing.pt-BR.md` (PT-BR)
   - Adicionados links de referência rápida nos arquivos `README.md` e `doc/index.md` (e suas respectivas versões `.pt-BR.md`).

---

## Como testar?
Execute a suíte de testes unitários ou o script PowerShell de integridade localmente:

```powershell
# 1. Testes unitários do RouterTree
dcc32 Console.dpr -U"..\..\src;modules\restrequest4delphi\src;modules\jhonson\src" -NS"System;System.Win;Winapi;Web;Xml;Data"
.\Console.exe -exit:Continue

# 2. Testes unitários do RadixRouter
dcc32 Console.dpr -U"..\..\src;modules\restrequest4delphi\src;modules\jhonson\src" -NS"System;System.Win;Winapi;Web;Xml;Data" -D"HORSE_RADIX_ROUTER"
.\Console.exe -exit:Continue

# 3. Teste de integridade completo dos dois roteadores
cd samples/delphi/console_complete
.\test_integrity.ps1
