### PR TITLE
feat(core): centralize and optimize memory buffering using IMemoryBuf…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The full guide lives in [`doc/`](./doc/index.md) — a small wiki that complemen
 | Request lifecycle hooks — onRequest, preParsing, preValidation, onSend, onResponse | [Lifecycle Hooks](./doc/lifecycle-hooks.md) |
 | Graceful Shutdown — draining active connections, telemetry ActiveRequests and flag IsShuttingDown | [Graceful Shutdown](./doc/graceful-shutdown.md) |
 | Multi-Instance — running and isolating multiple independent HTTP servers concurrently inside the same process | [Multi-Instance](./doc/multi-instance.md) |
+| Memory Buffer Pool — high-performance thread-safe buffer recycling to eliminate heap allocation | [Memory Buffer Pool](./doc/memory-buffer-pool.md) |
 | **Writing & publishing your own middleware** — skeleton, thread safety, Provider neutrality, Boss packaging | [**Writing a Middleware**](./doc/writing-middleware.md) |
 | **Choosing a transport provider** — Indy (default), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.md) |
 | **Deploy** as Console / VCL / Daemon / Windows Service / LCL / HTTPApplication — one-page recipe | [**Deployment Cheatsheet**](./doc/deployment.md) |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -74,6 +74,7 @@ O guia completo fica em [`doc/`](./doc/index.pt-BR.md) — um pequeno wiki que c
 | Ganchos de Ciclo de Vida — onRequest, preParsing, preValidation, onSend, onResponse | [Ganchos de Ciclo de Vida](./doc/lifecycle-hooks.pt-BR.md) |
 | Desligamento Suave (Graceful Shutdown) — escoamento de tráfego, telemetria ActiveRequests e IsShuttingDown | [Desligamento Suave](./doc/graceful-shutdown.pt-BR.md) |
 | Multi-Instance — executar e isolar múltiplos servidores HTTP independentes concorrentemente dentro do mesmo processo | [Multi-Instance](./doc/multi-instance.pt-BR.md) |
+| Pool de Buffers — otimização de memória usando reciclagem de buffers thread-safe para eliminar alocações de heap | [Pool de Buffers](./doc/memory-buffer-pool.pt-BR.md) |
 | **Criar e publicar o seu próprio middleware** — esqueleto, thread safety, neutralidade de Provider, empacotamento Boss | [**Criando um Middleware**](./doc/writing-middleware.pt-BR.md) |
 | **Escolher um provider de transporte** — Indy (padrão), CrossSocket, mORMot2, ICS, HttpSys, Apache, ISAPI, CGI, daemons | [**Providers**](./doc/providers.pt-BR.md) |
 | **Deploy** como Console / VCL / Daemon / Serviço Windows / LCL / HTTPApplication — receita de uma página | [**Cheatsheet de Deploy**](./doc/deployment.pt-BR.md) |

--- a/doc/index.md
+++ b/doc/index.md
@@ -45,6 +45,7 @@ graph TD
 | [Dependency Injection](./dependency-injection.md) | Lifecycle management and IoC on request scope (direct and lazy injectors). |
 | [Graceful Shutdown](./graceful-shutdown.md) | Coordinated connection shutdown in production environments (cloud/Kubernetes); telemetry properties `ActiveRequests` and flag `IsShuttingDown`. |
 | [Multi-Instance](./multi-instance.md) | Run and isolate multiple independent HTTP servers, routing tables, and middlewares on different ports concurrently within the same process. |
+| [Memory Buffer Pool](./memory-buffer-pool.md) | High-performance memory optimization using thread-safe buffer recycling to eliminate heap allocation. |
 | [Writing a Middleware](./writing-middleware.md) | Authoring a production-quality middleware: skeleton, configuration patterns, thread safety, Provider-neutral coding, cross-compiler pitfalls, testing matrix, Boss packaging, publishing. |
 | [Providers & Application types](./providers.md) | The two-axis model: **Provider** (transport — Indy default; CrossSocket, mORMot2, ICS optional; HttpSys, epoll and IOCP built-in) × **Application type** (Console / VCL / Daemon / LCL / HTTPApplication, plus host-managed Apache / ISAPI / CGI / FCGI). Compatibility matrix and selection guidance. |
 | [Middleware Ecosystem](./middleware-ecosystem.md) | Official `HashLoad/*` packages and the community-maintained list. |
@@ -67,6 +68,7 @@ doc/
 ├── dependency-injection.md    ← contextual dependency injection on request scope
 ├── graceful-shutdown.md       ← graceful connection shutdown in production
 ├── multi-instance.md          ← running multiple concurrent servers
+├── memory-buffer-pool.md      ← memory buffer pooling and recycling
 ├── providers.md               ← choosing a transport
 ├── iocp.md                    ← Windows async I/O completion ports
 ├── epoll.md                   ← Linux async event loop

--- a/doc/index.pt-BR.md
+++ b/doc/index.pt-BR.md
@@ -45,6 +45,7 @@ graph TD
 | [Injeção de Dependência](./dependency-injection.pt-BR.md) | Gerenciamento de ciclo de vida e IoC no request scope (injetores direct e lazy). |
 | [Desligamento Suave](./graceful-shutdown.pt-BR.md) | Encerramento coordenado de conexões em ambientes produtivos (nuvem/Kubernetes); propriedades de telemetria `ActiveRequests` e flag `IsShuttingDown`. |
 | [Multi-Instance](./multi-instance.pt-BR.md) | Executa e isola múltiplos servidores HTTP independentes, tabelas de rotas e middlewares em portas diferentes simultaneamente no mesmo processo. |
