### PR TITLE
fix: add missing Allow header on 405 responses (issue #500)

### DIFF
--- a/src/Horse.Core.Router.Radix.pas
+++ b/src/Horse.Core.Router.Radix.pas
@@ -502,6 +502,8 @@ var
   LStartSegmentIndex: Integer;
   LKeys: TArray<string>;
   I: Integer;
+  LKey: TMethodType;
+  LAllow: string;
 begin
   try
     Result := False;
@@ -540,7 +542,21 @@ begin
           else
           begin
             if LNode.Callbacks.Count > 0 then
-              {$IF DEFINED(FPC)}LCallbacksList.Add(@RadixMethodNotAllowedFinalizer){$ELSE}LCallbacksList.Add(RadixMethodNotAllowedFinalizer){$ENDIF}
+            begin
+              LAllow := '';
+              for LKey in LNode.Callbacks.Keys do
+              begin
+                if LKey <> TMethodType.mtAny then
+                begin
+                  if LAllow <> '' then
+                    LAllow := LAllow + ', ';
+                  LAllow := LAllow + UpperCase(LKey.ToString);
+                end;
+              end;
+              if LAllow <> '' then
+                AResponse.AddHeader('Allow', LAllow);
+              {$IF DEFINED(FPC)}LCallbacksList.Add(@RadixMethodNotAllowedFinalizer){$ELSE}LCallbacksList.Add(RadixMethodNotAllowedFinalizer){$ENDIF};
+            end
             else
               {$IF DEFINED(FPC)}LCallbacksList.Add(@RadixNotFoundFinalizer){$ELSE}LCallbacksList.Add(RadixNotFoundFinalizer){$ENDIF};
           end;

--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -153,6 +153,8 @@ var
   LCallback: TArray<THorseCallback>;
   LMiddlewareCount, LCallbackCount: Integer;
   {$ENDIF}
+  LKey: TMethodType;
+  LAllow: string;
 begin
   {$IF DEFINED(FPC)}
   LMiddlewareCount := FMiddleware.Count;
@@ -213,6 +215,18 @@ begin
       if FCallBack.Count > 0 then
       begin
         FFound^ := True;
+        LAllow := '';
+        for LKey in FCallBack.Keys do
+        begin
+          if LKey <> TMethodType.mtAny then
+          begin
+            if LAllow <> '' then
+              LAllow := LAllow + ', ';
+            LAllow := LAllow + UpperCase(LKey.ToString);
+          end;
+        end;
+        if LAllow <> '' then
+          FResponse.AddHeader('Allow', LAllow);
         FResponse.Send('Method Not Allowed').Status(THTTPStatus.MethodNotAllowed);
       end
       else

--- a/tests/src/Console.dproj
+++ b/tests/src/Console.dproj
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{A4A352F5-2896-4539-AE34-A7DF0D94AF4D}</ProjectGuid>
         <ProjectVersion>20.1</ProjectVersion>
@@ -68,7 +68,7 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>..\modules\.dcp;..\modules\.dcu;..\modules;..\modules\dataset-serialize\src;..\modules\horse\src;..\modules\jhonson\src;..\modules\restrequest4delphi\src\core;..\modules\restrequest4delphi\src\interfaces;..\modules\restrequest4delphi\src;$(DCC_UnitSearchPath);modules\.dcp;modules\.dcu;modules;modules\horse\src;modules\jhonson\src;modules\restrequest4delphi\src</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\src;..\modules\.dcp;..\modules\.dcu;..\modules;..\modules\dataset-serialize\src;..\modules\jhonson\src;..\modules\restrequest4delphi\src\core;..\modules\restrequest4delphi\src\interfaces;..\modules\restrequest4delphi\src;$(DCC_UnitSearchPath);modules\.dcp;modules\.dcu;modules;modules\jhonson\src;modules\restrequest4delphi\src</DCC_UnitSearchPath>
         <SanitizedProjectName>Console</SanitizedProjectName>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>

--- a/tests/src/VCL.dproj
+++ b/tests/src/VCL.dproj
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{090D8F0A-88C5-4ED1-BF6B-7D62B658AA0C}</ProjectGuid>
         <ProjectVersion>20.1</ProjectVersion>
@@ -68,7 +68,7 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>$(DUnitX);..\modules\.dcp;..\modules\.dcu;..\modules;..\modules\dataset-serialize\src;..\modules\horse\src;..\modules\jhonson\src;..\modules\restrequest4delphi\src\core;..\modules\restrequest4delphi\src\interfaces;..\modules\restrequest4delphi\src;$(DCC_UnitSearchPath);modules\.dcp;modules\.dcu;modules;modules\horse\src;modules\jhonson\src;modules\restrequest4delphi\src</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>$(DUnitX);..\..\src;..\modules\.dcp;..\modules\.dcu;..\modules;..\modules\dataset-serialize\src;..\modules\jhonson\src;..\modules\restrequest4delphi\src\core;..\modules\restrequest4delphi\src\interfaces;..\modules\restrequest4delphi\src;$(DCC_UnitSearchPath);modules\.dcp;modules\.dcu;modules;modules\jhonson\src;modules\restrequest4delphi\src</DCC_UnitSearchPath>
         <SanitizedProjectName>VCL</SanitizedProjectName>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>

--- a/tests/src/tests/Tests.Horse.Core.Middleware.pas
+++ b/tests/src/tests/Tests.Horse.Core.Middleware.pas
@@ -28,8 +28,10 @@ type
     procedure TestMiddlewareEarlyInterruption;
     [Test]
     procedure TestMiddlewareExceptionPropagation;
+    {$IF DEFINED(FPC)}
     [Test]
     procedure TestFPCLegacyCallbackAssignment;
+    {$ENDIF}
   end;
 
 implementation
@@ -168,6 +170,7 @@ begin
     EOSError);
 end;
 
