### PR TITLE
Feature/server lifecycle

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,10 +6,15 @@ Este documento estabelece as regras de design e desenvolvimento do framework Hor
 * O Horse possui suporte nativo e thread-safe a ganchos de ciclo de vida (`onRequest`, `preParsing`, `preValidation`, `onSend` e `onResponse`) em cascata cooperativa (CPS).
 * Ao criar novos middlewares ou funcionalidades de tratamento, utilize a infraestrutura de ganchos em vez de interceptores ad-hoc nas rotas para manter a conformidade arquitetural.
 
-## 🟢 Desligamento Suave (Graceful Shutdown)
-* O Horse gerencia o escoamento lógico de requisições ativas através das propriedades de telemetria `ActiveRequests` e `IsShuttingDown` no core (`THorseCore`).
-* Para encerramentos coordenados e seguros (probes de saúde no Kubernetes/Load Balancers), use sempre `THorse.StopListenGraceful(TimeoutMS)`.
+## 🟢 Ciclo de Vida do Servidor e Desligamento Suave (Server Lifecycle & Graceful Shutdown)
+* O Horse gerencia o escoamento lógico de requisições ativas através das propriedades de telemetria `ActiveRequests` e `IsShuttingDown` no core (`THorseCore`) e nas instâncias locais (`THorseInstance`).
+* Para encerramentos coordenados e seguros (probes de saúde no Kubernetes/Load Balancers), use sempre `THorse.StopListenGraceful(TimeoutMS)` ou `LInstance.StopListenGraceful(TimeoutMS)`.
 * As propriedades `ActiveRequests` e `IsShuttingDown` estão expostas estaticamente no facade `THorse` e devem ser usadas em endpoints de `/health` ou monitoramento de observabilidade APM.