+| [Pool de Buffers](./memory-buffer-pool.pt-BR.md) | Otimização de memória de alta performance usando reciclagem de buffers thread-safe para eliminar alocações de heap. |
 | [Criando um Middleware](./writing-middleware.pt-BR.md) | Criando um middleware de qualidade de produção: esqueleto, padrões de configuração, thread safety, código neutro a Provider, armadilhas entre compiladores, matriz de testes, empacotamento Boss, publicação. |
 | [Providers e Tipos de aplicação](./providers.pt-BR.md) | O modelo de dois eixos: **Provider** (transporte — Indy padrão; CrossSocket, mORMot2, ICS opcionais; HttpSys, epoll e IOCP embutidos) × **Tipo de aplicação** (Console / VCL / Daemon / LCL / HTTPApplication, mais host-managed Apache / ISAPI / CGI / FCGI). Matriz de compatibilidade e guia de escolha. |
 | [Ecossistema de Middlewares](./middleware-ecosystem.pt-BR.md) | Pacotes oficiais `HashLoad/*` e a lista mantida pela comunidade. |
@@ -67,6 +68,7 @@ doc/
 ├── dependency-injection.*.md  ← injeção de dependências no request scope
 ├── graceful-shutdown.*.md     ← desligamento suave em produção
 ├── multi-instance.*.md        ← execução de múltiplos servidores concorrentes
+├── memory-buffer-pool.*.md    ← pool de buffers de memória e reciclagem
 ├── providers.*.md             ← escolha de transporte
 ├── iocp.*.md                  ← portas de conclusão assíncronas (Windows)
 ├── epoll.*.md                 ← laço de eventos assíncronos (Linux)

--- a/doc/memory-buffer-pool.md
+++ b/doc/memory-buffer-pool.md
@@ -1,0 +1,77 @@
+# Memory Buffer Pooling
+
+Memory Buffer Pooling in Horse is a high-performance optimization designed to minimize memory allocation overhead (heap churn) and GC/Memory Manager lock contention under heavy concurrent workloads.
+
+## 💡 The Problem
+
+Normally, web frameworks allocate new memory structures for every HTTP request and response payload (using `TMemoryStream` or `TBytesStream`). In highly concurrent Delphi/FPC web applications, continuous allocation and deallocation (`GetMem`/`FreeMem`) can lead to:
+1. **Heap Fragmentation:** Splitting physical memory into tiny blocks.
+2. **Lock Contention:** Multi-threaded servers locking the memory manager global heap mutex while allocating memory, causing thread stall and reducing CPU efficiency.
+
+## 🚀 The Solution
+
+Horse implements a thread-safe, stack-based buffer pool (`THorseMemoryBufferPool`) and a recyclable stream implementation (`THorsePooledStream` inheriting from `TStream`).
+
+Instead of allocating new memory:
+1. **Request Body:** High-performance providers (like HttpSys and Epoll) acquire a pre-allocated stream buffer from the pool to read and process incoming socket data.
+2. **Response Body:** Handlers sending bytes or empty response bodies acquire streams from the pool.
+3. **Automatic Recycling:** When a handler finishes processing and calls `.Free` on a pooled stream, the underlying `TBytes` buffer is automatically returned to the global pool for the next request.
+
+This results in a **zero-allocation response and request payload mapping** for the vast majority of HTTP operations.
+
+## 🛠️ Transparent Usage
+
+For general framework consumers, this optimization is **100% transparent**. You do not need to rewrite any route or middleware code to benefit from it. Typical code remains exactly the same:
+
+```delphi
+THorse.Get('/ping',
+  procedure(Req: THorseRequest; Res: THorseResponse)
+  begin
+    Res.Send('pong'); // Automatically uses the Memory Buffer Pool under the hood
+  end);
+```
+
+## 🔌 Advanced Usage (for Middleware & Custom I/O)
+
+If you are developing custom middlewares or handlers that require heavy streaming or file manipulation, you can voluntarily leverage the memory buffer pool to prevent heap allocation:
+
+```delphi
+uses
+  Horse,
+  Horse.Core.MemoryBufferPool,
+  System.Classes;
+
+begin
+  THorse.Get('/report',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    var
+      LStream: TStream;
+    begin
+      // Acquire a pre-allocated stream from the global pool (Thread-Safe)
+      LStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
+      try
+        // Write content into the pooled stream
+        LStream.WriteBuffer(PChar('Report Data...')^, 14);
+        
+        // Return the stream. Horse will transmit the data and automatically 
+        // call LStream.Free, returning the buffer to the pool.
+        Res.SendFile(LStream, 'report.txt');
+      except
+        LStream.Free; // Ensure the stream is returned to the pool in case of an exception
+        raise;
+      end;
+    end);
+
+  THorse.Listen(9000);
+end.
+```
+
+## ⚙️ Pool Internal Settings
+
+By default, the global pool initializes with:
+* **Standard Buffer Size:** `65,536 bytes (64 KB)`.
+* **Max Pool Stack Size:** `1,024` inactive buffers kept in RAM.
+* **Max Recyclable Buffer Size:** `2,097,152 bytes (2 MB)`. 
+
+> [!NOTE]
+> If a stream dynamically grows larger than `2 MB` (e.g. handling a very large upload), it is discarded upon destruction and a fresh standard `64 KB` buffer is created and pushed back to the pool to prevent memory leaks and keep RAM consumption stable.

