### PR TITLE
docs: add telemetry section and documents for horse-opentelemetry and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 | **Choosing a transport provider** — Indy (default), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.md) |
 | **Deploy** as Console / VCL / Daemon / Windows Service / LCL / HTTPApplication — one-page recipe | [**Deployment Cheatsheet**](./doc/deployment.md) |
 | Full middleware catalogue with extended descriptions | [Middleware Ecosystem](./doc/middleware-ecosystem.md) |
+| Observability, distributed tracing (OpenTelemetry) and metrics collection (Prometheus) | [Observability & Telemetry](./doc/telemetry.md) |
 | Automated integration, resilience (Access Violation) and SO limit testing | [Integrity Testing](./doc/integrity-testing.md) |
 | Supported Delphi / FPC versions and platforms | [Compiler Support](./doc/compiler-support.md) |
 
@@ -190,9 +191,18 @@ This is a list of middlewares that are created by the Horse community, please cr
 |  [isaquepinheiro/horse-jsonbr](https://github.com/HashLoad/JSONBr)                                         | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [IagooCesaar/Horse-JsonInterceptor](https://github.com/IagooCesaar/Horse-JsonInterceptor)                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [dliocode/horse-datalogger](https://github.com/dliocode/horse-datalogger)                                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
-|  [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [weslleycapelari/horse-documentation](https://github.com/weslleycapelari/horse-documentation)             | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [weslleycapelari/horse-validator](https://github.com/weslleycapelari/horse-validator)                     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
+
+## 📊 Telemetry
+
+These are middlewares focused on application observability, metrics, and tracing:
+
+| Middleware | Delphi | Lazarus |
+| ---------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------- |
+|  [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
+|  [regyssilveira/horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry)                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+|  [regyssilveira/horse-prometheus](https://github.com/regyssilveira/horse-prometheus)                       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 ## Delphi Versions
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -75,6 +75,7 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 | **Escolher um provider de transporte** — Indy (padrão), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.pt-BR.md) |
 | **Deploy** como Console / VCL / Daemon / Serviço Windows / LCL / HTTPApplication — receita de uma página | [**Cheatsheet de Deploy**](./doc/deployment.pt-BR.md) |
 | Catálogo completo de middlewares com descrições estendidas | [Ecossistema de Middlewares](./doc/middleware-ecosystem.pt-BR.md) |
+| Observabilidade, rastreamento (OpenTelemetry) e coleta de métricas (Prometheus) | [Observabilidade e Telemetria](./doc/telemetry.pt-BR.md) |
 | Testes de integração automatizados, resiliência (Access Violation) e limites de Stack | [Testes de Integridade](./doc/integrity-testing.pt-BR.md) |
 | Versões suportadas de Delphi / FPC e plataformas | [Suporte de Compilador](./doc/compiler-support.pt-BR.md) |
 
@@ -190,9 +191,18 @@ Esta é uma lista de middlewares criados pela comunidade Horse — abra um PR se
 |  [isaquepinheiro/horse-jsonbr](https://github.com/HashLoad/JSONBr)                                         | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [IagooCesaar/Horse-JsonInterceptor](https://github.com/IagooCesaar/Horse-JsonInterceptor)                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [dliocode/horse-datalogger](https://github.com/dliocode/horse-datalogger)                                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
-|  [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [weslleycapelari/horse-documentation](https://github.com/weslleycapelari/horse-documentation)             | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
 |  [weslleycapelari/horse-validator](https://github.com/weslleycapelari/horse-validator)                     | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
+
+## 📊 Telemetria
+
+Estes são middlewares focados em observabilidade, métricas e rastreamento de aplicações:
+
+| Middleware | Delphi | Lazarus |
+| ---------------------------------------------------------------------------------------------------------- | -------------------- | --------------------------- |
+|  [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;❌ |
+|  [regyssilveira/horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry)                 | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
+|  [regyssilveira/horse-prometheus](https://github.com/regyssilveira/horse-prometheus)                       | &nbsp;&nbsp;&nbsp;✔️ | &nbsp;&nbsp;&nbsp;&nbsp;✔️ |
 
 ## Versões do Delphi
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -27,6 +27,7 @@ If you're new, start with [Getting Started](./getting-started.md). If you have a
 | [Writing a Middleware](./writing-middleware.md) | Authoring a production-quality middleware: skeleton, configuration patterns, thread safety, Provider-neutral coding, cross-compiler pitfalls, testing matrix, Boss packaging, publishing. |
 | [Providers & Application types](./providers.md) | The two-axis model: **Provider** (transport — Indy default; CrossSocket, mORMot2, ICS optional; HttpSys, epoll and IOCP built-in) × **Application type** (Console / VCL / Daemon / LCL / HTTPApplication, plus host-managed Apache / ISAPI / CGI / FCGI). Compatibility matrix and selection guidance. |
 | [Middleware Ecosystem](./middleware-ecosystem.md) | Official `HashLoad/*` packages and the community-maintained list. |
+| [Observability & Telemetry](./telemetry.md) | Setting up distributed tracing (OpenTelemetry) and metrics collection (Prometheus). |
 | [Compiler Support](./compiler-support.md) | Tested Delphi releases, FPC versions, target platforms, compiler-version guards. |
 | [Deployment Cheatsheet](./deployment.md) | One-page reference for shipping a CrossSocket or mORMot2 binary as any of the seven Application shapes (Console / VCL / Daemon / Windows Service / FPC daemon / LCL / FPC HTTPApplication). |
 | [Integrity Testing](./integrity-testing.md) | Automated integration, resilience (Access Violation) and SO limit testing. |
@@ -44,6 +45,7 @@ doc/
 ├── providers.md               ← choosing a transport
 ├── iocp.md                    ← Windows async I/O completion ports
 ├── epoll.md                   ← Linux async event loop
+├── telemetry.md               ← OpenTelemetry & Prometheus integration
 ├── middleware-ecosystem.md    ← package catalogue
 ├── integrity-testing.md       ← integrity and resilience testing
 └── compiler-support.md        ← versions / platforms

--- a/doc/index.pt-BR.md
+++ b/doc/index.pt-BR.md
@@ -27,6 +27,7 @@ Se você é novo por aqui, comece por [Primeiros passos](./getting-started.pt-BR
 | [Criando um Middleware](./writing-middleware.pt-BR.md) | Criando um middleware de qualidade de produção: esqueleto, padrões de configuração, thread safety, código neutro a Provider, armadilhas entre compiladores, matriz de testes, empacotamento Boss, publicação. |
 | [Providers e Tipos de aplicação](./providers.pt-BR.md) | O modelo de dois eixos: **Provider** (transporte — Indy padrão; CrossSocket, mORMot2, ICS opcionais; HttpSys, epoll e IOCP embutidos) × **Tipo de aplicação** (Console / VCL / Daemon / LCL / HTTPApplication, mais host-managed Apache / ISAPI / CGI / FCGI). Matriz de compatibilidade e guia de escolha. |
 | [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md) | Pacotes oficiais `HashLoad/*` e a lista mantida pela comunidade. |
+| [Observabilidade e Telemetria](./telemetry.pt-BR.md) | Configuração de rastreamento distribuído (OpenTelemetry) e coleta de métricas (Prometheus). |
 | [Suporte de Compilador](./compiler-support.pt-BR.md) | Versões testadas do Delphi, versões do FPC, plataformas-alvo, guards de versão de compilador. |
 | [Cheatsheet de Deploy](./deployment.pt-BR.md) | Referência de uma página pra entregar um binário CrossSocket ou mORMot2 como qualquer um dos sete formatos de Aplicação (Console / VCL / Daemon / Serviço Windows / daemon FPC / LCL / HTTPApplication FPC). |
 | [Testes de Integridade](./integrity-testing.pt-BR.md) | Testes de integração automatizados, resiliência (Access Violation) e limites de Stack. |
@@ -44,6 +45,7 @@ doc/
 ├── providers.*.md             ← escolha de transporte
 ├── iocp.*.md                  ← portas de conclusão assíncronas (Windows)
 ├── epoll.*.md                 ← laço de eventos assíncronos (Linux)
+├── telemetry.*.md             ← integração com OpenTelemetry e Prometheus
 ├── middleware-ecosystem.*.md  ← catálogo de pacotes
 ├── integrity-testing.*.md     ← testes de integridade e resiliência
 └── compiler-support.*.md      ← versões / plataformas

--- a/doc/middleware-ecosystem.md
+++ b/doc/middleware-ecosystem.md
@@ -85,9 +85,22 @@ These are not maintained by HashLoad but are listed here because they're commonl
 | [isaquepinheiro/horse-jsonbr](https://github.com/HashLoad/JSONBr) | JSON helpers | ✔️ | ❌ |
 | [IagooCesaar/Horse-JsonInterceptor](https://github.com/IagooCesaar/Horse-JsonInterceptor) | JSON request/response interceptor | ✔️ | ❌ |
 | [dliocode/horse-datalogger](https://github.com/dliocode/horse-datalogger) | Structured data logger | ✔️ | ❌ |
-| [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | Prometheus metrics endpoint | ✔️ | ❌ |
 | [weslleycapelari/horse-documentation](https://github.com/weslleycapelari/horse-documentation) | Auto-generated API docs | ✔️ | ❌ |
 | [weslleycapelari/horse-validator](https://github.com/weslleycapelari/horse-validator) | Request payload validation | ✔️ | ❌ |
+
+---
+
+## Telemetry
+
+These are middlewares focused on application observability, metrics, and tracing:
+
+| Middleware | Description | Delphi | Lazarus |
+|---|---|:---:|:---:|
+| [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | Prometheus metrics endpoint | ✔️ | ❌ |
+| [regyssilveira/horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry) | OpenTelemetry integration for distributed tracing | ✔️ | ✔️ |
+| [regyssilveira/horse-prometheus](https://github.com/regyssilveira/horse-prometheus) | Prometheus integration for metrics collection | ✔️ | ✔️ |
+
+---
 
 ## Third-party transport Providers
 

--- a/doc/middleware-ecosystem.pt-BR.md
+++ b/doc/middleware-ecosystem.pt-BR.md
@@ -85,9 +85,22 @@ Estes não são mantidos pela HashLoad mas estão listados aqui por serem usados
 | [isaquepinheiro/horse-jsonbr](https://github.com/HashLoad/JSONBr) | Helpers JSON | ✔️ | ❌ |
 | [IagooCesaar/Horse-JsonInterceptor](https://github.com/IagooCesaar/Horse-JsonInterceptor) | Interceptor de JSON em requisição/resposta | ✔️ | ❌ |
 | [dliocode/horse-datalogger](https://github.com/dliocode/horse-datalogger) | Logger de dados estruturado | ✔️ | ❌ |
-| [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | Endpoint de métricas Prometheus | ✔️ | ❌ |
 | [weslleycapelari/horse-documentation](https://github.com/weslleycapelari/horse-documentation) | Geração automática de docs de API | ✔️ | ❌ |
 | [weslleycapelari/horse-validator](https://github.com/weslleycapelari/horse-validator) | Validação de payload de requisição | ✔️ | ❌ |
+
+---
+
+## Telemetria
+
+Estes são middlewares focados em observabilidade, métricas e rastreamento de aplicações:
+
+| Middleware | Descrição | Delphi | Lazarus |
+|---|---|:---:|:---:|
+| [marcobreveglieri/horse-prometheus-metrics](https://github.com/marcobreveglieri/horse-prometheus-metrics) | Endpoint de métricas Prometheus | ✔️ | ❌ |
+| [regyssilveira/horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry) | Integração com OpenTelemetry para rastreamento distribuído | ✔️ | ✔️ |
+| [regyssilveira/horse-prometheus](https://github.com/regyssilveira/horse-prometheus) | Integração com Prometheus para coleta de métricas | ✔️ | ✔️ |
+
+---
 
 ## Providers de transporte de terceiros
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -1,0 +1,91 @@
+# Observability & Telemetry
+
+*Read this in [English](./telemetry.md) or [Português (BR)](./telemetry.pt-BR.md).*
+
+Observability is a critical aspect of running modern APIs in production. Horse supports application monitoring, tracing, and metrics collection through its middleware pipeline. 
+
+By using middleware, you can collect request duration, trace IDs, response codes, and system metrics without cluttering your business logic.
+
+---
+
+## Observability Pillars in Horse
+
+Through third-party integrations, you can set up complete observability for your Delphi and Lazarus applications:
+
+### 1. Distributed Tracing (OpenTelemetry)
+
+Distributed tracing allows you to follow requests as they flow through your architecture. Using the OpenTelemetry standard, you can visualize call graphs, measure database query times, and trace microservice calls.
+
+* **Middleware:** [horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry)
+* **What it does:** Automatically starts and propagates spans, records requests, injects W3C trace context, and exports trace data to OpenTelemetry collectors (Jaeger, Zipkin, Dynatrace, Datadog, etc.).
+
+### 2. Metrics Collection (Prometheus)
+
+Metrics tell you *how much* and *how fast* your application is running. You can track Request Rates, Error Rates, and Duration percentiles (RED method).
+
+* **Middleware:** [horse-prometheus](https://github.com/regyssilveira/horse-prometheus)
+* **What it does:** Tracks metrics internally (counters, histograms, gauges) and exposes an endpoint (typically `/metrics`) in the format expected by the Prometheus scraper.
+
+---
+
+## Quickstart: Setting up Telemetry
+
+To add metrics and tracing to your Horse application, install the packages via Boss:
+
+```sh
+boss install regyssilveira/horse-opentelemetry
+boss install regyssilveira/horse-prometheus
+```
+
+Then, register them in your main file. It is recommended to register observability middlewares early in the middleware pipeline to capture overall response latency and catch any exceptions:
+
+```delphi
+uses
+  Horse,
+  Horse.OpenTelemetry,
+  Horse.Prometheus;
+
+begin
+  // Register OpenTelemetry first to trace the entire request lifecycle
+  THorse.Use(THorseOpenTelemetry.New('my-horse-api'));
+
+  // Register Prometheus to gather request metrics
+  THorse.Use(THorsePrometheus.New);
+
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  THorse.Listen(9000);
+end.
+```
+
+## Running Admin/Metrics on a Separate Port
+
+In production, it is often a security best practice to expose metrics endpoints (like `/metrics`) only internally. You can run a separate Horse server on a different port solely for administration and metrics collection:
+
+```delphi
+uses
+  Horse,
+  Horse.Prometheus;
+
+begin
+  // Main API Server
+  THorse.Use(THorsePrometheus.New);
+  
+  THorse.Get('/api/v1/users', ...);
+  // Listen on public port
+  THorse.Listen(9000);
+
+  // Metrics scraper endpoint on a private port
+  // Note: Running multiple Horse instances is supported.
+end.
+```
+
+---
+
+## See Also
+- [Middleware Ecosystem](./middleware-ecosystem.md)
+- [Writing a Middleware](./writing-middleware.md)

--- a/doc/telemetry.pt-BR.md
+++ b/doc/telemetry.pt-BR.md
@@ -1,0 +1,91 @@
+# Observabilidade e Telemetria
+
+*Leia em [English](./telemetry.md) ou [Português (BR)](./telemetry.pt-BR.md).*
+
+A observabilidade é um aspecto crítico para executar APIs modernas em produção. O Horse suporta o monitoramento de aplicações, rastreamento (tracing) e coleta de métricas através de seu pipeline de middlewares.
+
+Ao usar middlewares, você pode coletar a duração das requisições, trace IDs, códigos de resposta e métricas do sistema sem misturar essa lógica com a sua regra de negócio.
+
+---
+
+## Pilares da Observabilidade no Horse
+
+Por meio de integrações de terceiros, você pode configurar uma observabilidade completa para suas aplicações Delphi e Lazarus:
+
+### 1. Rastreamento Distribuído (OpenTelemetry)
+
+O rastreamento distribuído permite acompanhar as requisições à medida que elas fluem pela sua arquitetura. Usando o padrão OpenTelemetry, você pode visualizar gráficos de chamadas, medir tempos de consulta ao banco de dados e rastrear chamadas de microsserviços.
+
+* **Middleware:** [horse-opentelemetry](https://github.com/regyssilveira/horse-opentelemetry)
+* **O que faz:** Inicia e propaga spans automaticamente, registra requisições, injeta o contexto de trace W3C e exporta dados de rastreamento para coletores OpenTelemetry (Jaeger, Zipkin, Dynatrace, Datadog, etc.).
+
+### 2. Coleta de Métricas (Prometheus)
+
+As métricas informam o *quanto* e o *quão rápido* sua aplicação está rodando. Você pode monitorar taxas de requisição (Request Rates), taxas de erro (Error Rates) e percentis de duração (método RED).
+
+* **Middleware:** [horse-prometheus](https://github.com/regyssilveira/horse-prometheus)
+* **O que faz:** Monitora métricas internamente (contadores, histogramas, gauges) e expõe um endpoint (geralmente `/metrics`) no formato esperado pelo coletor do Prometheus.
+
+---
+
+## Início Rápido: Configurando Telemetria
+
+Para adicionar métricas e rastreamento à sua aplicação Horse, instale os pacotes via Boss:
+
+```sh
+boss install regyssilveira/horse-opentelemetry
+boss install regyssilveira/horse-prometheus
+```
+
+Em seguida, registre-os em seu arquivo principal. Recomenda-se registrar os middlewares de observabilidade logo no início do pipeline de middlewares para capturar a latência total da resposta e registrar quaisquer exceções:
+
+```delphi
+uses
+  Horse,
+  Horse.OpenTelemetry,
+  Horse.Prometheus;
+
+begin
+  // Registre o OpenTelemetry primeiro para rastrear todo o ciclo de vida da requisição
+  THorse.Use(THorseOpenTelemetry.New('my-horse-api'));
+
+  // Registre o Prometheus para coletar métricas das requisições
+  THorse.Use(THorsePrometheus.New);
+
+  THorse.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  THorse.Listen(9000);
+end.
+```
+
+## Executando Métricas em uma Porta Separada
+
+Em produção, geralmente é uma prática recomendada de segurança expor endpoints de métricas (como `/metrics`) apenas internamente. Você pode rodar um servidor Horse separado em uma porta diferente exclusivamente para fins de administração e métricas:
+
+```delphi
+uses
+  Horse,
+  Horse.Prometheus;
+
+begin
+  // Servidor da API Principal
+  THorse.Use(THorsePrometheus.New);
+  
+  THorse.Get('/api/v1/users', ...);
+  // Escuta na porta pública
+  THorse.Listen(9000);
+
+  // Endpoint de métricas em uma porta privada
+  // Nota: A execução de múltiplas instâncias do Horse é suportada.
+end.
+```
+
+---
+
+## Veja Também
+- [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md)
+- [Criando um Middleware](./writing-middleware.pt-BR.md)


### PR DESCRIPTION
# Descrição
Este Pull Request adiciona uma seção dedicada a **Telemetria e Observabilidade** na documentação do Horse, destacando o suporte a rastreamento distribuído (tracing) e coleta de métricas (metrics) via middlewares. 

Além disso, introduz os novos middlewares da comunidade:
- `horse-opentelemetry` (OpenTelemetry para rastreamento distribuído)
- `horse-prometheus` (Exposição de métricas no padrão Prometheus)

## Alterações realizadas
- **Novos guias:**
  - Criado `doc/telemetry.md` com explicações teóricas e práticas de como inicializar o OpenTelemetry e Prometheus no Horse.
  - Criado `doc/telemetry.pt-BR.md` com a respectiva tradução dos guias para Português (BR).
- **README e Índice:**
  - Atualizados `README.md` e `README.pt-BR.md` criando uma seção visual separada (`## 📊 Telemetry / Telemetria`) para os middlewares de observabilidade.
  - Atualizados os índices `doc/index.md` e `doc/index.pt-BR.md` incluindo as referências e links aos novos documentos.
  - Atualizado o catálogo geral em `doc/middleware-ecosystem.md` e `doc/middleware-ecosystem.pt-BR.md` movendo os middlewares de telemetria da tabela comum para uma seção própria.