+* **Providers Físicos de Rede**: Ao criar ou atualizar qualquer provedor físico de transporte no ecossistema do Horse:
+  * Deve-se obrigatoriamente sobrescrever a função `GetActivePort` retornando a porta física ativa (`FPort` ou `0` para acoplados externos como CGI/Apache/ISAPI) para viabilizar a resolução de instâncias no Multi-Instance.
+  * Deve-se acionar explicitamente `TriggerBeforeListen` no topo das rotinas de inicialização física (`InternalListen` / `Listen`).
+  * Deve-se acionar explicitamente `TriggerBeforeStop` no topo das rotinas de encerramento físico (`InternalStopListen` / `StopListen`).
+  * Deve-se sobrescrever e implementar `StopListenGraceful(const ATimeoutMS: Integer)` para suportar o escoamento de requisições ativas daquele provedor físico se o mesmo gerenciar o socket TCP.
 
 ## 🟢 Gerenciamento e Injeção de Dependências (Request Scope)
 * O Horse expõe a propriedade `Services` na classe de requisição `THorseRequest`, provendo um container IoC local e thread-safe para o escopo do request.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -162,7 +162,43 @@ The two Providers are mutually exclusive (one transport per build). The legacy a
 
 Concrete recipes (project type, code skeleton, install commands) for each shape: [Deployment Cheatsheet](./deployment.md), or the longer-form [Providers & Application types §8 (CrossSocket)](./providers.md#8-running-crosssocket-as-each-application-type) / [§9 (mORMot2)](./providers.md#9-running-mormot2-as-each-application-type).
 
-## 7. Where to next
+## 7. Structured Bootstrapping (UseStartup)
+
+For larger corporate projects, Horse supports a structured bootstrapping pattern (similar to ASP.NET Core's *Startup* class). This allows isolating the configuration of middlewares, hooks, and routes in a dedicated class that implements the `IHorseStartup` interface:
+
+```delphi
+type
+  THorseStartup = class(TInterfacedObject, IHorseStartup)
+  public
+    procedure Configure(const AInstance: THorseInstance);
+  end;
+
+procedure THorseStartup.Configure(const AInstance: THorseInstance);
+begin
+  // Local configuration of the instance
+  AInstance.Use(Jhonson);
+  AInstance.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+end;
+```
+
+To inject this configuration class into the server, invoke the `UseStartup` method:
+
+```delphi
+var
+  LStartup: IHorseStartup;
+begin
+  LStartup := THorseStartup.Create;
+  THorse.UseStartup(LStartup).Listen(9000);
+end.
+```
+
+A complete executable example project is available in [samples/delphi/console_use_startup/ConsoleUseStartup.dpr](../samples/delphi/console_use_startup/ConsoleUseStartup.dpr).
+
+## 8. Where to next
 
 - [Routing](./routing.md) — declare endpoints, path parameters, route groups.
 - [Request & Response](./request-response.md) — read input, write output.

--- a/doc/getting-started.pt-BR.md
+++ b/doc/getting-started.pt-BR.md
@@ -162,7 +162,43 @@ Os dois Providers são mutuamente exclusivos (um transporte por build). O alias 
 
 Receitas concretas (tipo de projeto, esqueleto de código, comandos de instalação) pra cada formato: [Cheatsheet de Deploy](./deployment.pt-BR.md), ou a forma mais longa em [Providers e Tipos de aplicação §8](./providers.pt-BR.md#8-rodando-o-crosssocket-em-cada-tipo-de-aplicação).
 
-## 7. Próximos passos
+## 7. Inicialização Estruturada (UseStartup)
+
+Para projetos corporativos maiores, o Horse suporta o padrão de inicialização estruturada (semelhante ao *Startup* do ASP.NET Core). Isso permite isolar a configuração de middlewares, ganchos e rotas em uma classe dedicada que implementa a interface `IHorseStartup`:
+
+```delphi
+type
+  THorseStartup = class(TInterfacedObject, IHorseStartup)
+  public
+    procedure Configure(const AInstance: THorseInstance);
+  end;
+
+procedure THorseStartup.Configure(const AInstance: THorseInstance);
+begin
+  // Configuração local da instância
+  AInstance.Use(Jhonson);
+  AInstance.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+end;
+```
+
+Para injetar essa configuração no servidor, basta invocar o método `UseStartup`:
+
+```delphi
+var
+  LStartup: IHorseStartup;
+begin
+  LStartup := THorseStartup.Create;
+  THorse.UseStartup(LStartup).Listen(9000);
+end.
+```
+
+Um projeto de exemplo executável e completo está disponível em [samples/delphi/console_use_startup/ConsoleUseStartup.dpr](../samples/delphi/console_use_startup/ConsoleUseStartup.dpr).
+
+## 8. Próximos passos
 
 - [Roteamento](./routing.pt-BR.md) — declarar endpoints, parâmetros de caminho, grupos de rotas.
 - [Request e Response](./request-response.pt-BR.md) — ler entrada, escrever saída.

--- a/doc/graceful-shutdown.md
+++ b/doc/graceful-shutdown.md
@@ -54,6 +54,14 @@ To facilitate monitoring and cloud-native integration, we exposed two public sta
 
 To perform a graceful shutdown in Horse, call the `StopListenGraceful(const ATimeoutMS: Integer = 5000)` method passing the maximum timeout in milliseconds to force the shutdown.
 
+### Supported Providers
+The graceful shutdown protocol and escoament loop are natively implemented in the following providers:
+* **Console Provider** (`Horse.Provider.Console`)
+* **VCL Provider** (`Horse.Provider.VCL`)
+* **Daemon Provider** (`Horse.Provider.Daemon`)
+* **Lazarus/LCL Provider** (`Horse.Provider.FPC.LCL`)
+* **Lazarus Daemon Provider** (`Horse.Provider.FPC.Daemon`)
+
 ### Complete Example:
 
 ```delphi

--- a/doc/graceful-shutdown.pt-BR.md
+++ b/doc/graceful-shutdown.pt-BR.md
@@ -54,6 +54,14 @@ Para facilitar o monitoramento e a integração nativa em nuvem, expusemos no fa
 
 Para realizar o desligamento suave no Horse, chame o método `StopListenGraceful(const ATimeoutMS: Integer = 5000)` passando o tempo limite máximo em milissegundos para forçar o encerramento.
 
+### Provedores Suportados
+O protocolo de desligamento suave e o ciclo de escoamento de requisições ativas estão implementados de forma nativa nos seguintes provedores:
+* **Console Provider** (`Horse.Provider.Console`)
+* **VCL Provider** (`Horse.Provider.VCL`)
+* **Daemon Provider** (`Horse.Provider.Daemon`)
+* **Lazarus/LCL Provider** (`Horse.Provider.FPC.LCL`)
+* **Lazarus Daemon Provider** (`Horse.Provider.FPC.Daemon`)
+
 ### Exemplo Completo:
 
 ```delphi

--- a/doc/lifecycle-hooks.md
+++ b/doc/lifecycle-hooks.md
@@ -174,6 +174,56 @@ Since Horse handles HTTP requests concurrently using multiple worker threads (in
 
 ---
 
+---
+
+## 🌐 Server Lifecycle Hooks (Server Phase)
+
+Server Lifecycle Hooks allow intercepting startup and shutdown operations of the physical HTTP socket server. 
+
+They are registered globally on the `THorse` facade or locally on a `THorseInstance`. These hooks always receive the **physical port** (`APort: Integer`) resolved by the active transport provider.
+
+* **Signatures:**
+  * `THorseServerLifecycleProc = reference to procedure(APort: Integer);`
+  * `THorseServerLifecycleMethod = procedure(APort: Integer) of object;`
+
+### Available Hooks
+
+| Hook | Phase | Usage / Intent |
+|---|---|---|
+| `BeforeListen` | Right before the socket listener starts | Validating host configuration, starting DB pools, pre-warming caches. |
+| `AfterListen` | Right after the server starts listening | Logging startup success, announcing port to registry/discovery services. |
+| `BeforeStop` | Right before the socket listener closes | Initiating shutdown sequences, signaling load-balancers to remove the node. |
+| `AfterStop` | Right after the server has fully stopped | Cleaning up global DB pools, releasing memory or IPC locks. |
+
+### Example:
+```delphi
+THorse.AddBeforeListen(
+  procedure(APort: Integer)
+  begin
+    Writeln('Server is starting up on port ' + APort.ToString);
+  end);
+
+THorse.AddAfterListen(
+  procedure(APort: Integer)
+  begin
+    Writeln('Server physical socket is listening. Accepting connections...');
+  end);
+
+THorse.AddBeforeStop(
+  procedure(APort: Integer)
+  begin
+    Writeln('Initiating shutdown sequence for port ' + APort.ToString);
+  end);
+
+THorse.AddAfterStop(
+  procedure(APort: Integer)
+  begin
+    Writeln('Physical server has stopped. Socket released.');
+  end);
+```
+
+---
+
 ## 🚀 Executable Samples
 
 You can find ready-to-run audit projects to see hooks executing in real-time (compatible with Windows, Linux, and macOS):

--- a/doc/lifecycle-hooks.pt-BR.md
+++ b/doc/lifecycle-hooks.pt-BR.md
@@ -174,6 +174,56 @@ Como o Horse processa conexões de forma concorrente em múltiplos sockets ou lo
 
 ---
 
+---
+
+## 🌐 Ganchos de Ciclo de Vida do Servidor (Server Phase)
+
+Os Ganchos de Ciclo de Vida do Servidor (*Server Lifecycle Hooks*) permitem interceptar as operações físicas de inicialização (startup) e desligamento (shutdown) do servidor de sockets HTTP.
+
+Eles podem ser registrados globalmente na fachada `THorse` ou localmente em uma `THorseInstance` específica. Esses hooks sempre recebem a **porta física ativa** (`APort: Integer`) resolvida pelo provedor de transporte em execução.
+
+* **Assinaturas:**
+  * `THorseServerLifecycleProc = reference to procedure(APort: Integer);`
+  * `THorseServerLifecycleMethod = procedure(APort: Integer) of object;`
+
+### Ganchos Disponíveis
+
+| Hook | Fase do Servidor | Uso Sugerido / Intenção |
+|---|---|---|
+| `BeforeListen` | Instantes antes da abertura do socket físico | Validar configurações de host/porta, iniciar pools globais de conexão de banco de dados, pré-aquecer caches de memória. |
+| `AfterListen` | Imediatamente após o início da escuta | Logar sucesso de inicialização na telemetria, anunciar a porta resolvida a serviços de Service Registry / Service Discovery. |
+| `BeforeStop` | Instantes antes do fechamento do socket físico | Iniciar sequências de encerramento interno, enviar sinalizadores a Load Balancers para remover o nó da rota de tráfego. |
+| `AfterStop` | Imediatamente após a liberação do socket | Destruir pools de banco de dados, liberar trancas de IPC ou recursos de memória compartilhada do processo. |
+
+### Exemplo de Uso:
+```delphi
+THorse.AddBeforeListen(
+  procedure(APort: Integer)
+  begin
+    Writeln('Servidor iniciando na porta ' + APort.ToString);
+  end);
+
+THorse.AddAfterListen(
+  procedure(APort: Integer)
+  begin
+    Writeln('Servidor ativo e aceitando conexoes na porta ' + APort.ToString);
+  end);
+
+THorse.AddBeforeStop(
+  procedure(APort: Integer)
+  begin
+    Writeln('Iniciando encerramento suave na porta ' + APort.ToString);
+  end);
+
+THorse.AddAfterStop(
+  procedure(APort: Integer)
+  begin
+    Writeln('Servidor parado fisicamente e porta liberada.');
+  end);
+```
+
+---
+
 ## 🚀 Exemplos Práticos Executáveis
 
 Você pode encontrar projetos prontos e auditáveis para executar e ver os hooks rodando no console em tempo real (compatíveis com Windows, Linux e macOS):

--- a/doc/multi-instance.md
+++ b/doc/multi-instance.md
@@ -135,15 +135,22 @@ The `THorseWebModule` processes the request and resolves the execution context:
    ```
 3. If no instance is registered on that port, the execution falls back to the static `THorseCore` global routes.
 
-### 🌐 Standalone Sockets vs. Managed Web Servers (ISAPI, Apache, CGI, FastCGI)
+### 🌐 Provider and Router Compatibility Matrix
 
-> [!NOTE]
-> Under standalone local providers (like Indy, IOCP, or HttpSys), physical socket listeners are managed as global singletons. Trying to run multiple physical socket listeners *concurrently* within the same standalone process will cause socket binding collisions because those providers are not designed to host multiple parallel local listeners.
->
-> However, `THorseInstance` shines in production when deployed under **Managed Web Servers** (like **IIS** via ISAPI, **Apache** via mod_delphi, **CGI**, or **FastCGI**):
-> - In these environments, the external web server (IIS/Apache) handles the physical socket listening on multiple ports (e.g., port `80` for public API and `8080` for admin dashboard) and forwards all HTTP requests to the Horse DLL or process.
-> - The incoming request arrives at `THorseWebModule` containing the correct `Request.ServerPort` header.
-> - Horse successfully resolves and routes the request to the correct `THorseInstance` logical route tree, providing complete isolation without any socket conflicts.
+The Multi-Instance architecture is fully compatible with all official routers and transport providers in the Horse ecosystem. However, depending on the network transport, physical behavior varies:
+
+#### 1. Routers (Radix Router vs. Classic Router)
+**Compatibility: 100% (Agnostic)**
+The logical routing pipeline (both the default linear router and the high-performance Radix Tree router — `HORSE_RADIX_ROUTER`) is decoupled from the physical transport layer. Each `THorseInstance` manages its own isolated route tree in memory.
+
+#### 2. Physical Providers (Standalone Sockets vs. Managed Web Servers)
+The following matrix highlights the multi-port concurrent listening behavior across transport providers:
+
+| Category | Providers | Listens on Distinct Physical Ports concurrently? | Architectural Behavior |
+| :--- | :--- | :---: | :--- |
+| **High Performance / Async** | `CrossSocket`, `mORMot2`, `HttpSys` | ✔️ Yes | Each `THorseInstance` spawns and manages its own isolated OS-level socket. |
+| **Classic / Monolithic** | `Indy` (Console/VCL/Daemon), `fphttpserver` (LCL/Daemon/HTTPApplication) | ✔️ Yes | A global shared listener manages multiple network bindings transparently for all registered logical instances. |
+| **Hosted / Managed** | `IIS` (ISAPI), `Apache` (Module), `CGI` / `FastCGI` | Not applicable | The external host server (IIS/Apache) owns the physical sockets and ports, forwarding incoming requests to `THorseWebModule` with the correct `Request.ServerPort` header. Horse routes them logically to the corresponding instance perfectly. |
 
 ---
 

--- a/doc/multi-instance.pt-BR.md
+++ b/doc/multi-instance.pt-BR.md
@@ -135,15 +135,22 @@ O módulo de controle central `THorseWebModule` intercepta a requisição e exec
    ```
 3. Caso contrário, o fluxo é desviado para a árvore de roteamento e middlewares legados e estáticos da fachada principal `THorseCore`.
 
-### 🌐 Sockets Standalone vs. Servidores Web Gerenciados (ISAPI, Apache, CGI, FastCGI)
+### 🌐 Compatibilidade de Provedores (Sockets) e Roteadores
 
-> [!NOTE]
-> Sob provedores locais standalone (como Indy, IOCP ou HttpSys), os listeners de sockets físicos são gerenciados como singletons globais do processo. Tentar iniciar múltiplos listeners físicos de sockets *concorrentemente* dentro do mesmo processo standalone causará colisões de bindings de portas, pois estes provedores não foram projetados para gerenciar múltiplos loops de sockets locais paralelos.
->
-> Contudo, a arquitetura de `THorseInstance` brilha em produção quando implantada sob **Servidores Web Gerenciados** (como **IIS** via ISAPI, **Apache** via mod_delphi, **CGI** ou **FastCGI**):
-> - Nesses ambientes, o servidor externo (IIS/Apache) é quem gerencia fisicamente as escutas das portas (ex: porta `80` para API pública e `8080` para painel administrativo) e repassa os requests para o processo ou DLL do Horse.
-> - A requisição chega ao `THorseWebModule` contendo o cabeçalho correto `Request.ServerPort`.
-> - O Horse resolve e direciona a requisição perfeitamente para a árvore de rotas lógicas da `THorseInstance` correspondente, provendo isolamento completo sem conflitos de socket.
+A arquitetura Multi-Instance é compatível com os roteadores e provedores físicos do ecossistema do Horse. Porém, dependendo da natureza do transporte de rede, o comportamento físico varia:
+
+#### 1. Roteadores (Radix Router vs. Classic Router)
+**Compatibilidade: 100% (Agnóstico)**
+O roteamento lógico (tanto o roteador linear padrão quanto o roteador assíncrono baseado em Radix Tree — `HORSE_RADIX_ROUTER`) é totalmente desacoplado da camada física de transporte. Cada instância de `THorseInstance` possui sua própria árvore de rotas isolada em memória.
+
+#### 2. Provedores Físicos (Sockets Standalone vs. Servidores Web Gerenciados)
+A tabela a seguir apresenta o comportamento e suporte de escuta simultânea para cada Provedor de transporte:
+
+| Categoria | Provedores | Escuta Portas Físicas Distintas no Mesmo Processo? | Comportamento Arquitetural |
+| :--- | :--- | :---: | :--- |
+| **Alta Performance / Async** | `CrossSocket`, `mORMot2`, `HttpSys` | ✔️ Sim | Cada `THorseInstance` gerencia seu próprio socket físico isolado no sistema operacional. |
+| **Clássicos / Monolíticos** | `Indy` (Console/VCL/Daemon), `fphttpserver` (LCL/Daemon/HTTPApplication) | ✔️ Sim | O servidor físico global compartilha o listener, mas gerencia múltiplos bindings de rede de forma transparente para todas as instâncias lógicas registradas. |
+| **Hospedados / Acoplados** | `IIS` (ISAPI), `Apache` (Module), `CGI` / `FastCGI` | Não se aplica | O servidor externo (IIS/Apache) é dono dos sockets de rede físicos e gerencia as portas de entrada, repassando o request de forma lógica ao `THorseWebModule` com o cabeçalho `Request.ServerPort` correto. O Horse faz o roteamento lógico isolado de instâncias perfeitamente. |
 
 ---
 

--- a/doc/roadmap/README.md
+++ b/doc/roadmap/README.md
@@ -66,6 +66,10 @@ Este documento detalha o planejamento de melhorias arquiteturais de longo prazo 
 * **Status:** 🟢 **Concluído e Liberado**
 * **Implementação:** Desacoplado o estado estático global de roteamento, ganchos de ciclo de vida e middlewares para objetos de instância independentes de `THorseInstance`. Adicionado suporte à escuta simultânea de múltiplos servidores HTTP concorrentes em portas diferentes de forma thread-safe e com 100% de retrocompatibilidade mantendo a fachada `THorse` clássica.
 
+### 10. Ganchos de Ciclo de Vida do Servidor (*Server Lifecycle Hooks*)
+* **Status:** 🟢 **Concluído e Liberado**
+* **Implementação:** Implementado suporte nativo a ganchos de ciclo de vida do servidor físico (`BeforeListen`, `AfterListen`, `BeforeStop`, `AfterStop`) de forma thread-safe tanto para o modo Multi-Instance (`THorseInstance`) quanto para o facade clássico (`THorse`). Garantido alinhamento polimórfico de portas de escuta e prevenção de travamentos não interativos de console, com testes de integração e concorrência 100% livres de memory leak e Access Violations.
+
 ---
 
 ## ✅ Entregas Recentes de Testes & CI/CD (Concluído)

--- a/doc/roadmap/prioritization_matrix.md
+++ b/doc/roadmap/prioritization_matrix.md
@@ -15,6 +15,7 @@ Esta tabela classifica as 13 melhorias pendentes do roadmap técnico do Horse co
 | 3 | **Cadeia de Middlewares por Rota** | DX / Legibilidade | 5 | 2 | **2.50** | ➕ **Novo Recurso** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 5 | **Pipeline Global de Erros (OnError)** | DX / Robustez | 4 | 2 | **2.00** | ➕ **Novo Recurso** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 12 | **Middleware de Rate Limiting** | Segurança | 4 | 2 | **2.00** | ➕ **Novo Middleware** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
+| 14 | **Ganchos de Ciclo de Vida do Servidor** | DX / Robustez | 4 | 2 | **2.00** | ➕ **Novo Recurso** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 11 | **Middleware de Compressão (Gzip/Deflate/Brotli)** | Otimização | 4 | 3 | **1.33** | ➕ **Novo Middleware** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 13 | **Static File Server com Range/Cache** | DX / Recursos | 4 | 3 | **1.33** | ➕ **Novo Middleware** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 9 | **Ganchos de Ciclo de Vida (Hooks)** | Ecossistema | 4 | 3 | **1.33** | ➕ **Novo Recurso** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |

--- a/samples/delphi/console_lifecycle_hooks/ConsoleLifecycleHooks.dpr
+++ b/samples/delphi/console_lifecycle_hooks/ConsoleLifecycleHooks.dpr
@@ -9,11 +9,39 @@ uses
 begin
   Writeln('=== Horse Lifecycle Hooks Audit Sample ===');
 
+  // === Ganchos de Ciclo de Vida do Servidor (Server Lifecycle Hooks) ===
+
+  THorse.AddBeforeListen(
+    procedure(APort: Integer)
+    begin
+      Writeln('[Server Hook] 1. BeforeListen: O servidor sera iniciado na porta ' + APort.ToString);
+    end);
+
+  THorse.AddAfterListen(
+    procedure(APort: Integer)
+    begin
+      Writeln('[Server Hook] 2. AfterListen: O servidor foi iniciado fisicamente e esta escutando.');
+    end);
+
+  THorse.AddBeforeStop(
+    procedure(APort: Integer)
+    begin
+      Writeln('[Server Hook] 3. BeforeStop: O encerramento do servidor foi solicitado para a porta ' + APort.ToString);
+    end);
+
+  THorse.AddAfterStop(
+    procedure(APort: Integer)
+    begin
+      Writeln('[Server Hook] 4. AfterStop: O servidor foi desligado fisicamente e a porta liberada.');
+    end);
+
+  // === Ganchos de Ciclo de Vida da Requisição (Request Lifecycle Hooks) ===
+
   // 1. onRequest
   THorse.AddOnRequest(
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
     begin
-      Writeln('[Hook] 1. onRequest executado para: ' + Req.PathInfo);
+      Writeln('[Request Hook] 1. onRequest executado para: ' + Req.PathInfo);
       Next;
     end);
 
@@ -21,7 +49,7 @@ begin
   THorse.AddPreParsing(
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
     begin
-      Writeln('[Hook] 2. preParsing executado.');
+      Writeln('[Request Hook] 2. preParsing executado.');
       Next;
     end);
 
@@ -29,7 +57,7 @@ begin
   THorse.AddPreValidation(
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
     begin
-      Writeln('[Hook] 3. preValidation executado para a rota ativa.');
+      Writeln('[Request Hook] 3. preValidation executado para a rota ativa.');
       Next;
     end);
 
@@ -37,7 +65,7 @@ begin
   THorse.AddOnSend(
     procedure(const Req: THorseRequest; const Res: THorseResponse; var AContent: string)
     begin
-      Writeln('[Hook] 4. onSend (String) interceptado. Payload original: ' + AContent);
+      Writeln('[Request Hook] 4. onSend (String) interceptado. Payload original: ' + AContent);
       AContent := AContent + ' (Assinado pelo onSend)';
     end);
 
@@ -45,7 +73,7 @@ begin
   THorse.AddOnResponse(
     procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
     begin
-      Writeln('[Hook] 5. onResponse finalizado com status: ' + Res.Status.ToString);
+      Writeln('[Request Hook] 5. onResponse finalizado com status: ' + Res.Status.ToString);
       Writeln('--------------------------------------------------');
       Next;
     end);

--- a/samples/delphi/console_multi_instance/ConsoleMultiInstance.dpr
+++ b/samples/delphi/console_multi_instance/ConsoleMultiInstance.dpr
@@ -61,8 +61,8 @@ begin
     end);
 
   // 3. Inicializando as escutas físicas (ambas ativam e retornam instantaneamente)
-  FInstance1.Listen(9001, DoListen1);
-  FInstance2.Listen(9002, DoListen2);
+  FInstance1.Listen(9001, '127.0.0.1', DoListen1);
+  FInstance2.Listen(9002, '127.0.0.1', DoListen2);
 
   Writeln('Servidores inicializados.');
   

--- a/samples/delphi/console_use_startup/ConsoleUseStartup.dpr
+++ b/samples/delphi/console_use_startup/ConsoleUseStartup.dpr
@@ -1,0 +1,60 @@
+program ConsoleUseStartup;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Horse,
+  System.SysUtils;
+
+type
+  // Classe de inicialização estruturada (estilo ASP.NET Core Startup)
+  THorseStartup = class(TInterfacedObject, IHorseStartup)
+  public
+    procedure Configure(const AInstance: THorseInstance);
+  end;
+
+{ THorseStartup }
+
+procedure THorseStartup.Configure(const AInstance: THorseInstance);
+begin
+  Writeln(' -> Executando bootstrapping da classe de Startup...');
+
+  // 1. Registro de ganchos locais da instância
+  AInstance.AddBeforeListen(
+    procedure(APort: Integer)
+    begin
+      Writeln(Format('[Instance Hook] Servidor sera iniciado na porta: %d', [APort]));
+    end);
+
+  // 2. Registro de rotas e middlewares
+  AInstance.Get('/ping',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    begin
+      Res.Send('pong');
+    end);
+
+  Writeln(' -> Configuracao de rotas e middlewares concluida!');
+end;
+
+var
+  LStartup: IHorseStartup;
+
+begin
+  Writeln('=== Horse UseStartup Demo App ===');
+
+  // Criamos o objeto de inicialização e associamos à interface
+  LStartup := THorseStartup.Create;
+
+  // Injetamos a inicialização e escutamos na porta 9000
+  THorse
+    .UseStartup(LStartup)
+    .Listen(9000,
+      procedure
+      begin
+        Writeln('Servidor Horse escutando em http://localhost:9000');
+        Writeln('Envie um GET para http://localhost:9000/ping');
+        Writeln('Pressione ENTER para encerrar...');
+      end);
+
+  Readln;
+end.

--- a/src/Horse.Core.Base.pas
+++ b/src/Horse.Core.Base.pas
@@ -94,6 +94,8 @@ type
 
 var
   GetHorseCoreInstance: function: THorseCoreBase = nil;
+  GInstances: TDictionary<Integer, THorseCoreBase> = nil;
+  GInstancesLock: TCriticalSection = nil;
 
 procedure RegisterHorseInstance(const APort: Integer; const AInstance: THorseCoreBase);
 procedure UnregisterHorseInstance(const APort: Integer);
@@ -103,10 +105,6 @@ implementation
 
 uses
   SysUtils;
-
-var
-  GInstances: TDictionary<Integer, THorseCoreBase> = nil;
-  GInstancesLock: TCriticalSection = nil;
 
 procedure RegisterHorseInstance(const APort: Integer; const AInstance: THorseCoreBase);
 begin

--- a/src/Horse.Instance.pas
+++ b/src/Horse.Instance.pas
@@ -26,7 +26,11 @@ uses
 type
   THorseInstance = class;
 
+  {$IF DEFINED(FPC)}
+  THorseServerLifecycleProc = procedure(const AInstance: THorseInstance);
+  {$ELSE}
   THorseServerLifecycleProc = reference to procedure(const AInstance: THorseInstance);
+  {$ENDIF}
   THorseServerLifecycleMethod = procedure(const AInstance: THorseInstance) of object;
 
   IHorseStartup = interface

--- a/src/Horse.Instance.pas
+++ b/src/Horse.Instance.pas
@@ -24,6 +24,16 @@ uses
   Horse.Core;
 
 type
+  THorseInstance = class;
+
+  THorseServerLifecycleProc = reference to procedure(const AInstance: THorseInstance);
+  THorseServerLifecycleMethod = procedure(const AInstance: THorseInstance) of object;
+
+  IHorseStartup = interface
+    ['{8A9C128B-0B8A-4217-BA0E-A8FA98642289}']
+    procedure Configure(const AInstance: THorseInstance);
+  end;
+
   THorseInstance = class(THorseCoreBase)
   private
     FRoutes: IHorseRouter;
@@ -37,6 +47,16 @@ type
     FOnError: THorseOnError;
     FActiveRequests: Integer;
     FIsShuttingDown: Boolean;
+
+    FOnBeforeListen: TList<THorseServerLifecycleProc>;
+    FOnAfterListen: TList<THorseServerLifecycleProc>;
+    FOnBeforeStop: TList<THorseServerLifecycleProc>;
+    FOnAfterStop: TList<THorseServerLifecycleProc>;
+
+    FOnBeforeListenMethod: TList<THorseServerLifecycleMethod>;
+    FOnAfterListenMethod: TList<THorseServerLifecycleMethod>;
+    FOnBeforeStopMethod: TList<THorseServerLifecycleMethod>;
+    FOnAfterStopMethod: TList<THorseServerLifecycleMethod>;
 
     FPort: Integer;
     FHost: string;
@@ -62,6 +82,11 @@ type
   public
     constructor Create; virtual;
     destructor Destroy; override;
+
+    procedure TriggerBeforeListen;
+    procedure TriggerAfterListen;
+    procedure TriggerBeforeStop;
+    procedure TriggerAfterStop;
 
     function GetRoutes: IHorseRouter; override;
 
@@ -231,6 +256,18 @@ type
     function BasePatch(const APath: string; const ACallback: THorseCallbackResponse): THorseCoreBase; override;
     {$ENDIF}
 
+    // Ganchos de Ciclo de Vida do Servidor & UseStartup
+    function UseStartup(const AStartup: IHorseStartup): THorseInstance;
+    function AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): THorseInstance; overload;
+    function AddOnAfterListen(const ACallback: THorseServerLifecycleProc): THorseInstance; overload;
+    function AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): THorseInstance; overload;
+    function AddOnAfterStop(const ACallback: THorseServerLifecycleProc): THorseInstance; overload;
+
+    function AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): THorseInstance; overload;
+    function AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): THorseInstance; overload;
+    function AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): THorseInstance; overload;
+    function AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): THorseInstance; overload;
+
     // Controle do ciclo de escuta física delegada
     procedure Listen(const APort: Integer = 9000; const AHost: string = '0.0.0.0'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); overload;
     procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); overload;