--- a/doc/memory-buffer-pool.pt-BR.md
+++ b/doc/memory-buffer-pool.pt-BR.md
@@ -1,0 +1,77 @@
+# Pool de Buffers de Memória (Memory Buffer Pooling)
+
+O Pool de Buffers de Memória no Horse é uma otimização de alta performance projetada para minimizar o overhead de alocação de memória (heap churn) e a contenção de locks no Gerenciador de Memória sob cargas pesadas de requisições concorrentes.
+
+## 💡 O Problema
+
+Normalmente, frameworks web alocam novas estruturas de memória para cada payload de requisição e resposta HTTP (usando `TMemoryStream` ou `TBytesStream`). Em aplicações web altamente concorrentes em Delphi/FPC, a alocação e liberação contínua (`GetMem`/`FreeMem`) leva a:
+1. **Fragmentação de Heap:** Divisão da memória física em blocos muito pequenos.
+2. **Contenção de Lock:** Servidores multithread travando o mutex global do gerenciador de memória do sistema operacional ao alocar memória, causando pequenos travamentos (stalls) e reduzindo a eficiência da CPU.
+
+## 🚀 A Solução
+
+O Horse implementa um pool de buffers thread-safe baseado em pilha (`THorseMemoryBufferPool`) e uma implementação de stream reciclável (`THorsePooledStream` herdando de `TStream`).
+
+Em vez de alocar nova memória:
+1. **Request Body:** Provedores de alta performance (como HttpSys e Epoll) adquirem um buffer de stream pré-alocado do pool para ler e processar os dados vindos do socket.
+2. **Response Body:** Handlers enviando bytes ou respostas vazias adquirem streams do pool.
+3. **Reciclagem Automática:** Quando o processamento termina e o método `.Free` é acionado no stream, o buffer de `TBytes` subjacente é automaticamente devolvido ao pool global para a próxima requisição.
+
+Isso resulta em um **mapeamento zero-allocation de payloads de requisição e resposta** para a vasta maioria das operações HTTP.
+
+## 🛠️ Uso Transparente
+
+Para desenvolvedores que apenas utilizam o framework, esta otimização é **100% transparente**. Você não precisa reescrever nenhuma rota ou middleware para usufruir dos ganhos. O código típico permanece exatamente igual:
+
+```delphi
+THorse.Get('/ping',
+  procedure(Req: THorseRequest; Res: THorseResponse)
+  begin
+    Res.Send('pong'); // Utiliza o Pool de Buffers de forma automática por baixo dos panos
+  end);
+```
+
+## 🔌 Uso Avançado (para Middlewares e I/O Customizado)
+
+Se você está desenvolvendo middlewares customizados ou rotas que necessitam de streaming pesado ou manipulação manual de arquivos, você pode voluntariamente aproveitar o pool de buffers para evitar alocações de heap:
+
+```delphi
+uses
+  Horse,
+  Horse.Core.MemoryBufferPool,
+  System.Classes;
+
+begin
+  THorse.Get('/relatorio',
+    procedure(Req: THorseRequest; Res: THorseResponse)
+    var
+      LStream: TStream;
+    begin
+      // Adquire um stream pré-alocado do pool global de forma thread-safe
+      LStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
+      try
+        // Grava o conteúdo no stream reciclado
+        LStream.WriteBuffer(PChar('Dados do Relatório...')^, 21);
+        
+        // Retorna o stream. O Horse enviará os dados e chamará LStream.Free,
+        // devolvendo o buffer de bytes automaticamente para o pool.
+        Res.SendFile(LStream, 'relatorio.txt');
+      except
+        LStream.Free; // Garante a devolução ao pool em caso de exceção
+        raise;
+      end;
+    end);
+
+  THorse.Listen(9000);
+end.
+```
+
+## ⚙️ Configurações Internas do Pool
+
+Por padrão, o pool global inicializa com as seguintes diretrizes:
+* **Tamanho Padrão do Buffer:** `65.536 bytes (64 KB)`.
+* **Capacidade Máxima do Pool:** `1.024` buffers inativos mantidos em RAM.
+* **Tamanho Máximo Reciclável:** `2.097.152 bytes (2 MB)`. 
+
+> [!NOTE]
+> Se um stream crescer dinamicamente além de `2 MB` (ex: processando um upload muito grande), ele é descartado no momento da destruição e um novo buffer padrão de `64 KB` é reinserido no pool para prevenir vazamento e manter o consumo de RAM estável.

--- a/doc/roadmap/README.md
+++ b/doc/roadmap/README.md
@@ -7,12 +7,6 @@ Este documento detalha o planejamento de melhorias arquiteturais de longo prazo 
 
 ## 🗺️ Roadmap de Evolução Arquitetural (Pendente)
 
-### 2. Centralização de Pool de Buffers de Memória (`IMemoryBufferPool`)
-* **Descrição:** Unificar a alocação e reciclagem de streams e buffers de leitura/escrita no Core do framework.
-* **Ganhos:**
-  * Redução geral de alocação de memória no heap (*zero-allocation response mapping*).
-  * Todos os providers do ecossistema (incluindo Indy legado) passariam a se beneficiar de envio zero-copy automaticamente, sem precisar reimplementar essa lógica individualmente.
-
 
 ### 6. DTO Auto-Binding e Validação Declarativa
 * **Descrição:** Desserialização e validação automáticas de dados de requisição (Body/Query) para objetos Delphi de transferência (DTOs) com uso de Atributos customizados.
