### PR TITLE
feat: add MatchedRoute and State support for telemetry

### DIFF
--- a/src/Horse.Core.Router.Radix.pas
+++ b/src/Horse.Core.Router.Radix.pas
@@ -40,6 +40,7 @@ type
     Part: string;
     IsParam: Boolean;
     ParamName: string;
+    FullPath: string;
     Children: TObjectList<TRadixNode>;
     Callbacks: TDictionary<TMethodType, TArray<THorseCallback>>;
     Middlewares: TList<THorseCallback>;
@@ -400,6 +401,7 @@ begin
   end;
 
   LCurrent.AddRouteCallback(AHTTPType, ACallback, AIsMiddleware);
+  LCurrent.FullPath := '/' + APath.Trim(['/']);
 end;
 
 procedure THorseRadixRouter.RegisterRoute(const AHTTPType: TMethodType; const APath: string; const ACallback: THorseCallback);
@@ -530,6 +532,7 @@ begin
       
       if LNode <> nil then
       begin
+        ARequest.MatchedRoute := LNode.FullPath;
         if LParams <> nil then
         begin
           LKeys := LParams.Keys.ToArray;

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -35,6 +35,7 @@ type
   private
     FPart: string;
     FTag: string;
+    FFullPath: string;
     FIsParamsKey: Boolean;
     FRouterRegex: string;
     FIsRouterRegex: Boolean;
@@ -294,6 +295,8 @@ var
   LNextCaller: TNextCaller;
   LFound: Boolean;
 begin
+  if FFullPath <> '' then
+    ARequest.MatchedRoute := FFullPath;
   LFound := False;
   LNextCaller := TNextCaller.Create;
   try
@@ -544,6 +547,7 @@ begin
 
     if not AIsMiddleware then
       FHandlerMethods.Add(AHTTPType);
+    FFullPath := '/' + AFullPath.Trim(['/']);
   end;
 
   if APath.Count > 0 then

--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -11,9 +11,11 @@ uses
   SysUtils,
   fpHTTP,
   HTTPDefs,
+  Generics.Collections,
 {$ELSE}
   System.SysUtils,
   Web.HTTPApp,
+  System.Generics.Collections,
 {$IF CompilerVersion > 32.0}
   Web.ReqMulti,
 {$ENDIF}
@@ -73,6 +75,9 @@ type
   See: Horse.Provider.CrossSocket.WebRequestAdapter.pas
   =========================================================================== }
     FCSRawWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF};
+{ =========================================================================== }
+    FMatchedRoute: string;
+    FState: TObjectDictionary<string, TObject>;
 { =========================================================================== }
     function GetArena: THorseArenaAllocator;
     procedure InitializeQuery;
@@ -205,6 +210,8 @@ type
 { PATCH-REQ-9  called by TRequestBridge.MapBody to cache the decoded body. }
     procedure SetBodyString(const AValue: string);
 { =========================================================================== }
+    property MatchedRoute: string read FMatchedRoute write FMatchedRoute;
+    property State: TObjectDictionary<string, TObject> read FState;
     destructor Destroy; override;
   end;
 
@@ -281,6 +288,7 @@ end;
 constructor THorseRequest.Create(const AWebRequest: {$IF DEFINED(FPC)}TRequest{$ELSE}TWebRequest{$ENDIF});
 begin
   FWebRequest := AWebRequest;
+  FState := TObjectDictionary<string, TObject>.Create([doOwnsValues]);
 end;
 
 { ===========================================================================
@@ -289,6 +297,7 @@ end;
 constructor THorseRequest.Create;
 begin
   FWebRequest := nil;
+  FState := TObjectDictionary<string, TObject>.Create([doOwnsValues]);
 end;
 { =========================================================================== }
 
@@ -367,6 +376,9 @@ begin
   if Assigned(FSessions) then
     FSessions.Clear;
 { end PATCH-SES-1 }
+  FMatchedRoute := '';
+  if Assigned(FState) then
+    FState.Clear;
 end;
 { =========================================================================== }
 
@@ -396,6 +408,8 @@ begin
 { end PATCH-REQ-8 }
   if FOwnsArena and Assigned(FArena) then
     FreeAndNil(FArena);
+  if Assigned(FState) then
+    FreeAndNil(FState);
   inherited;
 end;
 

--- a/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
+++ b/tests/src/tests/Tests.Horse.Core.Router.Radix.pas
@@ -76,6 +76,7 @@ begin
     begin
       LCalled := True;
       Assert.AreEqual('123', Req.Params.Items['id']);
+      Assert.AreEqual('/users/:id', Req.MatchedRoute);
     end);
 
   FRequest.Populate('GET', mtGet, '/users/123', '', '');

--- a/tests/src/tests/Tests.Horse.Core.RouterTree.pas
+++ b/tests/src/tests/Tests.Horse.Core.RouterTree.pas
@@ -94,6 +94,7 @@ begin
     begin
       LCalled := True;
       Assert.AreEqual('123', Req.Params.Items['id']);