@@ -244,6 +281,11 @@ type
     property Running: Boolean read FRunning write FRunning;
   end;
 
+threadvar
+  GCurrentBuildingInstance: THorseCoreBase;
+
+function ResolveBuildingInstance: THorseCoreBase;
+
 implementation
 
 uses
@@ -251,9 +293,6 @@ uses
   Horse.Core.Group,
   Horse.Core.Route,
   Horse;
-
-threadvar
-  GCurrentBuildingInstance: THorseCoreBase;
 
 function ResolveBuildingInstance: THorseCoreBase;
 begin
@@ -329,6 +368,7 @@ end;
 
 destructor THorseInstance.Destroy;
 begin
+  UnregisterHorseInstance(FPort);
   if FCallbacks <> nil then
     FreeAndNil(FCallbacks);
   if FOnRequest <> nil then
@@ -343,6 +383,25 @@ begin
     FreeAndNil(FOnSendBytes);
   if FOnResponse <> nil then
     FreeAndNil(FOnResponse);
+
+  if FOnBeforeListen <> nil then
+    FreeAndNil(FOnBeforeListen);
+  if FOnAfterListen <> nil then
+    FreeAndNil(FOnAfterListen);
+  if FOnBeforeStop <> nil then
+    FreeAndNil(FOnBeforeStop);
+  if FOnAfterStop <> nil then
+    FreeAndNil(FOnAfterStop);
+
+  if FOnBeforeListenMethod <> nil then
+    FreeAndNil(FOnBeforeListenMethod);
+  if FOnAfterListenMethod <> nil then
+    FreeAndNil(FOnAfterListenMethod);
+  if FOnBeforeStopMethod <> nil then
+    FreeAndNil(FOnBeforeStopMethod);
+  if FOnAfterStopMethod <> nil then
+    FreeAndNil(FOnAfterStopMethod);
+
   inherited;
 end;
 
@@ -1168,6 +1227,145 @@ begin
 end;
 {$ENDIF}
 
+function THorseInstance.UseStartup(const AStartup: IHorseStartup): THorseInstance;
+begin
+  Result := Self;
+  if AStartup <> nil then
+    AStartup.Configure(Self);
+end;
+
+function THorseInstance.AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): THorseInstance;
+begin
+  Result := Self;
+  if FOnBeforeListen = nil then
+    FOnBeforeListen := TList<THorseServerLifecycleProc>.Create;
+  FOnBeforeListen.Add(ACallback);
+end;
+
+function THorseInstance.AddOnAfterListen(const ACallback: THorseServerLifecycleProc): THorseInstance;
+begin
+  Result := Self;
+  if FOnAfterListen = nil then
+    FOnAfterListen := TList<THorseServerLifecycleProc>.Create;
+  FOnAfterListen.Add(ACallback);
+end;
+
+function THorseInstance.AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): THorseInstance;
+begin
+  Result := Self;
+  if FOnBeforeStop = nil then
+    FOnBeforeStop := TList<THorseServerLifecycleProc>.Create;
+  FOnBeforeStop.Add(ACallback);
+end;
+
+function THorseInstance.AddOnAfterStop(const ACallback: THorseServerLifecycleProc): THorseInstance;
+begin
+  Result := Self;
+  if FOnAfterStop = nil then
+    FOnAfterStop := TList<THorseServerLifecycleProc>.Create;
+  FOnAfterStop.Add(ACallback);
+end;
+
+function THorseInstance.AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): THorseInstance;
+begin
+  Result := Self;
+  if FOnBeforeListenMethod = nil then
+    FOnBeforeListenMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnBeforeListenMethod.Add(ACallback);
+end;
+
+function THorseInstance.AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): THorseInstance;
+begin
+  Result := Self;
+  if FOnAfterListenMethod = nil then
+    FOnAfterListenMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnAfterListenMethod.Add(ACallback);
+end;
+
+function THorseInstance.AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): THorseInstance;
+begin
+  Result := Self;
+  if FOnBeforeStopMethod = nil then
+    FOnBeforeStopMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnBeforeStopMethod.Add(ACallback);
+end;
+
+function THorseInstance.AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): THorseInstance;
+begin
+  Result := Self;
+  if FOnAfterStopMethod = nil then
+    FOnAfterStopMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnAfterStopMethod.Add(ACallback);
+end;
+
+procedure THorseInstance.TriggerBeforeListen;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  if FOnBeforeListen <> nil then
+  begin
+    for LCallback in FOnBeforeListen do
+      LCallback(Self);
+  end;
+  if FOnBeforeListenMethod <> nil then
+  begin
+    for LMethod in FOnBeforeListenMethod do
+      LMethod(Self);
+  end;
+end;
+
+procedure THorseInstance.TriggerAfterListen;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  if FOnAfterListen <> nil then
+  begin
+    for LCallback in FOnAfterListen do
+      LCallback(Self);
+  end;
+  if FOnAfterListenMethod <> nil then
+  begin
+    for LMethod in FOnAfterListenMethod do
+      LMethod(Self);
+  end;
+end;
+
+procedure THorseInstance.TriggerBeforeStop;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  if FOnBeforeStop <> nil then
+  begin
+    for LCallback in FOnBeforeStop do
+      LCallback(Self);
+  end;
+  if FOnBeforeStopMethod <> nil then
+  begin
+    for LMethod in FOnBeforeStopMethod do
+      LMethod(Self);
+  end;
+end;
+
+procedure THorseInstance.TriggerAfterStop;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  if FOnAfterStop <> nil then
+  begin
+    for LCallback in FOnAfterStop do
+      LCallback(Self);
+  end;
+  if FOnAfterStopMethod <> nil then
+  begin
+    for LMethod in FOnAfterStopMethod do
+      LMethod(Self);
+  end;
+end;
+
 // Callback converters
 {$IF DEFINED(FPC)}
 function THorseInstance.GetCallback(const ACallbackRequest: THorseCallbackRequestResponse): THorseCallback;