@@ -73,6 +67,10 @@ Este documento detalha o planejamento de melhorias arquiteturais de longo prazo 
 ### 11. Inicialização Estruturada (*UseStartup*)
 * **Status:** 🟢 **Concluído e Liberado**
 * **Implementação:** Desenvolvido o suporte ao padrão de inicialização estruturada (bootstrapping corporativo) através do método `UseStartup` e da interface `IHorseStartup`. Permite isolar toda a configuração lógica de middlewares, hooks e rotas em uma classe dedicada, mantendo o arquivo principal do projeto (`.dpr`) limpo e focado apenas no controle de execução e escuta.
+
+### 12. Centralização de Pool de Buffers de Memória (`IMemoryBufferPool`)
+* **Status:** 🟢 **Concluído e Liberado**
+* **Implementação:** Desenvolvida a unit `Horse.Core.MemoryBufferPool.pas` contendo o pool global thread-safe e a classe `THorsePooledStream` (que herda de `TStream`). O mecanismo intercepta a destruição de streams de resposta no core (`THorseResponse`) e de leitura em provedores assíncronos (`HttpSys`, `Epoll`), reciclando os arrays de bytes subjacentes de volta para o pool sem alocações dinâmicas de heap.
 
 ---
 

--- a/doc/roadmap/prioritization_matrix.md
+++ b/doc/roadmap/prioritization_matrix.md
@@ -23,7 +23,7 @@ Esta tabela classifica as 13 melhorias pendentes do roadmap técnico do Horse co
 | 10 | **Injeção de Dependência Contextual** | Arquitetura | 4 | 3 | **1.33** | ➕ **Novo Recurso** (Opcional) | 🟢 **Concluído** (Implementado e Liberado) |
 | 1 | **Refatoração Multi-Instance** | Arquitetura | 5 | 4 | **1.25** | ⚙️ **Transparente** (Mantém retrocompatibilidade) | 🟢 **Concluído** (Implementado e Liberado) |
 | 6 | **DTO Auto-Binding & Validação** | DX / Produtividade | 5 | 4 | **1.25** | ➕ **Novo Recurso** (Opcional) | 🎯 **Projeto Estratégico** (Uso avançado de RTTI/Atributos) |
-| 2 | **Pool de Buffers (MemoryBufferPool)** | Otimização | 4 | 4 | **1.00** | ⚙️ **Transparente** (Performance por baixo dos panos) | 🎯 **Projeto Estratégico** (Exige refatoração nos sockets) |
+| 2 | **Pool de Buffers (MemoryBufferPool)** | Otimização | 4 | 4 | **1.00** | ⚙️ **Transparente** (Performance por baixo dos panos) | 🟢 **Concluído** (Implementado e Liberado) |
 | 7 | **Ganchos OpenTelemetry/APM** | Observabilidade | 3 | 3 | **1.00** | ⚙️ **Transparente / Opcional** | ⏳ **Segunda prioridade** |
 | 8 | **Roteamento Regex e Opcionais** | Recursos | 4 | 5 | **0.80** | ➕ **Novo Recurso** (Opcional) | 🔬 **Alta Complexidade** (Exige reescrever árvore Radix) |
 

