### PR TITLE
Feature/issue 357 group route tests

### DIFF
--- a/samples/delphi/console_complete/ConsoleComplete.dpr
+++ b/samples/delphi/console_complete/ConsoleComplete.dpr
@@ -121,6 +121,31 @@ begin
       Res.Send('pessoas');
     end);
 
+  // Teste de integridade para a issue #357 (Group + Route + End + Put)
+  THorse.Group.Prefix('/api')
+    .Delete('/test1/:id',
+      procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+      begin
+        Res.Send('delete1');
+      end)
+    .Route('/test2')
+      .Get(
+        procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+        begin
+          Res.Send('get2');
+        end)
+      .Post(
+        procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+        begin
+          Res.Send('post2');
+        end)
+    .&End
+    .Put('/teste3',
+      procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+      begin
+        Res.Send('put3');
+      end);
+
   // 12. GET * -> Rota wildcard genérica (coringão)
   THorse.Get('*',
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)

--- a/samples/delphi/console_complete/test_integrity.ps1
+++ b/samples/delphi/console_complete/test_integrity.ps1
@@ -97,6 +97,28 @@ function Run-IntegrityTest($RouterName, $Define) {
         $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/qualquercoisa"
         Assert-Response "GET /qualquercoisa (Cai no Wildcard)" $res "coringao"
 
+        # Testes de Integridade da issue #357 (Group + Route + End + Put)
+        # 1. DELETE /api/test1/123
+        $res = Invoke-RestMethod -Method Delete -Uri "http://localhost:9085/api/test1/123"
+        Assert-Response "DELETE /api/test1/:id (Group Delete)" $res "delete1"
+
+        # 2. GET /api/test2 (dentro do Route)
+        $res = Invoke-RestMethod -Method Get -Uri "http://localhost:9085/api/test2"
+        Assert-Response "GET /api/test2 (Group Route Get)" $res "get2"
+
+        # 3. POST /api/test2 (dentro do Route)
+        $res = Invoke-RestMethod -Method Post -Uri "http://localhost:9085/api/test2"
+        Assert-Response "POST /api/test2 (Group Route Post)" $res "post2"
+
+        # 4. PUT /api/teste3 (apos o &End do Route no mesmo grupo)
+        try {
+            $res = Invoke-RestMethod -Method Put -Uri "http://localhost:9085/api/teste3"
+            Assert-Response "PUT /api/teste3 (Group Route End Put)" $res "put3"
+        } catch {
+            Write-Host "  [FALHA] PUT /api/teste3 falhou com erro HTTP (esperado no bug #357)" -ForegroundColor Red
+            $global:errors++
+        }
+
         # Teste de Resiliencia: Access Violation Simulado (esperamos HTTP 500 sem cair o servidor)
         try {
             $resErr = curl.exe -s -i "http://localhost:9085/av-trigger"

--- a/src/Horse.Core.Group.Contract.pas
+++ b/src/Horse.Core.Group.Contract.pas
@@ -18,7 +18,7 @@ type
   IHorseCoreGroup<T: class> = interface
     ['{5EB734D6-6944-473E-9C79-506647E2F5E8}']
     function Prefix(const APrefix: string): IHorseCoreGroup<T>;
-    function Route(const APath: string): IHorseCoreRoute<T>;
+    function Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
     function AddCallback(const ACallback: THorseCallback): IHorseCoreGroup<T>;
     {$IF DEFINED(FPC)}
     function AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreGroup<T>;

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -24,7 +24,7 @@ type
   public
     constructor Create;
     function Prefix(const APrefix: string): IHorseCoreGroup<T>;
-    function Route(const APath: string): IHorseCoreRoute<T>;
+    function Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
     function AddCallback(const ACallback: THorseCallback): IHorseCoreGroup<T>;
     {$IF DEFINED(FPC)}
     function AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreGroup<T>;
@@ -80,6 +80,64 @@ type
 {$IFEND}
 {$IFEND}
     function &End: T;
+  end;
+
+  THorseCoreGroupRoute<T: THorseCoreBase> = class(TInterfacedObject, IHorseCoreRoute<IHorseCoreGroup<T>>)
+  private
+    FPath: string;
+    FGroup: IHorseCoreGroup<T>;
+    FHorseCore: T;
+  public
+    constructor Create(const AGroup: IHorseCoreGroup<T>; const AHorseCore: T; const APath: string);
+    function AddCallback(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+    {$IF DEFINED(FPC)}
+    function AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreRoute<IHorseCoreGroup<T>>;
+    {$ELSE}
+    function AddCallbacks(const ACallbacks: TArray<THorseCallback>): IHorseCoreRoute<IHorseCoreGroup<T>>;
+    {$ENDIF}
+    function All(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function All(const AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function All(const ACallbacks: array of THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function All(const ACallbacks: array of THorseCallback; const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Get(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Get(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Get(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Get(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    function Put(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Put(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Put(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Put(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    function Head(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Head(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Head(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Head(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    function Post(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Post(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Post(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Post(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    {$IF (DEFINED(FPC) OR (CompilerVersion > 27.0))}
+    function Patch(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Delete(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Patch(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Patch(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Patch(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    function Delete(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    function Delete(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$IFNDEF FPC}
+    function Delete(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>; overload;
+    {$ENDIF}
+    {$ENDIF}
+    function &End: IHorseCoreGroup<T>;
   end;
 
 implementation
@@ -242,9 +300,9 @@ begin
   FPrefix := '/' + APrefix.Trim(['/']);
 end;
 
-function THorseCoreGroup<T>.Route(const APath: string): IHorseCoreRoute<T>;
+function THorseCoreGroup<T>.Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
 begin
-  Result := THorseCoreBase(FHorseCore).BaseRoute(NormalizePath(APath)) as IHorseCoreRoute<T>;
+  Result := THorseCoreGroupRoute<T>.Create(Self, FHorseCore, NormalizePath(APath));
 end;
 
 function THorseCoreGroup<T>.Use(const AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>;
@@ -353,6 +411,233 @@ function THorseCoreGroup<T>.Post(const APath: string; const ACallback: THorseCal
 begin
   Result := Self;
   THorseCoreBase(FHorseCore).BasePost(NormalizePath(APath), ACallback);
+end;
+
+{ THorseCoreGroupRoute<T> }
+
+constructor THorseCoreGroupRoute<T>.Create(const AGroup: IHorseCoreGroup<T>; const AHorseCore: T; const APath: string);
+begin
+  FGroup := AGroup;
+  FHorseCore := AHorseCore;
+  FPath := APath;
+end;
+
+function THorseCoreGroupRoute<T>.AddCallback(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseAddCallback(ACallback);
+end;
+
+{$IF DEFINED(FPC)}
+function THorseCoreGroupRoute<T>.AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreRoute<IHorseCoreGroup<T>>;
+var
+  LCallback: THorseCallback;
+begin
+  if Assigned(ACallbacks) then
+  begin
+    for LCallback in ACallbacks do
+      AddCallback(LCallback);
+  end;
+  Result := Self;
+end;
+{$ELSE}
+function THorseCoreGroupRoute<T>.AddCallbacks(const ACallbacks: TArray<THorseCallback>): IHorseCoreRoute<IHorseCoreGroup<T>>;
+var
+  LCallback: THorseCallback;
+begin
+  for LCallback in ACallbacks do
+    AddCallback(LCallback);
+  Result := Self;
+end;
+{$ENDIF}
+
+function THorseCoreGroupRoute<T>.All(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseUse(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.All(const AMiddleware, ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseUse(FPath, [AMiddleware, ACallback]);
+end;
+
+function THorseCoreGroupRoute<T>.All(const ACallbacks: array of THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseUse(FPath, ACallbacks);
+end;
+
+function THorseCoreGroupRoute<T>.All(const ACallbacks: array of THorseCallback; const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseUse(FPath, ACallbacks);
+  THorseCoreBase(FHorseCore).BaseUse(FPath, [ACallback]);
+end;
+
+function THorseCoreGroupRoute<T>.Get(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseGet(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Get(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseGet(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Get(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseGet(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Get(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseGet(FPath, ACallback);
+end;
+{$ENDIF}
+
+function THorseCoreGroupRoute<T>.Put(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePut(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Put(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePut(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Put(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePut(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Put(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePut(FPath, ACallback);
+end;
+{$ENDIF}
+
+function THorseCoreGroupRoute<T>.Head(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseHead(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Head(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseHead(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Head(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseHead(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Head(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseHead(FPath, ACallback);
+end;
+{$ENDIF}
+
+// Implementacao de Post
+function THorseCoreGroupRoute<T>.Post(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePost(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Post(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePost(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Post(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePost(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Post(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePost(FPath, ACallback);
+end;
+{$ENDIF}
+
+{$IF (DEFINED(FPC) OR (CompilerVersion > 27.0))}
+function THorseCoreGroupRoute<T>.Patch(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePatch(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Delete(const ACallback: THorseCallback): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseDelete(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Patch(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePatch(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Patch(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePatch(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Patch(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BasePatch(FPath, ACallback);
+end;
+{$ENDIF}
+
+function THorseCoreGroupRoute<T>.Delete(const ACallback: THorseCallbackRequestResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseDelete(FPath, ACallback);
+end;
+
+function THorseCoreGroupRoute<T>.Delete(const ACallback: THorseCallbackRequest): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseDelete(FPath, ACallback);
+end;
+
+{$IFNDEF FPC}
+function THorseCoreGroupRoute<T>.Delete(const ACallback: THorseCallbackResponse): IHorseCoreRoute<IHorseCoreGroup<T>>;
+begin
+  Result := Self;
+  THorseCoreBase(FHorseCore).BaseDelete(FPath, ACallback);
+end;
+{$ENDIF}
+{$ENDIF}
+
+function THorseCoreGroupRoute<T>.&End: IHorseCoreGroup<T>;
+begin
+  Result := FGroup;
 end;
 
 end.

--- a/src/Horse.Core.Route.Contract.pas
+++ b/src/Horse.Core.Route.Contract.pas
@@ -13,7 +13,7 @@ uses
   Horse.Callback;
 
 type
-  IHorseCoreRoute<T: class> = interface
+  IHorseCoreRoute<T> = interface
     ['{8D593D98-44B3-4FD2-A21B-BA29F784B3AA}']
     function AddCallback(const ACallback: THorseCallback): IHorseCoreRoute<T>;
     {$IF DEFINED(FPC)}

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -64,6 +64,7 @@ uses
   Tests.AssertHelper in 'tests\Tests.AssertHelper.pas',
   Tests.CleanupHelper in 'tests\Tests.CleanupHelper.pas',
   Tests.Horse.Core.RouterTree in 'tests\Tests.Horse.Core.RouterTree.pas',
+  Tests.Horse.Core.Group in 'tests\Tests.Horse.Core.Group.pas',
   {$IFNDEF FPC}
   Tests.Horse.Core.Router.Radix in 'tests\Tests.Horse.Core.Router.Radix.pas',
   {$ENDIF}

--- a/tests/src/VCL.dpr
+++ b/tests/src/VCL.dpr
@@ -53,6 +53,7 @@ uses
   Horse.Core.Param.Field.Brackets in '..\..\src\Horse.Core.Param.Field.Brackets.pas',
   Horse.Core.Files in '..\..\src\Horse.Core.Files.pas',
   Tests.Horse.Core.Files in 'tests\Tests.Horse.Core.Files.pas',
+  Tests.Horse.Core.Group in 'tests\Tests.Horse.Core.Group.pas',
   Horse.Mime in '..\..\src\Horse.Mime.pas',
   Horse.Provider.Config in '..\..\src\Horse.Provider.Config.pas',
   Horse.Provider.IOHandleSSL.Contract in '..\..\src\Horse.Provider.IOHandleSSL.Contract.pas';

--- a/tests/src/tests/Tests.Horse.Core.Group.pas
+++ b/tests/src/tests/Tests.Horse.Core.Group.pas
@@ -1,0 +1,109 @@
+unit Tests.Horse.Core.Group;
+
+interface
+
+uses
+  DUnitX.TestFramework, System.Classes, SysUtils, Horse, RESTRequest4D,
+  Tests.CleanupHelper;
+
+type
+  [TestFixture]
+  TTestHorseCoreGroup = class(TObject)
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test]
+    procedure TestGroupRouteEndFluency;
+  end;
+
+implementation
+
+procedure TestDoDeleteApi(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('delete1');
+end;
+
+procedure TestDoGetApi(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('get2');
+end;
+
+procedure TestDoPostApi(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('post2');
+end;
+
+procedure TestDoPutApi(Req: THorseRequest; Res: THorseResponse);
+begin
+  Res.Send('put3');
+end;
+
+procedure TTestHorseCoreGroup.Setup;
+begin
+  try
+    if THorse.IsRunning then
+      ClearGlobalState;
+  except
+  end;
+
+  if not THorse.IsRunning then
+  begin
+    TThread.CreateAnonymousThread(
+      procedure
+      begin
+        THorse.Group.Prefix('/api')
+          .Delete('/test1/:id', TestDoDeleteApi)
+          .Route('/test2')
+            .Get(TestDoGetApi)
+            .Post(TestDoPostApi)
+          .&End
+          .Put('/teste3', TestDoPutApi);
+
+        THorse.Listen(9099);
+      end).Start;
+    Sleep(500);
+  end;
+end;
+
+procedure TTestHorseCoreGroup.TearDownFixture;
+begin
+  try
+    ClearGlobalState;
+  except
+  end;
+end;
+
+procedure TTestHorseCoreGroup.TestGroupRouteEndFluency;
+var
+  LResponse: IResponse;
+begin
+  // 1. Validar DELETE /api/test1/:id
+  LResponse := TRequest.New.BaseURL('http://localhost:9099/api/test1/123').Delete;
+  Assert.AreEqual(200, LResponse.StatusCode);
+  Assert.AreEqual('delete1', LResponse.Content.Trim);
+
+  // 2. Validar GET /api/test2 (dentro do Route)
+  LResponse := TRequest.New.BaseURL('http://localhost:9099/api/test2').Get;
+  Assert.AreEqual(200, LResponse.StatusCode);
+  Assert.AreEqual('get2', LResponse.Content.Trim);
+
+  // 3. Validar POST /api/test2 (dentro do Route)
+  LResponse := TRequest.New.BaseURL('http://localhost:9099/api/test2').Post;
+  Assert.AreEqual(200, LResponse.StatusCode);
+  Assert.AreEqual('post2', LResponse.Content.Trim);
+
+  // 4. Validar PUT /api/teste3 (apos o &End do Route no mesmo grupo)
+  // Sob o bug atual, esta rota falhara com 404 Not Found porque o prefixo /api foi perdido
+  LResponse := TRequest.New.BaseURL('http://localhost:9099/api/teste3').Put;
+  Assert.AreEqual(200, LResponse.StatusCode, 'A rota /api/teste3 nao foi localizada sob o prefixo correto.');
+  Assert.AreEqual('put3', LResponse.Content.Trim);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestHorseCoreGroup);
+
+end.


### PR DESCRIPTION
# fix(core): resolução da quebra de fluidez e perda de prefixo em grupos (#357)

## Descrição do Bug
Ao declarar rotas agrupadas contendo sub-rotas via método `.Route()`, a chamada subsequente ao método `.End` de encerramento da sub-rota forçava a API fluente a retornar a classe principal do core (`THorseCore`). 

Isso quebrava o escopo do grupo na mesma linha de instrução. Como consequência, qualquer declaração fluente subsequente (como um `.Put()` logo após o `.End` da sub-rota) era processada no escopo principal do Core, fazendo com que a rota fosse registrada erroneamente na raiz (ex: `/teste3` em vez de `/api/teste3`).

---

## Causa Raiz
No design original das interfaces:
1. `IHorseCoreRoute<T: class>` possuía a restrição `: class`, impedindo que o parâmetro genérico `T` recebesse tipos de interface (como `IHorseCoreGroup`).
2. O método `.Route()` de `IHorseCoreGroup<T>` retornava obrigatoriamente `IHorseCoreRoute<T>` (sendo `T` o core principal `THorseCore`), forçando a saída precoce do escopo de grupo no fechamento da rota.

---

## Solução Implementada (Design Orientado a Objetos Puro)
Adotamos uma solução estática de tipos, totalmente livre de variáveis globais de estado e de riscos de vazamento de escopo na memória (ARC):

1. **Desacoplamento de Restrição de Classe:**
   * Removemos a restrição `: class` na interface `IHorseCoreRoute<T>` em `Horse.Core.Route.Contract.pas`.
2. **Refatoração do Contrato de Grupo:**
   * Alteramos a assinatura do método `Route` em `IHorseCoreGroup<T>` (`Horse.Core.Group.Contract.pas`) para retornar `IHorseCoreRoute<IHorseCoreGroup<T>>`.
3. **Classe Proxy de Rota de Grupo (`THorseCoreGroupRoute`):**
   * Implementamos a classe proxy `THorseCoreGroupRoute<T: THorseCoreBase>` em `Horse.Core.Group.pas`. Esta classe delega os registros de endpoints para o core mas retorna a referência ao próprio grupo (`IHorseCoreGroup<T>`) ao invés do Core principal no seu método `&End`.
   * Ajustamos a classe `THorseCoreGroup<T>` para instanciar e retornar esta rota proxy.

Com essa modificação, a própria linguagem (via compilador) gerencia o retorno estático correto do grupo após a finalização de uma sub-rota.

---

## Validação e Testes Realizados

Os testes cobriram ambas as engines de roteamento do Horse: **RouterTree** (padrão) e **RadixRouter** (via `-DHORSE_RADIX_ROUTER`).

### 1. Teste Unitário (DUnitX)
Criamos a fixture `Tests.Horse.Core.Group.pas` replicando exatamente o cenário da issue:
```delphi
THorse.Group.Prefix('/api')
  .Delete('/test1/:id', DoDeleteApi)
  .Route('/test2')
    .Get(DoGetApi)
    .Post(DoPostApi)
  .&End
  .Put('/teste3', DoPutApi);