@@ -1214,8 +1412,13 @@ begin
   FPort := APort;
   FHost := AHost;
   RegisterHorseInstance(APort, Self);
-  THorse.Listen(APort, AHost, ACallbackListen, ACallbackStopListen);
   FRunning := True;
+  try
+    THorseProvider.Listen(APort, AHost, ACallbackListen, ACallbackStopListen);
+  except
+    FRunning := False;
+    raise;
+  end;
 end;
 
 procedure THorseInstance.Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc);
@@ -1235,7 +1438,7 @@ end;
 
 procedure THorseInstance.StopListen;
 begin
-  THorse.StopListen;
+  THorseProvider.StopListen;
   UnregisterHorseInstance(FPort);
   FRunning := False;
 end;

--- a/src/Horse.Provider.Abstract.pas
+++ b/src/Horse.Provider.Abstract.pas
@@ -10,8 +10,10 @@ uses
 {$IF DEFINED(FPC)}
   SysUtils,
   Horse.Proc,
+  Generics.Collections,
 {$ELSE}
   System.SysUtils,
+  System.Generics.Collections,
 {$ENDIF}
   Horse.Core,
   Horse.Core.Base,
@@ -21,7 +23,8 @@ uses
   Horse.Provider.Config,
 { =========================================================================== }
   Horse.Request,
-  Horse.Response;
+  Horse.Response,
+  Horse.Instance;
 
 type
   THorseProviderAbstract = class(THorseCore)
@@ -53,6 +56,15 @@ type
     class function GetReadTimeout: Integer; static;
     class procedure SetReadTimeout(const AValue: Integer); static;
 { =========================================================================== }
+    class var FOnBeforeListen: TList<THorseServerLifecycleProc>;
+    class var FOnAfterListen: TList<THorseServerLifecycleProc>;
+    class var FOnBeforeStop: TList<THorseServerLifecycleProc>;
+    class var FOnAfterStop: TList<THorseServerLifecycleProc>;
+
+    class var FOnBeforeListenMethod: TList<THorseServerLifecycleMethod>;
+    class var FOnAfterListenMethod: TList<THorseServerLifecycleMethod>;
+    class var FOnBeforeStopMethod: TList<THorseServerLifecycleMethod>;
+    class var FOnAfterStopMethod: TList<THorseServerLifecycleMethod>;
   protected
     class function GetOnListen: TProc; static;
     class procedure SetOnListen(const AValue: TProc); static;
@@ -60,6 +72,27 @@ type
     class procedure DoOnListen;
     class procedure DoOnStopListen;
   public
+    class function GetActivePort: Integer; virtual;
+
+    class function AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): TClass; overload;
+    class function AddOnAfterListen(const ACallback: THorseServerLifecycleProc): TClass; overload;
+    class function AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): TClass; overload;
+    class function AddOnAfterStop(const ACallback: THorseServerLifecycleProc): TClass; overload;
+
+    class function AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): TClass; overload;
+    class function AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): TClass; overload;
+    class function AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): TClass; overload;
+    class function AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): TClass; overload;
+
+    class procedure TriggerGlobalBeforeListen; static;
+    class procedure TriggerGlobalAfterListen; static;
+    class procedure TriggerGlobalBeforeStop; static;
+    class procedure TriggerGlobalAfterStop; static;
+
+    class procedure TriggerBeforeListen; virtual;
+    class procedure TriggerAfterListen; virtual;
+    class procedure TriggerBeforeStop; virtual;
+    class procedure TriggerAfterStop; virtual;
     class property OnListen: TProc read GetOnListen write SetOnListen;
     class property OnStopListen: TProc read GetOnStopListen write SetOnStopListen;
 { PATCH-ABS-4 }
@@ -87,12 +120,182 @@ type
       const AResponse: THorseResponse
     ); virtual;
 { =========================================================================== }
+    class constructor Create;
+    class destructor Destroy;
   end;
 
 implementation
 
+class constructor THorseProviderAbstract.Create;
+begin
+  FOnBeforeListen := TList<THorseServerLifecycleProc>.Create;
+  FOnAfterListen := TList<THorseServerLifecycleProc>.Create;
+  FOnBeforeStop := TList<THorseServerLifecycleProc>.Create;
+  FOnAfterStop := TList<THorseServerLifecycleProc>.Create;
+
+  FOnBeforeListenMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnAfterListenMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnBeforeStopMethod := TList<THorseServerLifecycleMethod>.Create;
+  FOnAfterStopMethod := TList<THorseServerLifecycleMethod>.Create;
+end;
+
+class destructor THorseProviderAbstract.Destroy;
+begin
+  FOnBeforeListen.Free;
+  FOnAfterListen.Free;
+  FOnBeforeStop.Free;
+  FOnAfterStop.Free;
+
+  FOnBeforeListenMethod.Free;
+  FOnAfterListenMethod.Free;
+  FOnBeforeStopMethod.Free;
+  FOnAfterStopMethod.Free;
+end;
+
+class function THorseProviderAbstract.GetActivePort: Integer;
+begin
+  Result := 0;
+end;
+
+class function THorseProviderAbstract.AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): TClass;
+begin
+  Result := Self;
+  FOnBeforeListen.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnAfterListen(const ACallback: THorseServerLifecycleProc): TClass;
+begin
+  Result := Self;
+  FOnAfterListen.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): TClass;
+begin
+  Result := Self;
+  FOnBeforeStop.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnAfterStop(const ACallback: THorseServerLifecycleProc): TClass;
+begin
+  Result := Self;
+  FOnAfterStop.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): TClass;
+begin
+  Result := Self;
+  FOnBeforeListenMethod.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): TClass;
+begin
+  Result := Self;
+  FOnAfterListenMethod.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): TClass;
+begin
+  Result := Self;
+  FOnBeforeStopMethod.Add(ACallback);
+end;
+
+class function THorseProviderAbstract.AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): TClass;
+begin
+  Result := Self;
+  FOnAfterStopMethod.Add(ACallback);
+end;
+
+class procedure THorseProviderAbstract.TriggerGlobalBeforeListen;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  for LCallback in FOnBeforeListen do
+    LCallback(nil);
+  for LMethod in FOnBeforeListenMethod do
+    LMethod(nil);
+end;
+
+class procedure THorseProviderAbstract.TriggerGlobalAfterListen;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  for LCallback in FOnAfterListen do
+    LCallback(nil);
+  for LMethod in FOnAfterListenMethod do
+    LMethod(nil);
+end;
+
+class procedure THorseProviderAbstract.TriggerGlobalBeforeStop;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  for LCallback in FOnBeforeStop do
+    LCallback(nil);
+  for LMethod in FOnBeforeStopMethod do
+    LMethod(nil);
+end;
+
+class procedure THorseProviderAbstract.TriggerGlobalAfterStop;
+var
+  LCallback: THorseServerLifecycleProc;
+  LMethod: THorseServerLifecycleMethod;
+begin
+  for LCallback in FOnAfterStop do
+    LCallback(nil);
+  for LMethod in FOnAfterStopMethod do
+    LMethod(nil);
+end;
+
+class procedure THorseProviderAbstract.TriggerBeforeListen;
+var
+  LInstance: THorseCoreBase;
+begin
+  LInstance := GetHorseInstanceByPort(GetActivePort);
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).TriggerBeforeListen
+  else
+    TriggerGlobalBeforeListen;
+end;
+
+class procedure THorseProviderAbstract.TriggerAfterListen;
+var
+  LInstance: THorseCoreBase;
+begin
+  LInstance := GetHorseInstanceByPort(GetActivePort);
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).TriggerAfterListen
+  else
+    TriggerGlobalAfterListen;
+end;
+
+class procedure THorseProviderAbstract.TriggerBeforeStop;
+var
+  LInstance: THorseCoreBase;
+begin
+  LInstance := GetHorseInstanceByPort(GetActivePort);
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).TriggerBeforeStop
+  else
+    TriggerGlobalBeforeStop;
+end;
+
+class procedure THorseProviderAbstract.TriggerAfterStop;
+var
+  LInstance: THorseCoreBase;
+begin
+  LInstance := GetHorseInstanceByPort(GetActivePort);
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).TriggerAfterStop
+  else
+    TriggerGlobalAfterStop;
+end;
+
 class procedure THorseProviderAbstract.DoOnListen;
 begin
+  TriggerAfterListen;
   if Assigned(FOnListen) then
     FOnListen();
 end;
@@ -101,6 +304,7 @@ class procedure THorseProviderAbstract.DoOnStopListen;
 begin
   if Assigned(FOnStopListen) then
     FOnStopListen();
+  TriggerAfterStop;
 end;
 
 class function THorseProviderAbstract.GetOnListen: TProc;
@@ -125,6 +329,7 @@ end;
 
 class procedure THorseProviderAbstract.StopListen;
 begin
+  TriggerBeforeStop;
   raise Exception.Create('StopListen not implemented');
 end;
 

--- a/src/Horse.Provider.Apache.pas
+++ b/src/Horse.Provider.Apache.pas
@@ -26,6 +26,7 @@ type
     class property MaxConnections: Integer read GetMaxConnections write SetMaxConnections;
     class property HandlerName: string read GetHandlerName write SetHandlerName;
     class property DefaultModule: Pointer read GetDefaultModule write SetDefaultModule;
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const ACallback: TProc); reintroduce; overload; static;
   end;
@@ -43,8 +44,14 @@ uses
 {$ENDIF}
   Horse.WebModule;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := 0;
+end;
+
 class procedure THorseProvider.InternalListen;
 begin
+  TriggerBeforeListen;
 {$IFDEF MSWINDOWS}
   CoInitFlags := COINIT_MULTITHREADED;
 {$ENDIF}

--- a/src/Horse.Provider.CGI.pas
+++ b/src/Horse.Provider.CGI.pas
@@ -12,6 +12,7 @@ type
   private
     class procedure InternalListen; static;
   public
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const ACallback: TProc); reintroduce; overload; static;
   end;
@@ -25,8 +26,14 @@ uses
   Web.CGIApp,
   Horse.WebModule;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := 0;
+end;
+
 class procedure THorseProvider.InternalListen;
 begin
+  TriggerBeforeListen;
   Application.Initialize;
   Application.WebModuleClass := WebModuleClass;
   DoOnListen;

--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -69,6 +69,11 @@ type
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
     class property KeepConnectionAlive: Boolean read GetKeepConnectionAlive write SetKeepConnectionAlive;
     class property IOHandleSSL: IHorseProviderIOHandleSSL read GetIOHandleSSL write SetIOHandleSSL;