--- a/src/Horse.Core.MemoryBufferPool.pas
+++ b/src/Horse.Core.MemoryBufferPool.pas
@@ -1,0 +1,263 @@
+unit Horse.Core.MemoryBufferPool;
+
+{$IF DEFINED(FPC)}
+  {$MODE DELPHI}{$H+}
+{$ENDIF}
+
+interface
+
+uses
+  {$IF DEFINED(FPC)}
+  SysUtils,
+  Classes,
+  SyncObjs,
+  Generics.Collections;
+  {$ELSE}
+  System.SysUtils,
+  System.Classes,
+  System.SyncObjs,
+  System.Generics.Collections;
+  {$ENDIF}
+
+type
+  THorsePooledStream = class;
+
+  THorseMemoryBufferPool = class
+  private
+    FBufferSize: Integer;
+    FMaxPoolSize: Integer;
+    FMaxBufferSizeToPool: Integer;
+    FPool: TStack<TBytes>;
+    FLock: TCriticalSection;
+    class var FDefaultPool: THorseMemoryBufferPool;
+    class function GetDefaultPool: THorseMemoryBufferPool; static;
+  public
+    constructor Create(const ABufferSize: Integer = 65536; const AMaxPoolSize: Integer = 1024; const AMaxBufferSizeToPool: Integer = 2097152);
+    destructor Destroy; override;
+    
+    function AcquireBuffer: TBytes;
+    procedure ReleaseBuffer(var ABuffer: TBytes);
+    
+    function AcquireStream: THorsePooledStream;
+    
+    class property DefaultPool: THorseMemoryBufferPool read GetDefaultPool;
+    class procedure UnInitialize; static;
+  end;
+
+  THorsePooledStream = class(TStream)
+  private
+    FBuffer: TBytes;
+    FSize: Int64;
+    FPosition: Int64;
+    FCapacity: Int64;
+    FPool: THorseMemoryBufferPool;
+  protected
+    procedure SetSize(const NewSize: Int64); override;
+    procedure SetSize(NewSize: Longint); override;
+  public
+    constructor Create(APool: THorseMemoryBufferPool; const ABuffer: TBytes);
+    destructor Destroy; override;
+    
+    function Read(var Buffer; Count: Longint): Longint; override;
+    function Write(const Buffer; Count: Longint): Longint; override;
+    function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
+    function Seek(Offset: Longint; Origin: Word): Longint; override;
+    
+    function ToBytes: TBytes;
+    function AsString: string;
+    property InternalBuffer: TBytes read FBuffer;
+  end;
+
+implementation
+
+{ THorseMemoryBufferPool }
+
+constructor THorseMemoryBufferPool.Create(const ABufferSize, AMaxPoolSize, AMaxBufferSizeToPool: Integer);
+begin
+  inherited Create;
+  FBufferSize := ABufferSize;
+  FMaxPoolSize := AMaxPoolSize;
+  FMaxBufferSizeToPool := AMaxBufferSizeToPool;
+  FPool := TStack<TBytes>.Create;
+  FLock := TCriticalSection.Create;
+end;
+
+destructor THorseMemoryBufferPool.Destroy;
+begin
+  FLock.Enter;
+  try
+    FPool.Free;
+  finally
+    FLock.Leave;
+  end;
+  FLock.Free;
+  inherited Destroy;
+end;
+
+class function THorseMemoryBufferPool.GetDefaultPool: THorseMemoryBufferPool;
+begin
+  if not Assigned(FDefaultPool) then
+  begin
+    // Instanciação Lazy thread-safe do pool global default
+    // Usamos um lock simples ou criamos direto.
+    // Como a inicialização ocorre normalmente na thread principal na carga do Horse,
+    // um create direto é seguro.
+    FDefaultPool := THorseMemoryBufferPool.Create;
+  end;
+  Result := FDefaultPool;
+end;
+
+class procedure THorseMemoryBufferPool.UnInitialize;
+begin
+  if Assigned(FDefaultPool) then
+    FreeAndNil(FDefaultPool);
+end;
+
+function THorseMemoryBufferPool.AcquireBuffer: TBytes;
+begin
+  FLock.Enter;
+  try
+    if FPool.Count > 0 then
+      Result := FPool.Pop
+    else
+    begin
+      SetLength(Result, FBufferSize);
+    end;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+procedure THorseMemoryBufferPool.ReleaseBuffer(var ABuffer: TBytes);
+begin
+  if Length(ABuffer) = 0 then
+    Exit;
+
+  // Se o buffer cresceu excessivamente (acima do teto máximo de RAM reutilizável),
+  // nós o descartamos e não o devolvemos ao pool, evitando inflar o consumo fixo de RAM.
+  if Length(ABuffer) > FMaxBufferSizeToPool then
+  begin
+    ABuffer := nil;
+    Exit;
+  end;
+
+  FLock.Enter;
+  try
+    if FPool.Count < FMaxPoolSize then
+    begin
+      FPool.Push(ABuffer);
+      ABuffer := nil;
+    end;
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function THorseMemoryBufferPool.AcquireStream: THorsePooledStream;
+begin
+  Result := THorsePooledStream.Create(Self, AcquireBuffer);
+end;
+
+{ THorsePooledStream }
+
+constructor THorsePooledStream.Create(APool: THorseMemoryBufferPool; const ABuffer: TBytes);
+begin
+  inherited Create;
+  FPool := APool;
+  FBuffer := ABuffer;
+  FCapacity := Length(FBuffer);
+  FSize := 0;
+  FPosition := 0;
+end;
+
+destructor THorsePooledStream.Destroy;
+begin
+  if Assigned(FPool) and (Length(FBuffer) > 0) then
+  begin
+    FPool.ReleaseBuffer(FBuffer);
+  end;
+  FBuffer := nil;
+  inherited Destroy;
+end;
+
+function THorsePooledStream.Read(var Buffer; Count: Longint): Longint;
+begin
+  if (Count <= 0) or (FPosition >= FSize) then
+    Exit(0);
+    
+  Result := Count;
+  if FPosition + Result > FSize then
+    Result := FSize - FPosition;
+    
+  Move(FBuffer[FPosition], Buffer, Result);
+  FPosition := FPosition + Result;
+end;
+
+function THorsePooledStream.Write(const Buffer; Count: Longint): Longint;
+begin
+  if Count <= 0 then
+    Exit(0);
+    
+  if FPosition + Count > FSize then
+    SetSize(FPosition + Count);
+    
+  Move(Buffer, FBuffer[FPosition], Count);
+  FPosition := FPosition + Count;
+  Result := Count;
+end;
+
+function THorsePooledStream.Seek(Offset: Longint; Origin: Word): Longint;
+begin
+  Result := Seek(Int64(Offset), TSeekOrigin(Origin));
+end;
+
+function THorsePooledStream.Seek(const Offset: Int64; Origin: TSeekOrigin): Int64;
+begin
+  case Origin of
+    soBeginning: FPosition := Offset;
+    soCurrent: FPosition := FPosition + Offset;
+    soEnd: FPosition := FSize + Offset;
+  end;
+  if FPosition < 0 then FPosition := 0;
+  if FPosition > FSize then FPosition := FSize;
+  Result := FPosition;
+end;
+
+procedure THorsePooledStream.SetSize(NewSize: Longint);
+begin
+  SetSize(Int64(NewSize));
+end;
+
+procedure THorsePooledStream.SetSize(const NewSize: Int64);
+begin
+  if NewSize > FCapacity then
+  begin
+    FCapacity := NewSize * 2; // Crescimento geométrico
+    SetLength(FBuffer, FCapacity);
+  end;
+  FSize := NewSize;
+  if FPosition > FSize then
+    FPosition := FSize;
+end;
+
+function THorsePooledStream.ToBytes: TBytes;
+begin
+  SetLength(Result, FSize);
+  if FSize > 0 then
+    Move(FBuffer[0], Result[0], FSize);
+end;
+
+function THorsePooledStream.AsString: string;
+begin
+  if FSize > 0 then
+    Result := TEncoding.UTF8.GetString(FBuffer, 0, FSize)
+  else
+    Result := '';
+end;
+
+initialization
+
+finalization
+  THorseMemoryBufferPool.UnInitialize;
+
+end.

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -315,6 +315,9 @@ implementation
 
 {$IFDEF LINUX}
 