+{$IF DEFINED(FPC)}
 procedure MyLegacyCallback(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 begin
   //
@@ -185,6 +188,7 @@ begin
   LCallback := GetLegacyCallback;
   Assert.IsNotNull(Pointer(LCallback));
 end;
+{$ENDIF}
 
 initialization
   TDUnitX.RegisterTestFixture(TTestHorseCoreMiddleware);

--- a/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
+++ b/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
@@ -44,6 +44,8 @@ type
     procedure ExecuteRouteWithMiddlewares;
     [Test]
     procedure ExecuteRouteWithCoringaoPriority;
+    [Test]
+    procedure ExecuteRouteWithMethodNotAllowedAllowHeader;
   end;
 
 implementation
@@ -332,6 +334,34 @@ begin
   Assert.IsFalse(LClientesCalled);
   Assert.IsFalse(LPessoasCalled);
   Assert.IsTrue(LCoringaoCalled);
+end;
+
+procedure TTestHorseCoreRouterRadix.ExecuteRouteWithMethodNotAllowedAllowHeader;
+var
+  LAllow: string;
+begin
+  FRouter.RegisterRoute(mtGet, '/users',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+    end);
+
+  FRouter.RegisterRoute(mtPost, '/users',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+    end);
+
+  FRequest.Populate('PUT', mtPut, '/users', '', '');
+  Assert.IsTrue(FRouter.Execute(FRequest, FResponse));
+  Assert.AreEqual(405, FResponse.Status);
+
+  {$IF DEFINED(FPC)}
+  LAllow := FResponse.CustomHeaders.Values['Allow'];
+  {$ELSE}
+  LAllow := FResponse.CustomHeaders.Items['Allow'];
+  {$ENDIF}
+
+  Assert.IsTrue(LAllow.Contains('GET'));
+  Assert.IsTrue(LAllow.Contains('POST'));
 end;
 
 initialization

--- a/tests/src/tests/Tests.Horse.Core.RouterTree.pas
+++ b/tests/src/tests/Tests.Horse.Core.RouterTree.pas
@@ -62,6 +62,8 @@ type
     procedure ExecuteRouteWithTwoConsecutiveCoringao;
     [Test]
     procedure ExecuteRouteWithCoringaoPriority;
+    [Test]
+    procedure ExecuteRouteWithMethodNotAllowedAllowHeader;
   end;
 
 implementation
@@ -473,6 +475,34 @@ begin
   Assert.IsFalse(LClientesCalled);
   Assert.IsFalse(LPessoasCalled);
   Assert.IsTrue(LCoringaoCalled);
+end;
+
+procedure TTestHorseCoreRouterTree.ExecuteRouteWithMethodNotAllowedAllowHeader;
+var
+  LAllow: string;
+begin
+  FRouterTree.RegisterRoute(mtGet, '/users',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+    end);
+
+  FRouterTree.RegisterRoute(mtPost, '/users',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+    end);
+
+  FRequest.Populate('PUT', mtPut, '/users', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.AreEqual(405, FResponse.Status);
+
+  {$IF DEFINED(FPC)}
+  LAllow := FResponse.CustomHeaders.Values['Allow'];
+  {$ELSE}
+  LAllow := FResponse.CustomHeaders.Items['Allow'];
+  {$ENDIF}
+
+  Assert.IsTrue(LAllow.Contains('GET'));
+  Assert.IsTrue(LAllow.Contains('POST'));
 end;
 
 initialization

--- a/tests/src/tests/Tests.Integration.HttpMethods.pas
+++ b/tests/src/tests/Tests.Integration.HttpMethods.pas
@@ -22,6 +22,8 @@ type
     procedure TestOptionsMethodInterceptedByMiddleware;
     [Test]
     procedure TestTraceMethodInterceptedByMiddleware;
+    [Test]
+    procedure TestMethodNotAllowedAllowHeader;
   end;
 
 implementation
@@ -55,6 +57,13 @@ begin
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
     begin
       Res.Send('get-ok');
+    end);
+
+  // Rota POST normal usando TNextProc
+  THorse.Post('/resource',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+    begin
+      Res.Send('post-ok');
     end);
 
   TThread.CreateAnonymousThread(
@@ -97,6 +106,24 @@ begin
     LRes := LClient.Execute('TRACE', Format('http://localhost:%d/resource', [TEST_PORT])) as IHTTPResponse;
     Assert.AreEqual(200, LRes.StatusCode);
     Assert.AreEqual('trace-interceptor-ok', LRes.ContentAsString);
+  finally
+    LClient.Free;
+  end;
+end;
+
+procedure TTestIntegrationHttpMethods.TestMethodNotAllowedAllowHeader;
+var
+  LClient: THTTPClient;
+  LRes: IHTTPResponse;
+  LAllow: string;
+begin
+  LClient := THTTPClient.Create;
+  try
+    LRes := LClient.Execute('PUT', Format('http://localhost:%d/resource', [TEST_PORT])) as IHTTPResponse;
+    Assert.AreEqual(405, LRes.StatusCode);
+    LAllow := LRes.HeaderValue['Allow'];
+    Assert.IsTrue(LAllow.Contains('GET'));
+    Assert.IsTrue(LAllow.Contains('POST'));
   finally
     LClient.Free;
   end;


### PR DESCRIPTION
# Acerto issue #500 

Esta Pull Request corrige a desconformidade com a especificação HTTP do protocolo RFC 9110 §15.5.6 reportada na issue #500. Quando uma rota era atingida usando um método HTTP não suportado, o Horse retornava o status `405 Method Not Allowed`, mas omitia o cabeçalho obrigatório `Allow` contendo a lista de métodos HTTP permitidos pelo recurso.

## Mudanças Realizadas

### Core
* **Roteador Padrão (`Horse.Core.RouterTree.NextCaller.pas`):**
  * Inclusão de variáveis locais compatíveis com versões antigas do Delphi (sem uso de `var` inline).
  * Iteração nas chaves do dicionário `FCallBack.Keys` ao gerar a resposta 405 para compor a lista de métodos suportados em maiúsculas (ex: `GET, POST`), ignorando a diretiva interna de curinga `mtAny`.
  * Adição do cabeçalho correspondente na resposta via `FResponse.AddHeader('Allow', LAllow)`.
* **Roteador Radix (`Horse.Core.Router.Radix.pas`):**
  * Implementação da mesma lógica de iteração sobre `LNode.Callbacks.Keys` e injeção do cabeçalho `Allow` no response antes da execução da pipeline finalizadora do status 405.

### Testes
* **Testes de Unidade:**
  * Adicionados testes de validação unitária em `Tests.Horse.Core.RouterTree.pas` e `Tests.Horse.Core.Router.Radix.pas` que simulam requisições de verbos não cadastrados e validam o retorno do cabeçalho `Allow`.
* **Testes de Integração:**
  * Criado um teste de integração de ponta a ponta (`TestMethodNotAllowedAllowHeader`) na unit `Tests.Integration.HttpMethods.pas` usando o cliente HTTP nativo (`THTTPClient`), levantando o servidor real do Horse e validando as respostas.
* **Correções Adicionais:**
  * Ajustada a compilação condicional em `Tests.Horse.Core.Middleware.pas` para isolar o teste específico do compilador FPC (`TestFPCLegacyCallbackAssignment`), evitando quebra de build no Delphi.

## Como Testar

Todos os testes unitários e de integração foram validados e passaram com 100% de sucesso localmente.
Para testar, basta executar a suite de testes consolidada via linha de comando ou IDE:
```bash
Console.exe