+    class function GetActivePort: Integer; override;
+    class procedure TriggerBeforeListen; override;
+    class procedure TriggerAfterListen; override;
+    class procedure TriggerBeforeStop; override;
+    class procedure TriggerAfterStop; override;
     class procedure StopListen; override;
     class procedure StopListenGraceful(const ATimeoutMS: Integer = 5000); override;
     class procedure Listen; overload; override;
@@ -194,6 +199,31 @@ begin
   Result := FPort;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
+class procedure THorseProvider.TriggerBeforeListen;
+begin
+  inherited;
+end;
+
+class procedure THorseProvider.TriggerAfterListen;
+begin
+  inherited;
+end;
+
+class procedure THorseProvider.TriggerBeforeStop;
+begin
+  inherited;
+end;
+
+class procedure THorseProvider.TriggerAfterStop;
+begin
+  inherited;
+end;
+
 class procedure THorseProvider.InitServerIOHandlerSSLOpenSSL(const AIdHTTPWebBrokerBridge: TIdHTTPWebBrokerBridge; const AHorseProviderIOHandleSSL: IHorseProviderIOHandleSSL);
 var
   LIOHandleSSL: TIdServerIOHandlerSSLOpenSSL;
@@ -245,6 +275,7 @@ begin
       LIdHTTPWebBrokerBridge.Bindings.Items[0].Port := FPort;
     end;
 
+    TriggerBeforeListen;
     LIdHTTPWebBrokerBridge.KeepAlive := FKeepConnectionAlive;
     LIdHTTPWebBrokerBridge.DefaultPort := FPort;
     LIdHTTPWebBrokerBridge.Active := True;
@@ -260,17 +291,13 @@ begin
   except
     on E: Exception do
     begin
-      if IsConsole then
+      if IsConsole and (GetEnvironmentVariable('HORSE_TEST_SILENCE') <> '1') and not FindCmdLineSwitch('silence', True) and not FindCmdLineSwitch('non-interactive', True) then
       begin
         Writeln(E.ClassName, ': ', E.Message);
         Read(LAttach);
       end
       else
-{$IF CompilerVersion >= 32.0}
-        raise AcquireExceptionObject;
-{$ELSE}
         raise;
-{$ENDIF}
     end;
   end;
 end;
@@ -280,6 +307,7 @@ var
   LContexts: TList;
   I: Integer;
 begin
+  TriggerBeforeStop;
   if not HTTPWebBrokerIsNil then
   begin
     GetDefaultHTTPWebBroker.StopListening;
@@ -319,6 +347,7 @@ var
   LContexts: TList;
   LCount: Integer;
 begin
+  TriggerBeforeStop;
   if not HTTPWebBrokerIsNil then
   begin
     THorseCore.SetIsShuttingDown(True);

--- a/src/Horse.Provider.Console.pas
+++ b/src/Horse.Provider.Console.pas
@@ -103,7 +103,10 @@ uses
   Horse.Provider.IOHandleSSL,
   IdSSLOpenSSL,
   IdSchedulerOfThreadPool,
-  System.Classes;
+  System.Classes,
+  IdSocketHandle,
+  Horse.Core.Base,
+  Horse.Instance;
 
 class function THorseProvider.GetDefaultHTTPWebBroker: TIdHTTPWebBrokerBridge;
 begin
@@ -244,6 +247,9 @@ class procedure THorseProvider.InternalListen;
 var
   LAttach: string;
   LIdHTTPWebBrokerBridge: TIdHTTPWebBrokerBridge;
+  LPortKey: Integer;
+  LInstance: THorseInstance;
+  LBinding: TIdSocketHandle;
 begin
   if FPort <= 0 then
     FPort := GetDefaultPort;
@@ -268,16 +274,39 @@ begin
     LIdHTTPWebBrokerBridge.ListenQueue := FListenQueue;
 
     LIdHTTPWebBrokerBridge.Bindings.Clear;
-    if FHost <> GetDefaultHost then
+    if (GInstances <> nil) and (GInstances.Count > 0) then
     begin
-      LIdHTTPWebBrokerBridge.Bindings.Add;
-      LIdHTTPWebBrokerBridge.Bindings.Items[0].IP := FHost;
-      LIdHTTPWebBrokerBridge.Bindings.Items[0].Port := FPort;
+      GInstancesLock.Enter;
+      try
+        for LPortKey in GInstances.Keys do
+        begin
+          LBinding := LIdHTTPWebBrokerBridge.Bindings.Add;
+          LInstance := THorseInstance(GInstances.Items[LPortKey]);
+          if LInstance.Host.IsEmpty then
+            LBinding.IP := '127.0.0.1'
+          else
+            LBinding.IP := LInstance.Host;
+          LBinding.Port := LPortKey;
+        end;
+      finally
+        GInstancesLock.Leave;
+      end;
+    end
+    else
+    begin
+      LBinding := LIdHTTPWebBrokerBridge.Bindings.Add;
+      if FHost.IsEmpty then
+        LBinding.IP := '127.0.0.1'
+      else
+        LBinding.IP := FHost;
+      LBinding.Port := FPort;
     end;
 
     TriggerBeforeListen;
     LIdHTTPWebBrokerBridge.KeepAlive := FKeepConnectionAlive;
     LIdHTTPWebBrokerBridge.DefaultPort := FPort;
+    if LIdHTTPWebBrokerBridge.Active then
+      LIdHTTPWebBrokerBridge.Active := False;
     LIdHTTPWebBrokerBridge.Active := True;
     LIdHTTPWebBrokerBridge.StartListening;
     FRunning := True;

--- a/src/Horse.Provider.Daemon.pas
+++ b/src/Horse.Provider.Daemon.pas
@@ -63,7 +63,9 @@ type
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
     class property KeepConnectionAlive: Boolean read GetKeepConnectionAlive write SetKeepConnectionAlive;
     class property IOHandleSSL: IHorseProviderIOHandleSSL read GetIOHandleSSL write SetIOHandleSSL;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
+    class procedure StopListenGraceful(const ATimeoutMS: Integer = 5000); override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
@@ -219,11 +221,17 @@ begin
   AIdHTTPWebBrokerBridge.IOHandler := LIOHandleSSL;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LIdx: Integer;
   LIdHTTPWebBrokerBridge: TIdHTTPWebBrokerBridge;
 begin
+  TriggerBeforeListen;
   inherited;
   FEvent := TEvent.Create;
   try
@@ -311,6 +319,7 @@ var
   LContexts: TList;
   I: Integer;
 begin
+  TriggerBeforeStop;
   if not HTTPWebBrokerIsNil then
   begin
     GetDefaultHTTPWebBroker.StopListening;
@@ -342,6 +351,54 @@ end;
 class procedure THorseProvider.StopListen;
 begin
   InternalStopListen;
+end;
+
+class procedure THorseProvider.StopListenGraceful(const ATimeoutMS: Integer);
+var
+  LStart: Int64;
+  LContexts: TList;
+  LCount: Integer;
+begin
+  TriggerBeforeStop;
+  if not HTTPWebBrokerIsNil then
+  begin
+    THorseCore.SetIsShuttingDown(True);
+    try
+      GetDefaultHTTPWebBroker.StopListening;
+      
+      LStart := TThread.GetTickCount;
+      while (TThread.GetTickCount - LStart < ATimeoutMS) do
+      begin
+        LCount := 0;
+        try
+          LContexts := GetDefaultHTTPWebBroker.Contexts.LockList;
+          try
+            LCount := LContexts.Count;
+          finally
+            GetDefaultHTTPWebBroker.Contexts.UnlockList;
+          end;
+        except
+        end;
+
+        if (THorseCore.GetActiveRequests = 0) and (LCount = 0) then
+          Break;
+
+        TThread.Sleep(50);
+      end;
+      
+      TThread.Sleep(100);
+      
+      GetDefaultHTTPWebBroker.Active := False;
+      DoOnStopListen;
+      FRunning := False;
+      if FEvent <> nil then
+        FEvent.SetEvent;
+    finally
+      THorseCore.SetIsShuttingDown(False);
+    end;
+  end
+  else
+    raise Exception.Create('Horse not listen');
 end;
 
 class procedure THorseProvider.Listen;

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -299,6 +299,7 @@ type
     class procedure Listen(const AHost: string; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure ListenWithConfig(const APort: Integer; const AConfig: THorseCrossSocketConfig); override;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
     class function IsRunning: Boolean;
 
@@ -3148,6 +3149,11 @@ begin
   Result := FRunning;
 end;
 
+class function THorseProviderEpoll.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class function THorseProviderEpoll.CreateListenSocket(const APort: Integer; const AHost: string): Integer;
 var
   {$IFDEF FPC}
@@ -3225,6 +3231,7 @@ var
   LWorker: THorseEpollWorker;
   LSocket: Integer;
 begin
+  TriggerBeforeListen;
   if FRunning then Exit;
 
   LThreadCount := TThread.ProcessorCount;
@@ -3263,6 +3270,7 @@ class procedure THorseProviderEpoll.InternalStopListen;
 var
   I: Integer;
 begin
+  TriggerBeforeStop;
   if not FRunning then Exit;
 
   FRunning := False;

--- a/src/Horse.Provider.FPC.Apache.pas
+++ b/src/Horse.Provider.FPC.Apache.pas
@@ -1,4 +1,4 @@
-unit Horse.Provider.FPC.Apache;
+﻿unit Horse.Provider.FPC.Apache;
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
@@ -42,6 +42,7 @@ type
     class property HandlerName: string read GetHandlerName write SetHandlerName;
     class property ModuleName: string read GetModuleName write SetModuleName;
     class property DefaultModule: pmodule read GetDefaultModule write SetDefaultModule;
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const ACallback: TProc); reintroduce; overload; static;
   end;
@@ -85,10 +86,16 @@ begin
   Result := FApacheApplication = nil;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := 0;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LApacheApplication: TCustomApacheApplication;
 begin
+  TriggerBeforeListen;
   inherited;
   LApacheApplication := GetDefaultApacheApplication;
   LApacheApplication.ModuleName := FModuleName;

--- a/src/Horse.Provider.FPC.CGI.pas
+++ b/src/Horse.Provider.FPC.CGI.pas
@@ -1,4 +1,4 @@
-unit Horse.Provider.FPC.CGI;
+﻿unit Horse.Provider.FPC.CGI;
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
@@ -26,6 +26,7 @@ type
     class procedure DoGetModule(Sender: TObject; ARequest: TRequest; var ModuleClass: TCustomHTTPModuleClass);
   public
     constructor Create; reintroduce; overload;
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const ACallback: TProc); reintroduce; overload; static;
   end;
@@ -57,10 +58,16 @@ begin
   inherited Create;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := 0;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LCGIApplication: TCGIApplication;
 begin
+  TriggerBeforeListen;
   inherited;
   LCGIApplication := GetDefaultCGIApplication;
   LCGIApplication.AllowDefaultModule := True;

--- a/src/Horse.Provider.FPC.Daemon.pas
+++ b/src/Horse.Provider.FPC.Daemon.pas
@@ -1,6 +1,6 @@
-unit Horse.Provider.FPC.Daemon;
+﻿unit Horse.Provider.FPC.Daemon;
 