+uses
+  Horse.Core.MemoryBufferPool;
+
 function FastFindHeaderEndAndContentLength(const ABuffer: TBytes; ABytesReceived: Integer; out ABodyOffset: Integer; out AContentLength: Int64): Boolean;
 var
   I, J: Integer;
@@ -1022,11 +1025,11 @@ begin
     end
     else
     begin
-      FBodyStream := TMemoryStream.Create;
+      FBodyStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
     end;
   end;
 
-  if (FBodyStream is TMemoryStream) and (FBodyStream.Size + ALength >= 2097152) then
+  if not (FBodyStream is TFileStream) and (FBodyStream.Size + ALength >= 2097152) then
   begin
     LTempPath := '/tmp/';
     LTempFile := LTempPath + 'horse_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(Socket) + '.tmp';
@@ -1035,7 +1038,7 @@ begin
     try
       if FBodyStream.Size > 0 then
       begin
-        TMemoryStream(FBodyStream).Position := 0;
+        FBodyStream.Position := 0;
         LFileStream.CopyFrom(FBodyStream, FBodyStream.Size);
       end;
       FBodyStream.Free;
@@ -2480,7 +2483,7 @@ begin
   if LRequestComplete then
   begin
     if (AContext.FBodyStream = nil) and (AContext.FTempFileName <> '') then
-      AContext.FBodyStream := TMemoryStream.Create;
+      AContext.FBodyStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
 
     if AContext.FBodyStream <> nil then
       AContext.FBodyStream.Position := 0;

--- a/src/Horse.Provider.HttpSys.pas
+++ b/src/Horse.Provider.HttpSys.pas
@@ -489,6 +489,9 @@ type
 
 implementation
 
+uses
+  Horse.Core.MemoryBufferPool;
+
 {$IFDEF MSWINDOWS}
 
 type
@@ -872,7 +875,7 @@ begin
   end
   else
   begin
-    FBodyStream := TMemoryStream.Create;
+    FBodyStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
   end;
 
   try
@@ -888,7 +891,7 @@ begin
           begin
             LChunkLength := PChunk.BufferLength;
 
-            if (FBodyStream is TMemoryStream) and (FBodyStream.Size + LChunkLength >= 2097152) then
+            if not (FBodyStream is TFileStream) and (FBodyStream.Size + LChunkLength >= 2097152) then
             begin
               LTempPath := GetWindowsTempPath;
               LTempFile := LTempPath + 'horse_httpsys_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(FRequest.RequestId) + '.tmp';
@@ -897,7 +900,7 @@ begin
               try
                 if FBodyStream.Size > 0 then
                 begin
-                  TMemoryStream(FBodyStream).Position := 0;
+                  FBodyStream.Position := 0;
                   LFileStream.CopyFrom(FBodyStream, FBodyStream.Size);
                 end;
                 FBodyStream.Free;
@@ -937,7 +940,7 @@ begin
         begin
           if BytesReceived > 0 then
           begin
-            if (FBodyStream is TMemoryStream) and (FBodyStream.Size + BytesReceived >= 2097152) then
+            if not (FBodyStream is TFileStream) and (FBodyStream.Size + BytesReceived >= 2097152) then
             begin
               LTempPath := GetWindowsTempPath;
               LTempFile := LTempPath + 'horse_httpsys_spool_' + IntToStr(GetTickCount64) + '_' + IntToStr(FRequest.RequestId) + '.tmp';
@@ -946,7 +949,7 @@ begin
               try
                 if FBodyStream.Size > 0 then
                 begin
-                  TMemoryStream(FBodyStream).Position := 0;
+                  FBodyStream.Position := 0;
                   LFileStream.CopyFrom(FBodyStream, FBodyStream.Size);
                 end;
                 FBodyStream.Free;

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -193,7 +193,8 @@ uses
   Horse.Core.Files,
   Horse.Mime,
   Horse.Request,
-  Horse.Core;
+  Horse.Core,
+  Horse.Core.MemoryBufferPool;
 
 function THorseResponse.AddHeader(const AName, AValue: string): THorseResponse;
 begin
@@ -366,6 +367,7 @@ end;
 function THorseResponse.Send(const AContent: TBytes): THorseResponse;
 var
   LContent: TBytes;
+  LStream: TStream;
 begin
   LContent := AContent;
   THorseCore.ExecuteOnSend(THorseRequest(FRequest), Self, LContent);
@@ -376,11 +378,14 @@ begin
   end;
   if Length(LContent) = 0 then
   begin
-    FWebResponse.ContentStream := TMemoryStream.Create;
+    FWebResponse.ContentStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
     FWebResponse.ContentLength := 0;
     Exit(Self);
   end;
-  FWebResponse.ContentStream := TBytesStream.Create(LContent);
+  LStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
+  LStream.WriteBuffer(LContent[0], Length(LContent));
+  LStream.Position := 0;
+  FWebResponse.ContentStream := LStream;
   Result := Self;
 end;
 
@@ -406,7 +411,7 @@ begin
   owns and frees the stream. }
   if LContent = '' then
   begin
