### PR TITLE
fix(core): resolve generic route compilation error on FPC 3.2.2

### DIFF
--- a/src/Horse.Core.Group.Contract.pas
+++ b/src/Horse.Core.Group.Contract.pas
@@ -18,7 +18,11 @@ type
   IHorseCoreGroup<T: class> = interface
     ['{5EB734D6-6944-473E-9C79-506647E2F5E8}']
     function Prefix(const APrefix: string): IHorseCoreGroup<T>;
+    {$IF DEFINED(FPC)}
+    function Route(const APath: string): IHorseCoreRoute<T>;
+    {$ELSE}
     function Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
+    {$ENDIF}
     function AddCallback(const ACallback: THorseCallback): IHorseCoreGroup<T>;
     {$IF DEFINED(FPC)}
     function AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreGroup<T>;

--- a/src/Horse.Core.Group.pas
+++ b/src/Horse.Core.Group.pas
@@ -24,7 +24,11 @@ type
   public
     constructor Create;
     function Prefix(const APrefix: string): IHorseCoreGroup<T>;
+    {$IF DEFINED(FPC)}
+    function Route(const APath: string): IHorseCoreRoute<T>;
+    {$ELSE}
     function Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
+    {$ENDIF}
     function AddCallback(const ACallback: THorseCallback): IHorseCoreGroup<T>;
     {$IF DEFINED(FPC)}
     function AddCallbacks(const ACallbacks: TList<THorseCallback>): IHorseCoreGroup<T>;
@@ -82,6 +86,7 @@ type
     function &End: T;
   end;
 
+  {$IFNDEF FPC}
   THorseCoreGroupRoute<T: THorseCoreBase> = class(TInterfacedObject, IHorseCoreRoute<IHorseCoreGroup<T>>)
   private
     FPath: string;
@@ -139,6 +144,7 @@ type
     {$ENDIF}
     function &End: IHorseCoreGroup<T>;
   end;
+  {$ENDIF}
 
 implementation
 
@@ -300,10 +306,17 @@ begin
   FPrefix := '/' + APrefix.Trim(['/']);
 end;
 
+{$IF DEFINED(FPC)}
+function THorseCoreGroup<T>.Route(const APath: string): IHorseCoreRoute<T>;
+begin
+  Result := THorseCoreBase(FHorseCore).BaseRoute(NormalizePath(APath)) as IHorseCoreRoute<T>;
+end;
+{$ELSE}
 function THorseCoreGroup<T>.Route(const APath: string): IHorseCoreRoute<IHorseCoreGroup<T>>;
 begin
   Result := THorseCoreGroupRoute<T>.Create(Self, FHorseCore, NormalizePath(APath));
 end;
+{$ENDIF}
 
 function THorseCoreGroup<T>.Use(const AMiddleware, ACallback: THorseCallback): IHorseCoreGroup<T>;
 begin
@@ -413,6 +426,7 @@ begin
   THorseCoreBase(FHorseCore).BasePost(NormalizePath(APath), ACallback);
 end;
 
+{$IFNDEF FPC}
 { THorseCoreGroupRoute<T> }
 
 constructor THorseCoreGroupRoute<T>.Create(const AGroup: IHorseCoreGroup<T>; const AHorseCore: T; const APath: string);
@@ -639,5 +653,6 @@ function THorseCoreGroupRoute<T>.&End: IHorseCoreGroup<T>;
 begin
   Result := FGroup;
 end;
+{$ENDIF}
 
 end.


### PR DESCRIPTION
# Descrição

Este Pull Request resolve um erro de compilação no Free Pascal (FPC 3.2.2) que foi introduzido nas alterações recentes da API fluida de roteamento de grupos (issue #357).

### 🐛 Problema / Causa Raiz
Nas últimas alterações, o método `Route` em `IHorseCoreGroup<T>` foi modificado para retornar `IHorseCoreRoute<IHorseCoreGroup<T>>`. 
O compilador do Free Pascal (FPC) apresenta incompatibilidade com a especialização de interfaces genéricas aninhadas quando o parâmetro genérico é uma interface ainda não especializada no próprio escopo, gerando o seguinte erro durante o build:
`Horse.Core.Route.Contract.pas(18,77) Error: Generics cannot be used as parameters when specializing generics`

### 🛠️ Solução Aplicada
Para restaurar a compatibilidade de compilação com FPC sem perder as melhorias de fluidez de roteamento no Delphi, isolamos o comportamento da classe genérica aninhada utilizando diretivas de compilação condicional:
1. **Assinaturas Condicionais de Retorno**: 
   * Sob a diretiva `FPC`, o método `Route` tanto em `IHorseCoreGroup<T>` quanto em `THorseCoreGroup<T>` retorna `IHorseCoreRoute<T>` (mantendo a compatibilidade retroativa estável).
   * Sob a diretiva `Delphi`, o método continua retornando `IHorseCoreRoute<IHorseCoreGroup<T>>` para manter o comportamento fluído premium.
2. **Isolamento de Classe**: A nova classe `THorseCoreGroupRoute<T>` e suas implementações foram encapsuladas em blocos `{$IFNDEF FPC}`, evitando que o compilador do FPC tente processá-la e quebre a build.

### 🧪 Testes Realizados
* Compilação com sucesso do container Docker de benchmark FPC (utilizando debian:bookworm-slim e FPC 3.2.2).
* Compilação e execução corretas em Delphi no Linux 64-bit.