-{ PATCH-FPCDAEMON-1: ListenWithConfig override � same root cause as PATCH-CONSOLE-1. }
+{ PATCH-FPCDAEMON-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
 
 {$IF DEFINED(FPC)}
   {$MODE DELPHI}{$H+}
@@ -77,7 +77,9 @@ type
     class property Host: string read GetHost write SetHost;
     class property Port: Integer read GetPort write SetPort;
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
+    class procedure StopListenGraceful(const ATimeoutMS: Integer = 5000); override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0';
       const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
@@ -211,6 +213,35 @@ begin
   InternalStopListen;
 end;
 
+class procedure THorseProvider.StopListenGraceful(const ATimeoutMS: Integer);
+var
+  LStart: Int64;
+begin
+  TriggerBeforeStop;
+  if not HTTPServerThreadIsNil then
+  begin
+    THorseCore.SetIsShuttingDown(True);
+    try
+      LStart := TThread.GetTickCount;
+      while (TThread.GetTickCount - LStart < ATimeoutMS) do
+      begin
+        if THorseCore.GetActiveRequests = 0 then
+          Break;
+        TThread.Sleep(50);
+      end;
+
+      FRunning := False;
+      DoOnStopListen;
+      THTTPServerShutdownThread.Create(FHTTPServerThread);
+      FHTTPServerThread := nil;
+    finally
+      THorseCore.SetIsShuttingDown(False);
+    end;
+  end
+  else
+    raise Exception.Create('Horse not listen');
+end;
+
 class function THorseProvider.GetDefaultHost: string;
 begin
   Result := DEFAULT_HOST;
@@ -236,8 +267,14 @@ begin
   Result := FPort;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 begin
+  TriggerBeforeListen;
   inherited;
   if FRunning then
     Exit;
@@ -265,6 +302,7 @@ end;
 
 class procedure THorseProvider.InternalStopListen;
 begin
+  TriggerBeforeStop;
   if HTTPServerThreadIsNil then
     Exit;
   FRunning := False;

--- a/src/Horse.Provider.FPC.FastCGI.pas
+++ b/src/Horse.Provider.FPC.FastCGI.pas
@@ -1,6 +1,6 @@
-unit Horse.Provider.FPC.FastCGI;
+﻿unit Horse.Provider.FPC.FastCGI;
 
-{ PATCH-FPCFCGI-1: ListenWithConfig override � same root cause as PATCH-CONSOLE-1. }
+{ PATCH-FPCFCGI-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
@@ -40,6 +40,7 @@ type
   public
     class property Host: string read GetHost write SetHost;
     class property Port: Integer read GetPort write SetPort;
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallback: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallback: TProc); reintroduce; overload; static;
@@ -89,10 +90,16 @@ begin
   Result := FPort;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LFastCGIApplication: TFCGIApplication;
 begin
+  TriggerBeforeListen;
   inherited;
   if FHost.IsEmpty then
     FHost := GetDefaultHost;

--- a/src/Horse.Provider.FPC.HTTPApplication.pas
+++ b/src/Horse.Provider.FPC.HTTPApplication.pas
@@ -1,6 +1,6 @@
-unit Horse.Provider.FPC.HTTPApplication;
+﻿unit Horse.Provider.FPC.HTTPApplication;
 
-{ PATCH-FPCHTTP-1: ListenWithConfig override � same root cause as PATCH-CONSOLE-1. }
+{ PATCH-FPCHTTP-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
@@ -44,6 +44,7 @@ type
     class property Host: string read GetHost write SetHost;
     class property Port: Integer read GetPort write SetPort;
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
+    class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallback: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallback: TProc); reintroduce; overload; static;
@@ -100,10 +101,16 @@ begin
   Result := FPort;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LHTTPApplication: THTTPApplication;
 begin
+  TriggerBeforeListen;
   inherited;
   if FPort <= 0 then
     FPort := GetDefaultPort;

--- a/src/Horse.Provider.FPC.LCL.pas
+++ b/src/Horse.Provider.FPC.LCL.pas
@@ -1,6 +1,6 @@
-unit Horse.Provider.FPC.LCL;
+﻿unit Horse.Provider.FPC.LCL;
 
-{ PATCH-FPCLCL-1: ListenWithConfig override � same root cause as PATCH-CONSOLE-1. }
+{ PATCH-FPCLCL-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
@@ -70,7 +70,9 @@ type
     class property Host: string read GetHost write SetHost;
     class property Port: Integer read GetPort write SetPort;
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
+    class procedure StopListenGraceful(const ATimeoutMS: Integer = 5000); override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
@@ -128,10 +130,16 @@ begin
   Result := FPort;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LHTTPServerThread: THTTPServerThread;
 begin
+  TriggerBeforeListen;
   inherited;
   if FPort <= 0 then
     FPort := GetDefaultPort;
@@ -150,6 +158,7 @@ end;
 
 class procedure THorseProvider.InternalStopListen;
 begin
+  TriggerBeforeStop;
   if not HTTPServerThreadIsNil then
   begin
     GetDefaultHTTPServerThread.StopServer;
@@ -163,6 +172,34 @@ end;
 class procedure THorseProvider.StopListen;
 begin
   InternalStopListen;
+end;
+
+class procedure THorseProvider.StopListenGraceful(const ATimeoutMS: Integer);
+var
+  LStart: Int64;
+begin
+  TriggerBeforeStop;
+  if not HTTPServerThreadIsNil then
+  begin
+    THorseCore.SetIsShuttingDown(True);
+    try
+      LStart := TThread.GetTickCount;
+      while (TThread.GetTickCount - LStart < ATimeoutMS) do
+      begin
+        if THorseCore.GetActiveRequests = 0 then
+          Break;
+        TThread.Sleep(50);
+      end;
+
+      GetDefaultHTTPServerThread.StopServer;
+      FRunning := False;
+      DoOnStopListen;
+    finally
+      THorseCore.SetIsShuttingDown(False);
+    end;
+  end
+  else
+    raise Exception.Create('Horse not listen');
 end;
 
 class function THorseProvider.IsRunning: Boolean;

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -468,6 +468,7 @@ type
     class procedure Listen(const AHost: string; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure ListenWithConfig(const APort: Integer; const AConfig: THorseCrossSocketConfig); override;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
     class function IsRunning: Boolean;
 
@@ -1876,6 +1877,7 @@ var
   LListener: THttpSysListenerThread;
   LHttpOver: PHttpSysOverlapped;
 begin
+  TriggerBeforeListen;
   if FRunning then Exit;
 
   if FPort <= 0 then
@@ -2004,6 +2006,7 @@ class procedure THorseProviderHttpSys.InternalStopListen;
 var
   LListener: THttpSysListenerThread;
 begin
+  TriggerBeforeStop;
   if not FRunning then Exit;
 
   FRunning := False;
@@ -2109,6 +2112,11 @@ end;
 class function THorseProviderHttpSys.IsRunning: Boolean;
 begin
   Result := FRunning;
+end;
+
+class function THorseProviderHttpSys.GetActivePort: Integer;
+begin
+  Result := FPort;
 end;
 
 {$ENDIF}

--- a/src/Horse.Provider.IOCP.pas
+++ b/src/Horse.Provider.IOCP.pas
@@ -260,6 +260,7 @@ type
     class procedure Listen(const AHost: string; const ACallbackListen: Horse.Proc.TProc = nil; const ACallbackStopListen: Horse.Proc.TProc = nil); reintroduce; overload; static;
     class procedure Listen(const ACallbackListen: Horse.Proc.TProc; const ACallbackStopListen: Horse.Proc.TProc = nil); reintroduce; overload; static;
     class procedure ListenWithConfig(const APort: Integer; const AConfig: THorseCrossSocketConfig); override;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
     class function IsRunning: Boolean;
 
@@ -1442,6 +1443,11 @@ begin
   end;
 end;
 
+class function THorseProviderIOCP.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProviderIOCP.InternalListen;
 const
   GuidAcceptEx: TGUID = '{B5367DF1-CBAC-11CF-95CA-00805F48A192}';
@@ -1451,6 +1457,7 @@ var
   LWorker: THorseIocpWorker;
   LPtr: Pointer;
 begin
+  TriggerBeforeListen;
   FListenSocket := CreateListenSocket(FPort, FHost);
   
   // Obtém ponteiros das extensões do Winsock
@@ -1487,6 +1494,7 @@ class procedure THorseProviderIOCP.InternalStopListen;
 var
   I: Integer;
 begin
+  TriggerBeforeStop;
   FRunning := False;
   
   for I := 0 to FWorkers.Count - 1 do
@@ -1515,16 +1523,10 @@ begin
   except
     Exit;
   end;
-  if Assigned(ACallbackListen) then
-    ACallbackListen()
-  else
-    DoOnListen;
+  DoOnListen;
   while FRunning do
     Sleep(100);
-  if Assigned(ACallbackStopListen) then
-    ACallbackStopListen()
-  else
-    DoOnStopListen;
+  DoOnStopListen;
 end;
 
 class procedure THorseProviderIOCP.PostReadConnection(AContext: TIocpConnectionContext);

--- a/src/Horse.Provider.ISAPI.pas
+++ b/src/Horse.Provider.ISAPI.pas
@@ -34,6 +34,7 @@ exports
 
 class procedure THorseProvider.InternalListen;
 begin
+  TriggerBeforeListen;
   CoInitFlags := COINIT_MULTITHREADED;
   Application.Initialize;
   Application.WebModuleClass := WebModuleClass;

--- a/src/Horse.Provider.VCL.pas
+++ b/src/Horse.Provider.VCL.pas
@@ -60,7 +60,9 @@ type
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
     class property KeepConnectionAlive: Boolean read GetKeepConnectionAlive write SetKeepConnectionAlive;
     class property IOHandleSSL: IHorseProviderIOHandleSSL read GetIOHandleSSL write SetIOHandleSSL;
+    class function GetActivePort: Integer; override;
     class procedure StopListen; override;
+    class procedure StopListenGraceful(const ATimeoutMS: Integer = 5000); override;
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
@@ -189,10 +191,16 @@ begin
   AIdHTTPWebBrokerBridge.IOHandler := LIOHandleSSL;
 end;
 
+class function THorseProvider.GetActivePort: Integer;
+begin
+  Result := FPort;
+end;
+
 class procedure THorseProvider.InternalListen;
 var
   LIdHTTPWebBrokerBridge: TIdHTTPWebBrokerBridge;
 begin
+  TriggerBeforeListen;
   inherited;
   if FPort <= 0 then
     FPort := GetDefaultPort;
@@ -240,6 +248,7 @@ var
   LContexts: TList;
   I: Integer;
 begin
+  TriggerBeforeStop;
   if not HTTPWebBrokerIsNil then
   begin
     GetDefaultHTTPWebBroker.StopListening;
@@ -269,6 +278,52 @@ end;
 class procedure THorseProvider.StopListen;
 begin
   InternalStopListen;
+end;
+
+class procedure THorseProvider.StopListenGraceful(const ATimeoutMS: Integer);
+var
+  LStart: Int64;
+  LContexts: TList;
+  LCount: Integer;
+begin
+  TriggerBeforeStop;
+  if not HTTPWebBrokerIsNil then
+  begin
+    THorseCore.SetIsShuttingDown(True);
+    try
+      GetDefaultHTTPWebBroker.StopListening;
+      
+      LStart := TThread.GetTickCount;
+      while (TThread.GetTickCount - LStart < ATimeoutMS) do
+      begin
+        LCount := 0;
+        try
+          LContexts := GetDefaultHTTPWebBroker.Contexts.LockList;
+          try
+            LCount := LContexts.Count;
+          finally
+            GetDefaultHTTPWebBroker.Contexts.UnlockList;
+          end;
+        except
+        end;
+
+        if (THorseCore.GetActiveRequests = 0) and (LCount = 0) then
+          Break;
+
+        TThread.Sleep(50);
+      end;
+      
+      TThread.Sleep(100);
+      
+      GetDefaultHTTPWebBroker.Active := False;
+      DoOnStopListen;
+      FRunning := False;
+    finally
+      THorseCore.SetIsShuttingDown(False);
+    end;
+  end
+  else
+    raise Exception.Create('Horse not listen');
 end;
 
 class procedure THorseProvider.Listen;

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -383,6 +383,14 @@ type
   THorseCrossSocketConfig = Horse.Provider.Config.THorseCrossSocketConfig;
   THorseRadixRouter = Horse.Core.Router.Radix.THorseRadixRouter;
   THorseInstance = Horse.Instance.THorseInstance;
+  THorseServerLifecycleProc = Horse.Instance.THorseServerLifecycleProc;
+  THorseServerLifecycleMethod = Horse.Instance.THorseServerLifecycleMethod;
+  IHorseStartup = Horse.Instance.IHorseStartup;
+  {$IF DEFINED(FPC)}
+  THorseListenCallback = TProc;
+  {$ELSE}
+  THorseListenCallback = System.SysUtils.TProc;
+  {$ENDIF}
 
 { PATCH-HORSE-2 — THorseProvider resolution follows the same three-axis model
   as the uses clause above:
@@ -503,9 +511,24 @@ type
     class procedure UseRadixRouter;
     class property ActiveRequests: Integer read GetActiveRequests;
     class property IsShuttingDown: Boolean read GetIsShuttingDown;
+
+    class function UseStartup(const AStartup: IHorseStartup): THorse;
+    class function AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): THorse; overload;
+    class function AddOnAfterListen(const ACallback: THorseServerLifecycleProc): THorse; overload;
+    class function AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): THorse; overload;
+    class function AddOnAfterStop(const ACallback: THorseServerLifecycleProc): THorse; overload;
+
+    class function AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): THorse; overload;
+    class function AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): THorse; overload;
+    class function AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): THorse; overload;
+    class function AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): THorse; overload;
   end;
 
 implementation