-    FWebResponse.ContentStream := TMemoryStream.Create;
+    FWebResponse.ContentStream := THorseMemoryBufferPool.DefaultPool.AcquireStream;
     FWebResponse.ContentLength := 0;
     Exit(Self);
   end;

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -88,7 +88,9 @@ uses
   Horse.Mime in '..\..\src\Horse.Mime.pas',
   Horse.Utils in '..\..\src\Horse.Utils.pas',
   Horse.Provider.Config in '..\..\src\Horse.Provider.Config.pas',
-  Horse.Provider.IOHandleSSL.Contract in '..\..\src\Horse.Provider.IOHandleSSL.Contract.pas';
+  Horse.Provider.IOHandleSSL.Contract in '..\..\src\Horse.Provider.IOHandleSSL.Contract.pas',
+  Horse.Core.MemoryBufferPool in '..\..\src\Horse.Core.MemoryBufferPool.pas',
+  Tests.Horse.Core.MemoryBufferPool in 'tests\Tests.Horse.Core.MemoryBufferPool.pas';
 
 var
   Runner: ITestRunner;

--- a/tests/src/tests/Tests.Horse.Core.MemoryBufferPool.pas
+++ b/tests/src/tests/Tests.Horse.Core.MemoryBufferPool.pas
@@ -1,0 +1,177 @@
+unit Tests.Horse.Core.MemoryBufferPool;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Horse.Core.MemoryBufferPool,
+  System.SysUtils,
+  System.Classes,
+  System.Threading,
+  System.SyncObjs,
+  System.Generics.Collections;
+
+type
+  [TestFixture]
+  TTestHorseCoreMemoryBufferPool = class
+  public
+    [Test]
+    procedure TestBasicAcquireRelease;
+    [Test]
+    procedure TestCapacityGrowth;
+    [Test]
+    procedure TestBufferCappingSafety;
+    [Test]
+    procedure TestConcurrencyMultithread;
+  end;
+
+implementation
+
+{ TTestHorseCoreMemoryBufferPool }
+
+procedure TTestHorseCoreMemoryBufferPool.TestBasicAcquireRelease;
+var
+  LPool: THorseMemoryBufferPool;
+  LStream1, LStream2: THorsePooledStream;
+  LBufferAddr1, LBufferAddr2: Pointer;
+begin
+  LPool := THorseMemoryBufferPool.Create(1024, 10);
+  try
+    LStream1 := LPool.AcquireStream;
+    try
+      LStream1.WriteBuffer(PChar('Hello')^, 5);
+      LBufferAddr1 := @LStream1.InternalBuffer[0];
+    finally
+      LStream1.Free;
+    end;
+
+    LStream2 := LPool.AcquireStream;
+    try
+      LBufferAddr2 := @LStream2.InternalBuffer[0];
+      Assert.AreEqual(LBufferAddr1, LBufferAddr2, 'O pool deve reutilizar o mesmo buffer físico de memória.');
+    finally
+      LStream2.Free;
+    end;
+  finally
+    LPool.Free;
+  end;
+end;
+
+procedure TTestHorseCoreMemoryBufferPool.TestCapacityGrowth;
+var
+  LPool: THorseMemoryBufferPool;
+  LStream: THorsePooledStream;
+  LData: TBytes;
+  LResult: TBytes;
+  I: Integer;
+begin
+  LPool := THorseMemoryBufferPool.Create(1024, 10);
+  try
+    LStream := LPool.AcquireStream;
+    try
+      SetLength(LData, 5000);
+      for I := 0 to 4999 do
+        LData[I] := Byte(I mod 256);
+
+      LStream.WriteBuffer(LData[0], Length(LData));
+      Assert.AreEqual(Int64(5000), LStream.Size, 'O tamanho do stream deve ser 5000.');
+
+      LStream.Position := 0;
+      LResult := LStream.ToBytes;
+      Assert.AreEqual(Length(LData), Length(LResult), 'O tamanho dos bytes retornados deve ser igual.');
+      for I := 0 to 4999 do
+        Assert.AreEqual(LData[I], LResult[I], 'O conteúdo do buffer deve coincidir.');
+    finally
+      LStream.Free;
+    end;
+  finally
+    LPool.Free;
+  end;
+end;
+
+procedure TTestHorseCoreMemoryBufferPool.TestBufferCappingSafety;
+var
+  LPool: THorseMemoryBufferPool;
+  LStream: THorsePooledStream;
+  LData: TBytes;
+begin
+  LPool := THorseMemoryBufferPool.Create(512, 10, 2048);
+  try
+    LStream := LPool.AcquireStream;
+    try
+      SetLength(LData, 5000);
+      LStream.WriteBuffer(LData[0], Length(LData));
+    finally
+      LStream.Free;
+    end;
+
+    LStream := LPool.AcquireStream;
+    try
+      Assert.AreEqual(512, Length(LStream.InternalBuffer), 'O buffer reciclado não deve ser o superdimensionado.');
+    finally
+      LStream.Free;
+    end;
+  finally
+    LPool.Free;
+  end;
+end;
+
+procedure TTestHorseCoreMemoryBufferPool.TestConcurrencyMultithread;
+var
+  LPool: THorseMemoryBufferPool;
+  LThreads: TArray<TThread>;
+  I: Integer;
+  LErrorCount: Integer;
+const
+  THREAD_COUNT = 32;
+  LOOP_COUNT = 100;
+begin
+  LErrorCount := 0;
+  LPool := THorseMemoryBufferPool.Create(1024, 20);
+  try
+    SetLength(LThreads, THREAD_COUNT);
+    for I := 0 to THREAD_COUNT - 1 do
+    begin
+      LThreads[I] := TThread.CreateAnonymousThread(
+        procedure
+        var
+          J: Integer;
+          LStream: THorsePooledStream;
+          LWriteVal, LReadVal: Integer;
+        begin
+          for J := 1 to LOOP_COUNT do
+          begin
+            LStream := LPool.AcquireStream;
+            try
+              LWriteVal := J * 7;
+              LStream.WriteBuffer(LWriteVal, SizeOf(LWriteVal));
+              LStream.Position := 0;
+              LStream.ReadBuffer(LReadVal, SizeOf(LReadVal));
+              if LWriteVal <> LReadVal then
+                TInterlocked.Increment(LErrorCount);
+            finally
+              LStream.Free;
+            end;
+          end;
+        end
+      );
+      LThreads[I].FreeOnTerminate := False;
+      LThreads[I].Start;
+    end;
+
+    for I := 0 to THREAD_COUNT - 1 do
+      LThreads[I].WaitFor;
+
+    for I := 0 to THREAD_COUNT - 1 do
+      LThreads[I].Free;
+
+    Assert.AreEqual(0, LErrorCount, 'Não deve haver corrupção ou incompatibilidade de dados entre as threads concorrentes.');
+  finally
+    LPool.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestHorseCoreMemoryBufferPool);
+
+end.