+      Assert.AreEqual('/users/:id', Req.MatchedRoute);
     end);
 
   FRequest.Populate('GET', mtGet, '/users/123', '', '');

--- a/tests/src/tests/Tests.Horse.Request.Recycle.pas
+++ b/tests/src/tests/Tests.Horse.Request.Recycle.pas
@@ -24,6 +24,8 @@ type
     procedure TestRequestArenaRecyclingAndObjectLifetime;
     [Test]
     procedure TestResponseSendBytesOverload;
+    [Test]
+    procedure TestRequestStateAndMatchedRouteCycle;
   end;
 
 implementation
@@ -146,6 +148,29 @@ begin
   finally
     LResponse.Free;
   end;
+end;
+
+procedure TTestHorseRequestRecycle.TestRequestStateAndMatchedRouteCycle;
+var
+  LDestroyed: Boolean;
+  LTestObj: TTestArenaObject;
+begin
+  LDestroyed := False;
+  FRequest.MatchedRoute := '/my/route/:id';
+  LTestObj := TTestArenaObject.Create(@LDestroyed);
+
+  FRequest.State.Add('context', LTestObj);
+
+  Assert.AreEqual('/my/route/:id', FRequest.MatchedRoute);
+  Assert.IsNotNull(FRequest.State.Items['context']);
+  Assert.IsFalse(LDestroyed);
+
+  // Limpa o request (reciclagem no pool)
+  FRequest.Clear;
+
+  Assert.AreEqual('', FRequest.MatchedRoute, 'MatchedRoute should be empty after Clear');
+  Assert.AreEqual<Integer>(0, FRequest.State.Count, 'State dictionary should be empty after Clear');
+  Assert.IsTrue(LDestroyed, 'State values should be automatically freed after Clear due to doOwnsValues');
 end;
 
 initialization


### PR DESCRIPTION
# Suporte a telemetria

## Descrição
Este Pull Request introduz o suporte básico de infraestrutura no Core do Horse para viabilizar a criação de middlewares de telemetria e observabilidade distribuída externos (como `horse-opentelemetry` ou `horse-prometheus`). 

Seguindo os princípios **KISS** e de **baixo acoplamento**, o Core do Horse foi modificado estritamente com o mínimo necessário para suportar o rastreamento de rotas e a propagação de contextos de requisição de forma thread-safe, mantendo a compatibilidade do compilador do Delphi XE7 em diante e do Lazarus (FPC).

---

## 🛠️ Alterações no Core

### 1. `THorseRequest` (`src/Horse.Request.pas`)
* Adição da propriedade pública **`MatchedRoute: string`**: armazena o template da rota original cadastrado no roteador (ex: `/usuarios/:id`). Isso é essencial para que coletores de métricas agrupem requisições sem causar explosão de cardinalidade nos bancos de dados de séries temporais (como o Prometheus).
* Adição da propriedade pública **`State: TObjectDictionary<string, TObject>`**: um dicionário de estado genérico específico por requisição. Ele permite que middlewares injetem e compartilhem objetos (como contextos de Span/Trace) durante o ciclo de vida da chamada, de forma isolada por thread.
* Integração de ambas as propriedades nos construtores, destructor e no método **`Clear`** (reciclagem no pool de requisições). A flag `[doOwnsValues]` garante a liberação automática de objetos no dicionário de estados, prevenindo qualquer vazamento de memória.

### 2. Roteadores (`src/Horse.Core.Router.Radix.pas` e `src/Horse.Core.RouterTree.pas`)
* Modificação em ambos os roteadores (Radix e Clássico) para capturar o template original da rota no registro e preencher a propriedade `MatchedRoute` do `THorseRequest` assim que o casamento da rota é executado com sucesso.

---

## 🧪 Testes de Unidade Adicionados

Para garantir a estabilidade das alterações e evitar regressões:
* **`Tests.Horse.Request.Recycle.pas`**: Adicionado o teste `TestRequestStateAndMatchedRouteCycle` que valida a correta atribuição de `MatchedRoute`, o armazenamento de objetos em `State` e a destruição/limpeza automática dos mesmos ao reciclar a requisição no pool.
* **`Tests.Horse.Core.Router.Radix.pas`** e **`Tests.Horse.Core.RouterTree.pas`**: Atualizado o teste de rotas parametrizadas para validar que o `Req.MatchedRoute` retorna o template original `/users/:id`.

---

## 🚀 Validação e Performance

* **Compilação e Testes (Delphi):** A suíte de testes passou com **100% de sucesso** em múltiplos compiladores (Delphi 10 Seattle, 11 Alexandria, 12 Athens e 13 Florence) e sob vários provedores de transporte HTTP (`Default`, `Default+Radix`, `HttpSys`, `IOCP`).
* **Compilação (Lazarus/FPC):** Compilação validada com sucesso via compilador local FPC 3.2.2.
* **Impacto em Performance:** A atribuição de `MatchedRoute` opera apenas sobre referências de strings (custo quase nulo), e o dicionário `State` vazia consome apenas ciclos insignificantes de CPU durante a reciclagem, não impactando a performance de requisições que não utilizam telemetria.