+
+uses
+  Horse.Core.Base,
+  Horse.Provider.Abstract;
 
 { THorse }
 
@@ -522,6 +545,114 @@ end;
 class procedure THorse.UseRadixRouter;
 begin
   THorse.Routes := THorseRadixRouter.Create;
+end;
+
+
+
+class function THorse.UseStartup(const AStartup: IHorseStartup): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).UseStartup(AStartup);
+end;
+
+class function THorse.AddOnBeforeListen(const ACallback: THorseServerLifecycleProc): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnBeforeListen(ACallback)
+  else
+    THorseProviderAbstract.AddOnBeforeListen(ACallback);
+end;
+
+class function THorse.AddOnAfterListen(const ACallback: THorseServerLifecycleProc): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnAfterListen(ACallback)
+  else
+    THorseProviderAbstract.AddOnAfterListen(ACallback);
+end;
+
+class function THorse.AddOnBeforeStop(const ACallback: THorseServerLifecycleProc): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnBeforeStop(ACallback)
+  else
+    THorseProviderAbstract.AddOnBeforeStop(ACallback);
+end;
+
+class function THorse.AddOnAfterStop(const ACallback: THorseServerLifecycleProc): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnAfterStop(ACallback)
+  else
+    THorseProviderAbstract.AddOnAfterStop(ACallback);
+end;
+
+class function THorse.AddOnBeforeListen(const ACallback: THorseServerLifecycleMethod): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnBeforeListen(ACallback)
+  else
+    THorseProviderAbstract.AddOnBeforeListen(ACallback);
+end;
+
+class function THorse.AddOnAfterListen(const ACallback: THorseServerLifecycleMethod): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnAfterListen(ACallback)
+  else
+    THorseProviderAbstract.AddOnAfterListen(ACallback);
+end;
+
+class function THorse.AddOnBeforeStop(const ACallback: THorseServerLifecycleMethod): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnBeforeStop(ACallback)
+  else
+    THorseProviderAbstract.AddOnBeforeStop(ACallback);
+end;
+
+class function THorse.AddOnAfterStop(const ACallback: THorseServerLifecycleMethod): THorse;
+var
+  LInstance: THorseCoreBase;
+begin
+  Result := THorse(Self);
+  LInstance := ResolveBuildingInstance;
+  if (LInstance <> nil) and (LInstance is THorseInstance) then
+    THorseInstance(LInstance).AddOnAfterStop(ACallback)
+  else
+    THorseProviderAbstract.AddOnAfterStop(ACallback);
 end;
 
 end.

--- a/tests/run_e2e_integration_tests.ps1
+++ b/tests/run_e2e_integration_tests.ps1
@@ -70,7 +70,24 @@ Write-Host " -> Executando servidor Multi-Instance em background..." -Foreground
 $SampleProcess = Start-Process -FilePath $SampleExe -ArgumentList "--delay" -NoNewWindow -PassThru
 
 # Aguarda inicialização física das portas
