### PR TITLE
fix(fpc): fix callback compatibility with official middlewares (issue…

### DIFF
--- a/samples/lazarus/test_issue498/TestIssue498.lpr
+++ b/samples/lazarus/test_issue498/TestIssue498.lpr
@@ -1,0 +1,62 @@
+program TestIssue498;
+
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  SysUtils,
+  Horse,
+  Horse.Jhonson,
+  Horse.Compression,
+  Horse.BasicAuthentication,
+  Horse.CORS,
+  Horse.OctetStream;
+
+function MyAuthenticate(const AUser, APass: string): Boolean;
+begin
+  Result := (AUser = 'user') and (APass = 'pass');
+end;
+
+procedure GetPing(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  Res.Send('pong');
+end;
+
+procedure MyCORS(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  CORS(Req, Res, Next);
+end;
+
+procedure MyOctetStream(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  OctetStream(Req, Res, Next);
+end;
+
+begin
+  // Inicialização com os 5 middlewares oficiais
+  THorse.Use(Jhonson());
+  THorse.Use(Compression());
+
+  {$IFDEF FPC}
+  THorse.Use(HorseBasicAuthentication(MyAuthenticate));
+  {$ELSE}
+  THorse.Use(HorseBasicAuthentication(
+    function(const AUsername, APassword: string): Boolean
+    begin
+      Result := MyAuthenticate(AUsername, APassword);
+    end));
+  {$ENDIF}
+
+  THorse.Use(MyCORS);
+  THorse.Use(MyOctetStream);
+
+  THorse.Get('/ping', GetPing);
+
+  Writeln('Servidor ativo!');
+end.

--- a/samples/lazarus/test_issue498/test_issue498.dpr
+++ b/samples/lazarus/test_issue498/test_issue498.dpr
@@ -1,0 +1,63 @@
+program test_issue498;
+
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  SysUtils,
+  Horse,
+  Horse.Proc,
+  Horse.Jhonson,
+  Horse.Compression,
+  Horse.BasicAuthentication,
+  Horse.CORS,
+  Horse.OctetStream;
+
+function MyAuthenticate(const AUser, APass: string): Boolean;
+begin
+  Result := (AUser = 'user') and (APass = 'pass');
+end;
+
+procedure GetPing(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  Res.Send('pong');
+end;
+
+procedure MyCORS(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  CORS(Req, Res, Next);
+end;
+
+procedure MyOctetStream(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  OctetStream(Req, Res, Next);
+end;
+
+begin
+  // Inicialização com os 5 middlewares oficiais
+  THorse.Use(Jhonson());
+  THorse.Use(Compression());
+
+  {$IFDEF FPC}
+  THorse.Use(HorseBasicAuthentication(MyAuthenticate));
+  {$ELSE}
+  THorse.Use(HorseBasicAuthentication(
+    function(const AUsername, APassword: string): Boolean
+    begin
+      Result := MyAuthenticate(AUsername, APassword);
+    end));
+  {$ENDIF}
+
+  THorse.Use(MyCORS);
+  THorse.Use(MyOctetStream);
+
+  THorse.Get('/ping', GetPing);
+
+  Writeln('Servidor ativo!');
+end.

--- a/src/Horse.Callback.pas
+++ b/src/Horse.Callback.pas
@@ -29,7 +29,18 @@ type
   THorseCallbackRequest = procedure(AReq: THorseRequest);
   THorseCallbackResponse = procedure(ARes: THorseResponse);
   THorseCallbackRequestResponse = procedure(AReq: THorseRequest; ARes: THorseResponse);
-  THorseCallback = Pointer;
+  THorseCallback = record
+  private
+    FValue: Pointer;
+  public
+    class operator Implicit(AValue: Pointer): THorseCallback; inline;
+    class operator Implicit(AValue: THorseCallbackProc): THorseCallback; inline;
+    class operator Implicit(AValue: THorseCallbackRequest): THorseCallback; inline;
+    class operator Implicit(AValue: THorseCallbackResponse): THorseCallback; inline;
+    class operator Implicit(AValue: THorseCallbackRequestResponse): THorseCallback; inline;
+    class operator Implicit(AValue: THorseCallback): Pointer; inline;
+    class operator Implicit(AValue: THorseCallback): THorseCallbackProc; inline;
+  end;
   TCallNextPath = function(const ASegments: TArray<THorseBufferSlice>; AIndex: Integer; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse): Boolean of object;
 {$ELSE}
   THorseCallbackRequest = reference to procedure(AReq: THorseRequest);
@@ -40,5 +51,42 @@ type
 {$ENDIF}
 
 implementation
+
+{$IF DEFINED(FPC)}
+class operator THorseCallback.Implicit(AValue: Pointer): THorseCallback;
+begin
+  Result.FValue := AValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallbackProc): THorseCallback;
+begin
+  Result.FValue := @AValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallbackRequest): THorseCallback;
+begin
+  Result.FValue := @AValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallbackResponse): THorseCallback;
+begin
+  Result.FValue := @AValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallbackRequestResponse): THorseCallback;
+begin
+  Result.FValue := @AValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallback): Pointer;
+begin
+  Result := AValue.FValue;
+end;
+
+class operator THorseCallback.Implicit(AValue: THorseCallback): THorseCallbackProc;
+begin
+  Result := THorseCallbackProc(AValue.FValue);
+end;
+{$ENDIF}
 
 end.

--- a/src/Horse.Core.Wrappers.inc
+++ b/src/Horse.Core.Wrappers.inc
@@ -135,10 +135,10 @@ procedure W1_62(Req: THorseRequest; Res: THorseResponse; Next: TNextProc); begin
 procedure W1_63(Req: THorseRequest; Res: THorseResponse; Next: TNextProc); begin Res.Status(THTTPStatus.NoContent); GCallbacks1[63](Req); end;
 
 const
-  GWrapperList2: array[0..63] of THorseCallback = (
+  GWrapperList2: array[0..63] of Pointer = (
     @W2_0, @W2_1, @W2_2, @W2_3, @W2_4, @W2_5, @W2_6, @W2_7, @W2_8, @W2_9, @W2_10, @W2_11, @W2_12, @W2_13, @W2_14, @W2_15, @W2_16, @W2_17, @W2_18, @W2_19, @W2_20, @W2_21, @W2_22, @W2_23, @W2_24, @W2_25, @W2_26, @W2_27, @W2_28, @W2_29, @W2_30, @W2_31, @W2_32, @W2_33, @W2_34, @W2_35, @W2_36, @W2_37, @W2_38, @W2_39, @W2_40, @W2_41, @W2_42, @W2_43, @W2_44, @W2_45, @W2_46, @W2_47, @W2_48, @W2_49, @W2_50, @W2_51, @W2_52, @W2_53, @W2_54, @W2_55, @W2_56, @W2_57, @W2_58, @W2_59, @W2_60, @W2_61, @W2_62, @W2_63
   );
-  GWrapperList1: array[0..63] of THorseCallback = (
+  GWrapperList1: array[0..63] of Pointer = (
     @W1_0, @W1_1, @W1_2, @W1_3, @W1_4, @W1_5, @W1_6, @W1_7, @W1_8, @W1_9, @W1_10, @W1_11, @W1_12, @W1_13, @W1_14, @W1_15, @W1_16, @W1_17, @W1_18, @W1_19, @W1_20, @W1_21, @W1_22, @W1_23, @W1_24, @W1_25, @W1_26, @W1_27, @W1_28, @W1_29, @W1_30, @W1_31, @W1_32, @W1_33, @W1_34, @W1_35, @W1_36, @W1_37, @W1_38, @W1_39, @W1_40, @W1_41, @W1_42, @W1_43, @W1_44, @W1_45, @W1_46, @W1_47, @W1_48, @W1_49, @W1_50, @W1_51, @W1_52, @W1_53, @W1_54, @W1_55, @W1_56, @W1_57, @W1_58, @W1_59, @W1_60, @W1_61, @W1_62, @W1_63
   );
 {$ENDIF}

--- a/tests/src/tests/Tests.Horse.Core.Middleware.pas
+++ b/tests/src/tests/Tests.Horse.Core.Middleware.pas
@@ -6,7 +6,8 @@ uses
   DUnitX.TestFramework, Horse.Core.RouterTree, Horse.Request, Horse.Response,
   System.SysUtils, System.Generics.Collections,
   Horse.Exception.Interrupted,
-  {$IF DEFINED(FPC)} HTTPApp {$ELSE} Web.HTTPApp {$ENDIF}, Horse.Commons;
+  {$IF DEFINED(FPC)} HTTPApp {$ELSE} Web.HTTPApp {$ENDIF}, Horse.Commons,
+  Horse, Horse.Proc, Horse.Callback;
 
 type
   [TestFixture]
@@ -27,6 +28,8 @@ type
     procedure TestMiddlewareEarlyInterruption;
     [Test]
     procedure TestMiddlewareExceptionPropagation;
+    [Test]
+    procedure TestFPCLegacyCallbackAssignment;
   end;
 
 implementation
@@ -163,6 +166,24 @@ begin
       FRouterTree.Execute(FRequest, FResponse);
     end,
     EOSError);
+end;
+
+procedure MyLegacyCallback(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  //
+end;
+
+function GetLegacyCallback: THorseCallback;
+begin
+  Result := MyLegacyCallback;
+end;
+
+procedure TTestHorseCoreMiddleware.TestFPCLegacyCallbackAssignment;
+var
+  LCallback: THorseCallback;
+begin
+  LCallback := GetLegacyCallback;
+  Assert.IsNotNull(Pointer(LCallback));
 end;
 
 initialization


### PR DESCRIPTION
# Descrição

Este Pull Request resolve a issue #498 ao restaurar a compatibilidade reversa para atribuição de callbacks procedurais a `THorseCallback` no Free Pascal Compiler (FPC) sem exigir o operador de endereço (`@`). Ele garante que a sintaxe herdada usada pelos middlewares oficiais compile perfeitamente no FPC, mantendo a proteção interna de segurança.

## Contexto & Alterações

### 1. Callbacks Transparentes no FPC (`src/Horse.Callback.pas`)
- Redefinido `THorseCallback` como um `record` encapsulando um `Pointer` genérico sob o compilador FPC.
- Adicionados operadores implícitos bidirecionais (`class operator Implicit`) para converter de/para:
  - `Pointer`
  - `THorseCallbackProc`
  - `THorseCallbackRequest`
  - `THorseCallbackResponse`
  - `THorseCallbackRequestResponse`
- Isso garante que expressões como `Result := MyCallback` ou a passagem direta do nome da procedure compilem sem que o compilador acuse incompatibilidade de tipos procedurais.

### 2. Ajustes nos Arrays de Wrappers (`src/Horse.Core.Wrappers.inc`)
- Alterado o tipo dos elementos dos arrays de constantes globais estáticas `GWrapperList1` e `GWrapperList2` para `Pointer`.
- Como o FPC não permite a inicialização estática de arrays de constantes cujos elementos sejam records contendo endereços procedurais (ex: `@W1_0`), a mudança para `Pointer` viabiliza a compilação. Os operadores implícitos do record garantem que a conversão ocorra de forma transparente e segura ao ler esses ponteiros em `Horse.Core.pas`.

### 3. Verificação e Testes
- **Testes Unitários**: Incluído o caso de teste `TestFPCLegacyCallbackAssignment` para validar que a atribuição de callbacks de sintaxe legada compila sem problemas.
- **Testes de Integração**: Adicionado um servidor console completo de teste em `samples/lazarus/test_issue498/` utilizando os 5 middlewares oficiais (`jhonson`, `horse-compression`, `horse-basic-auth`, `horse-cors` e `horse-octet-stream`).
- A compilação foi verificada com sucesso em ambiente **Windows** e **Linux** usando:
  - **Free Pascal Compiler (FPC 3.2.2)**
  - **Delphi (dcc32 / dcclinux64)**