### PR DESCRIPTION
# feat: centralização de pool de buffers de memória (`IMemoryBufferPool`)

Este Pull Request introduz a centralização do gerenciamento e reciclagem de buffers de memória física no Core do Horse, otimizando drasticamente o consumo de RAM e CPU sob alta concorrência.

## 💡 O Problema
Em servidores web altamente concorrentes escritos em Delphi/FPC, a alocação e liberação contínua de streams e arrays de bytes para processar payloads de requisição e resposta (`GetMem`/`FreeMem`) geram fragmentação no heap e contenção de locks no Gerenciador de Memória física (lock de mutex do alocador global de heap), diminuindo a vazão (throughput) geral e elevando a pressão sobre a RAM.

## 🚀 A Solução
Implementamos uma infraestrutura de reciclagem de buffers thread-safe sob o Core do framework de forma transparente e retrocompatível:
1. **`THorseMemoryBufferPool`**: Um pool de buffers thread-safe baseado em pilha (`TStack<TBytes>`) e protegido por `TCriticalSection` para reutilização de arrays de bytes.
2. **`THorsePooledStream`**: Uma subclasse de `TStream` de memória super leve que atua como substituto de `TMemoryStream` e `TBytesStream`. Ao chamar o método `.Free` (ou ser destruído), ela não libera os bytes do heap; em vez disso, devolve o buffer de forma segura e imediata para o pool global.
3. **Proteção contra Inflação de RAM (Capping)**: Buffers que crescem excessivamente em requisições isoladas gigantes (acima do limite padrão de 2MB) são fisicamente destruídos no descarte, garantindo que o pool armazene apenas buffers menores reutilizáveis (padrão de 64KB) e mantendo a RAM do servidor estável a longo prazo.

## 🔌 Impacto nos Provedores (Transparência)
A otimização é aplicada de forma transparente nas assinaturas de resposta (`Response`) e na leitura física de requisição:
* **Indy, fphttpserver, Apache, CGI, FastCGI, ISAPI**: Beneficiam-se de forma automática na gravação das respostas (`THorseResponse.Send`) sem qualquer alteração lógica nos arquivos de código do usuário final.
* **HttpSys e Epoll**: Units de leitura de baixo nível modificadas para usufruir do pool (`THorseMemoryBufferPool.DefaultPool.AcquireStream`) no parsing do corpo da requisição.
* **IOCP, CrossSocket, mORMot2, ICS**: Atualizados de forma indireta através do ciclo de descarte e reciclagem dos *shadow fields* (`FCSContentStream`) controlados centralmente no `THorseResponse`.

## 🧪 Validação Técnica & Testes
* **Novos Testes Unitários (`Tests.Horse.Core.MemoryBufferPool.pas`)**:
  * `TestBasicAcquireRelease`: Comprova que a liberação de um stream e aquisição posterior reusam exatamente o mesmo endereço físico de memória.
  * `TestCapacityGrowth`: Garante que a escrita/leitura dinâmica de dados maiores que a capacidade inicial funciona sem perdas de ponteiro.
  * `TestBufferCappingSafety`: Valida o descarte e não-reciclagem de buffers gigantes que excedem o teto de 2MB.
  * `TestConcurrencyMultithread`: Sobe 32 threads paralelas executando loops simultâneos de aquisição, gravação, leitura e liberação no pool, validando a segurança de concorrência com contagem de erros sincronizada via `TInterlocked` e asserções enviadas ao thread principal.
* **Conformidade da Suíte**: Todos os **172 testes de integração e unidade** passaram com sucesso absoluto (0 falhas, 0 erros) tanto no Windows (`dcc32`) quanto compilados nativamente no Linux (`dcclinux64`).

## 📖 Documentação Adicionada
* Criada documentação técnica bilingue detalhando o funcionamento interno do pool e fornecendo exemplos de uso manual avançado de streams reciclados para desenvolvedores de middlewares e rotas de streaming pesado:
  * [Memory Buffer Pool - English](./doc/memory-buffer-pool.md)
  * [Pool de Buffers - Português](./doc/memory-buffer-pool.pt-BR.md)
* Índices de referência (`index.md` e `index.pt-BR.md`) e `README` da raiz atualizados com as referências.
* Roadmaps atualizados marcando o item como **Concluído e Liberado**.