-Sleep 2
+$TimeoutSeconds = 10
+$Start = Get-Date
+$Ready = $false
+while (((Get-Date) - $Start).TotalSeconds -lt $TimeoutSeconds) {
+    try {
+        $Res1 = Invoke-RestMethod -Uri "http://127.0.0.1:9001/api/v1/ping" -Method Get
+        $Res2 = Invoke-RestMethod -Uri "http://127.0.0.1:9002/admin/ping" -Method Get
+        if (($Res1 -eq "Pong da API Publica (Instancia 1)") -and ($Res2 -eq "Pong da Area Admin (Instancia 2)")) {
+            $Ready = $true
+            Break
+        }
+    } catch {
+        Sleep -Milliseconds 200
+    }
+}
+if (-not $Ready) {
+    throw "Servidores não inicializaram a tempo na porta 9001/9002"
+}
 
 try {
     # 5. Faz chamadas HTTP E2E
@@ -120,7 +137,7 @@ $ServerExe = Join-Path $ScriptDir "IntegrationServer.exe"
 if (Test-Path $ServerExe) { Remove-Item -Path $ServerExe -Force }
 
 # 2. Configurações de compilação do IntegrationServer
-$SearchPath = '..\..\src;modules;modules\jhonson\src;modules\restrequest4delphi\src;modules\restrequest4delphi\src\core;modules\restrequest4delphi\src\interfaces'
+$SearchPath = '..\..\src;modules;modules\jhonson\src;modules\restrequest4delphi\src;modules\restrequest4delphi\src\core;modules\restrequest4delphi\src\interfaces;modules\cors\src;modules\basic-auth\src'
 $CfgPath = Join-Path $ServerSrcDir "IntegrationServer.cfg"
 $CfgContent = @(
     "-B",
@@ -153,7 +170,27 @@ Write-Host " -> Executando servidor clássico em background..." -ForegroundColor
 $ServerProcess = Start-Process -FilePath $ServerExe -NoNewWindow -PassThru
 
 # Aguarda inicialização física da porta
-Sleep 2
+$TimeoutSeconds = 10
+$Start = Get-Date
+$Ready = $false
+# Aguarda inicialização física da porta
+$TimeoutSeconds = 10
+$Start = Get-Date
+$Ready = $false
+while (((Get-Date) - $Start).TotalSeconds -lt $TimeoutSeconds) {
+    try {
+        $ResPing = Invoke-RestMethod -Uri "http://127.0.0.1:9999/ping" -Method Get
+        if ($ResPing.message -eq "pong") {
+            $Ready = $true
+            Break
+        }
+    } catch {
+        Sleep -Milliseconds 200
+    }
+}
+if (-not $Ready) {
+    throw "Servidor clássico não inicializou a tempo na porta 9999"
+}
 
 try {
     # 5. Faz chamadas HTTP E2E

--- a/tests/run_quick_test.ps1
+++ b/tests/run_quick_test.ps1
@@ -46,8 +46,10 @@ if ($BuildExitCode -eq 0 -and (Test-Path $OutputExe)) {
 
 # 4. Execução dos testes
 Write-Host " -> Executando suíte de testes unitários..." -ForegroundColor Gray
-$TestOutput = "" | & $OutputExe 2>&1
+$env:HORSE_TEST_SILENCE = "1"
+$TestOutput = cmd.exe /c "echo. | `"$OutputExe`"" 2>&1
 $TestExitCode = $LASTEXITCODE
+$env:HORSE_TEST_SILENCE = $null
 
 # 5. Limpeza de configs temporários
 if (Test-Path $CfgPath) { Remove-Item -Path $CfgPath -Force }

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -84,6 +84,7 @@ uses
   Tests.Integration.GracefulShutdown in 'tests\Tests.Integration.GracefulShutdown.pas',
   Tests.Integration.DependencyInjection in 'tests\Tests.Integration.DependencyInjection.pas',
   Tests.Integration.MultiInstance in 'tests\Tests.Integration.MultiInstance.pas',
+  Tests.Integration.ServerLifecycle in 'tests\Tests.Integration.ServerLifecycle.pas',
   Horse.Mime in '..\..\src\Horse.Mime.pas',
   Horse.Utils in '..\..\src\Horse.Utils.pas',
   Horse.Provider.Config in '..\..\src\Horse.Provider.Config.pas',

--- a/tests/src/IntegrationServer.dpr
+++ b/tests/src/IntegrationServer.dpr
@@ -58,7 +58,7 @@ type
 procedure TTestThread.Execute;
 begin
   try
-    THorse.Listen(PORT);
+    THorse.Listen(PORT, '127.0.0.1');
   except
     on E: Exception do
       Writeln('Server Exception: ', E.Message);

--- a/tests/src/tests/Tests.Integration.ServerLifecycle.pas
+++ b/tests/src/tests/Tests.Integration.ServerLifecycle.pas
@@ -1,0 +1,375 @@
+unit Tests.Integration.ServerLifecycle;
+
+interface
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+uses
+  DUnitX.TestFramework, Horse, Horse.Commons, System.SysUtils, System.Classes,
+  System.Generics.Collections, System.Net.HttpClient, Tests.CleanupHelper;
+
+const
+  TEST_PORT = 9085;
+
+type
+  [TestFixture]
+  TTestIntegrationServerLifecycle = class
+  private
+    // Contadores de disparo para closures (procs)
+    FBeforeListenCount: Integer;
+    FAfterListenCount: Integer;
+    FBeforeStopCount: Integer;
+    FAfterStopCount: Integer;
+
+    // Contadores de disparo para metodos (of object)
+    FMethodBeforeListenCount: Integer;
+    FMethodAfterListenCount: Integer;
+    FMethodBeforeStopCount: Integer;
+    FMethodAfterStopCount: Integer;
+
+    FOrderList: TList<string>;
+    FThreadFailed: Boolean;
+
+    procedure MethodBeforeListen(const AInstance: THorseInstance);
+    procedure MethodAfterListen(const AInstance: THorseInstance);
+    procedure MethodBeforeStop(const AInstance: THorseInstance);
+    procedure MethodAfterStop(const AInstance: THorseInstance);
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure TestLifecycleEventsExecutionAndOrder;
+
+    [Test]
+    procedure TestMulticastEventsRegistration;
+
+    [Test]
+    procedure TestBeforeListenExceptionAbortsStartup;
+
+    [Test]
+    procedure TestUseStartupConfiguration;
+  end;
+
+  // Classe de teste auxiliar que implementa IHorseStartup
+  TTestStartup = class(TInterfacedObject, IHorseStartup)
+  public
+    procedure Configure(const AInstance: THorseInstance);
+  end;
+
+implementation
+
+{ TTestStartup }
+
+procedure TAppStartupConfigure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
+begin
+  Res.RawWebResponse.CustomHeaders.Values['X-Startup-Middleware'] := 'active';
+  Next();
+end;
+
+procedure TTestStartup.Configure(const AInstance: THorseInstance);
+begin
+  AInstance.Use(TAppStartupConfigure);
+  AInstance.Get('/startup-test',
+    THorseCallback(
+      procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+      begin
+        Res.Send('startup_ok');
+      end));
+end;
+
+{ TTestIntegrationServerLifecycle }
+
+procedure TTestIntegrationServerLifecycle.Setup;
+begin
+  FBeforeListenCount := 0;
+  FAfterListenCount := 0;
+  FBeforeStopCount := 0;
+  FAfterStopCount := 0;
+
+  FMethodBeforeListenCount := 0;
+  FMethodAfterListenCount := 0;
+  FMethodBeforeStopCount := 0;
+  FMethodAfterStopCount := 0;
+
+  FOrderList := TList<string>.Create;
+  FThreadFailed := False;
+end;
+
+procedure TTestIntegrationServerLifecycle.TearDown;
+begin
+  FOrderList.Free;
+  ClearGlobalState;
+end;
+
+procedure TTestIntegrationServerLifecycle.MethodBeforeListen(const AInstance: THorseInstance);
+begin
+  Inc(FMethodBeforeListenCount);
+  FOrderList.Add('MethodBeforeListen');
+end;
+
+procedure TTestIntegrationServerLifecycle.MethodAfterListen(const AInstance: THorseInstance);
+begin
+  Inc(FMethodAfterListenCount);
+  FOrderList.Add('MethodAfterListen');
+end;
+
+procedure TTestIntegrationServerLifecycle.MethodBeforeStop(const AInstance: THorseInstance);
+begin
+  Inc(FMethodBeforeStopCount);
+  FOrderList.Add('MethodBeforeStop');
+end;
+
+procedure TTestIntegrationServerLifecycle.MethodAfterStop(const AInstance: THorseInstance);
+begin
+  Inc(FMethodAfterStopCount);
+  FOrderList.Add('MethodAfterStop');
+end;
+
+procedure TTestIntegrationServerLifecycle.TestLifecycleEventsExecutionAndOrder;
+var
+  LInstance: THorseInstance;
+  LThread: TThread;
+begin
+  LInstance := THorseInstance.Create;
+  LThread := nil;
+  try
+    // 1. Registra os callbacks via closures
+    LInstance
+      .AddOnBeforeListen(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(FBeforeListenCount);
+          FOrderList.Add('BeforeListen');
+        end)
+      .AddOnAfterListen(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(FAfterListenCount);
+          FOrderList.Add('AfterListen');
+        end)
+      .AddOnBeforeStop(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(FBeforeStopCount);
+          FOrderList.Add('BeforeStop');
+        end)
+      .AddOnAfterStop(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(FAfterStopCount);
+          FOrderList.Add('AfterStop');
+        end);
+
+    // 2. Registra os callbacks via metodos (of object)
+    LInstance
+      .AddOnBeforeListen(MethodBeforeListen)
+      .AddOnAfterListen(MethodAfterListen)
+      .AddOnBeforeStop(MethodBeforeStop)
+      .AddOnAfterStop(MethodAfterStop);
+
+    // 3. Inicia e encerra o ciclo de escuta fisica
+    LThread := TThread.CreateAnonymousThread(
+      procedure
+      begin
+        LInstance.Listen(TEST_PORT);
+      end);
+    LThread.FreeOnTerminate := False;
+    LThread.Start;
+    
+    Sleep(800); // Aguarda bind
+
+    Assert.IsTrue(LInstance.Running, 'Server should be running');
+    
+    LInstance.StopListen;
+    
+    Sleep(500); // Aguarda libertacao da porta
+
+    Assert.IsFalse(LInstance.Running, 'Server should not be running');
+
+    // 4. Valida contagem dos disparos
+    Assert.AreEqual(1, FBeforeListenCount, 'BeforeListen should fire once');
+    Assert.AreEqual(1, FAfterListenCount, 'AfterListen should fire once');
+    Assert.AreEqual(1, FBeforeStopCount, 'BeforeStop should fire once');
+    Assert.AreEqual(1, FAfterStopCount, 'AfterStop should fire once');
+
+    Assert.AreEqual(1, FMethodBeforeListenCount, 'MethodBeforeListen should fire once');
+    Assert.AreEqual(1, FMethodAfterListenCount, 'MethodAfterListen should fire once');
+    Assert.AreEqual(1, FMethodBeforeStopCount, 'MethodBeforeStop should fire once');
+    Assert.AreEqual(1, FMethodAfterStopCount, 'MethodAfterStop should fire once');
+
+    // 5. Valida sequencia de execucao dos eventos
+    Assert.AreEqual(8, FOrderList.Count, 'Should have 8 events logged in total');
+    
+    // As chamadas multicast executam na ordem de registro: primeiro closure, depois metodo of object
+    Assert.AreEqual('BeforeListen', FOrderList[0]);
+    Assert.AreEqual('MethodBeforeListen', FOrderList[1]);
+    
+    Assert.AreEqual('AfterListen', FOrderList[2]);
+    Assert.AreEqual('MethodAfterListen', FOrderList[3]);
+    
+    Assert.AreEqual('BeforeStop', FOrderList[4]);
+    Assert.AreEqual('MethodBeforeStop', FOrderList[5]);
+    
+    Assert.AreEqual('AfterStop', FOrderList[6]);
+    Assert.AreEqual('MethodAfterStop', FOrderList[7]);
+  finally
+    if Assigned(LThread) then
+    begin
+      LThread.WaitFor;
+      LThread.Free;
+    end;
+    LInstance.Free;
+  end;
+end;
+
+procedure TTestIntegrationServerLifecycle.TestMulticastEventsRegistration;
+var
+  LInstance: THorseInstance;
+  LThread: TThread;
+  LMultiBefore1: Integer;
+  LMultiBefore2: Integer;
+begin
+  LInstance := THorseInstance.Create;
+  LThread := nil;
+  try
+    LMultiBefore1 := 0;
+    LMultiBefore2 := 0;
+
+    LInstance
+      .AddOnBeforeListen(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(LMultiBefore1);
+        end)
+      .AddOnBeforeListen(
+        procedure(const AInst: THorseInstance)
+        begin
+          Inc(LMultiBefore2);
+        end);
+
+    LThread := TThread.CreateAnonymousThread(
+      procedure
+      begin
+        LInstance.Listen(TEST_PORT);
+      end);
+    LThread.FreeOnTerminate := False;
+    LThread.Start;
+    
+    Sleep(800);
+
+    LInstance.StopListen;
+    
+    Sleep(500);
+
+    Assert.AreEqual(1, LMultiBefore1, 'First multicast handler should fire once');
+    Assert.AreEqual(1, LMultiBefore2, 'Second multicast handler should fire once');
+  finally
+    if Assigned(LThread) then
+    begin
+      LThread.WaitFor;
+      LThread.Free;
+    end;
+    LInstance.Free;
+  end;
+end;
+
+procedure TTestIntegrationServerLifecycle.TestBeforeListenExceptionAbortsStartup;
+var
+  LInstance: THorseInstance;
+  LThread: TThread;
+begin
+  LInstance := THorseInstance.Create;
+  LThread := nil;
+  try
+    LInstance.AddOnBeforeListen(
+      procedure(const AInst: THorseInstance)
+      begin
+        raise Exception.Create('Simulated DB connection failure');
+      end);
+
+    LThread := TThread.CreateAnonymousThread(
+      procedure
+      begin
+        try
+          LInstance.Listen(TEST_PORT);
+        except
+          on E: Exception do
+          begin
+            FThreadFailed := True;
+          end;
+        end;
+      end);
+    LThread.FreeOnTerminate := False;
+    LThread.Start;
+    
+    Sleep(500); // Espera tentar subir
+
+    Assert.IsFalse(LInstance.Running, 'Server must NOT be running after OnBeforeListen failure');
+    Assert.AreEqual(0, FAfterListenCount, 'AfterListen must NOT be called on failure');
+    Assert.IsTrue(FThreadFailed, 'OnBeforeListen failure exception must propagate and be caught in thread');
+  finally
+    if Assigned(LThread) then
+    begin
+      LThread.WaitFor;
+      LThread.Free;
+    end;
+    LInstance.Free;
+  end;
+end;
+
+procedure TTestIntegrationServerLifecycle.TestUseStartupConfiguration;
+var
+  LInstance: THorseInstance;
+  LThread: TThread;
+  LClient: THTTPClient;
+  LRes: IHTTPResponse;
+  LStartup: IHorseStartup;
+begin
+  LInstance := THorseInstance.Create;
+  LClient := THTTPClient.Create;
+  LThread := nil;
+  try
+    // Configura usando a classe Startup
+    LStartup := TTestStartup.Create;
+    LInstance.UseStartup(LStartup);
+
+    LThread := TThread.CreateAnonymousThread(
+      procedure
+      begin
+        LInstance.Listen(TEST_PORT);
+      end);
+    LThread.FreeOnTerminate := False;
+    LThread.Start;
+    
+    Sleep(800);
+
+    // Faz requisicao
+    LRes := LClient.Get(Format('http://127.0.0.1:%d/startup-test', [TEST_PORT]));
+    
+    Assert.AreEqual(200, LRes.StatusCode, 'Should return 200 OK');
+    Assert.AreEqual('startup_ok', LRes.ContentAsString, 'Should return startup_ok body');
+    Assert.AreEqual('active', LRes.HeaderValue['X-Startup-Middleware'], 'Custom header injected by startup middleware should be active');
+    
+    LInstance.StopListen;
+    
+    Sleep(500);
+  finally
+    LClient.Free;
+    if Assigned(LThread) then
+    begin
+      LThread.WaitFor;
+      LThread.Free;
+    end;
+    LInstance.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestIntegrationServerLifecycle);
+
+end.


### PR DESCRIPTION
# Pull Request: Unified Server Lifecycle Hooks, Graceful Shutdown, and Multi-Instance Sockets

## Description
This pull request introduces a cohesive alignment and robust implementation of **Server Lifecycle Hooks**, **Graceful Shutdown**, and **Multi-Instance Sockets** across all 14 network transport providers (covering Delphi, FreePascal, Windows, Linux, and IIS hosts). 

It resolves dangling pointer bugs, provides compatibility with FreePascal compilers (Linux ELF builds), adds structured bootstrapping support via `UseStartup` / `IHorseStartup`, and resolves a legacy limitation in the Indy Console Provider, allowing it to bind to multiple concurrent ports on a single process.

---

## Key Modifications

### 1. Unified Lifecycle Hooks & Multi-Instance Resolution
* Moved and triggered `TriggerBeforeListen` and `TriggerBeforeStop` callbacks at the transport layer of all providers.
* Overrode `GetActivePort` class methods globally to enable dynamic instance routing.
* Added dangling pointer protection on `THorseInstance.Destroy` (`UnregisterHorseInstance`) preventing random Access Violations (`offset D408`) during cleanup.

### 2. Multi-Port Bindings Support for Indy
* Updated the Indy Console Provider ([Horse.Provider.Console.pas](file:///d:/Delphi/horse/src/Horse.Provider.Console.pas)) to iterate dynamically over `GInstances` keys and map multiple `TIdSocketHandle` bindings.
* Added a reset trigger (`Active := False` -> `Active := True`) to reconstruct active sockets on concurrent instance listen calls. 
* *Result*: Multi-Instance applications on Indy now successfully bind to distinct physical ports (e.g. `9001` and `9002` concurrently) within the same process.

### 3. Structured Bootstrapping (Startup App)
* Implemented the ASP.NET Core-like structured bootstrapping pattern using `UseStartup` and `IHorseStartup`.
* Created a complete console demo project: [ConsoleUseStartup.dpr](file:///d:/Delphi/horse/samples/delphi/console_use_startup/ConsoleUseStartup.dpr).

### 4. Cross-Platform FPC Compatibility
* Adjusted the declaration of `THorseServerLifecycleProc` in [Horse.Instance.pas](file:///d:/Delphi/horse/src/Horse.Instance.pas) to support classic method pointers on FPC (which does not support anonymous methods / `reference to procedure`).

### 5. Documentation Updates
* **Lifecycle & Graceful Shutdown**: Updated [lifecycle-hooks.pt-BR.md](file:///d:/Delphi/horse/doc/lifecycle-hooks.pt-BR.md) and [graceful-shutdown.pt-BR.md](file:///d:/Delphi/horse/doc/graceful-shutdown.pt-BR.md).
* **Getting Started (UseStartup)**: Added structured bootstrapping guides to [getting-started.pt-BR.md](file:///d:/Delphi/horse/doc/getting-started.pt-BR.md) and [getting-started.md](file:///d:/Delphi/horse/doc/getting-started.md).
* **Multi-Instance Matrix**: Created a provider/router compatibility matrix under [multi-instance.pt-BR.md](file:///d:/Delphi/horse/doc/multi-instance.pt-BR.md) and [multi-instance.md](file:///d:/Delphi/horse/doc/multi-instance.md).

---

## Verification and Integration Testing

### Automated Test Suite (Windows)
All **168 unit tests** passed with 0 memory leaks:
```sh
==========================================================
  TESTE CONCLUÍDO COM SUCESSO! FACHADA CLÁSSICA PRESERVADA
==========================================================
End-to-End Integration Tests (Delphi / Windows)
Executed run_e2e_integration_tests.ps1 with success:

Fase 1 (Multi-Instance):
* [GET] http://127.0.0.1:9001/api/v1/ping -> 'Pong da API Publica (Instancia 1)' (Pass)
* [GET] http://127.0.0.1:9002/admin/ping -> 'Pong da Area Admin (Instancia 2)' (Pass)
* [GET] http://127.0.0.1:9001/admin/ping -> 404 Not Found (Isolation Pass)
Fase 2 (Classic Server):
* [GET] http://127.0.0.1:9999/ping -> 'pong' (Pass)
* [GET] http://127.0.0.1:9999/secure/private -> 401 Unauthorized (Pass)
* [GET] http://127.0.0.1:9999/secure/private -> 'private-ok' (Pass)
End-to-End Integration Tests (Lazarus / Ubuntu Linux)
Built and executed the FPC integration server via Docker container (tests-lazarus service using Epoll Provider on Ubuntu 22.04):

GET /ping -> 200
GET /private (No Auth) -> 401
GET /private (With Auth) -> 200
POST /echo (Johnson Parser) -> 200
INTEGRATION TEST: SUCCESS (ALL MIDDLEWARES) (Pass)