### PR TITLE
Fix/issue 524

### DIFF
--- a/src/Horse.Core.Regex.pas
+++ b/src/Horse.Core.Regex.pas
@@ -9,10 +9,11 @@ interface
 uses
   {$IF DEFINED(FPC)}
   RegExpr,
+  SysUtils;
   {$ELSE}
   System.RegularExpressions,
-  {$ENDIF}
   System.SysUtils;
+  {$ENDIF}
 
 type
   THorseRegex = class

--- a/src/Horse.Provider.FPC.HTTPApplication.pas
+++ b/src/Horse.Provider.FPC.HTTPApplication.pas
@@ -1,4 +1,4 @@
-﻿unit Horse.Provider.FPC.HTTPApplication;
+unit Horse.Provider.FPC.HTTPApplication;
 
 { PATCH-FPCHTTP-1: ListenWithConfig override — same root cause as PATCH-CONSOLE-1. }
 
@@ -46,10 +46,14 @@ type
     class property ListenQueue: Integer read GetListenQueue write SetListenQueue;
     class function GetActivePort: Integer; override;
     class procedure Listen; overload; override;
-    class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallback: TProc = nil); reintroduce; overload; static;
-    class procedure Listen(const APort: Integer; const ACallback: TProc); reintroduce; overload; static;
-    class procedure Listen(const AHost: string; const ACallback: TProc = nil); reintroduce; overload; static;
-    class procedure Listen(const ACallback: TProc); reintroduce; overload; static;
+    class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0';
+      const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const APort: Integer; const ACallbackListen: TProc;
+      const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const AHost: string; const ACallbackListen: TProc = nil;
+      const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
+    class procedure Listen(const ACallbackListen: TProc;
+      const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     // PATCH-FPCHTTP-1
     class procedure ListenWithConfig(const APort: Integer;
       const AConfig: THorseCrossSocketConfig); override;
@@ -147,27 +151,28 @@ begin
   InternalListen;;
 end;
 
-class procedure THorseProvider.Listen(const APort: Integer; const AHost: string; const ACallback: TProc);
+class procedure THorseProvider.Listen(const APort: Integer; const AHost: string; const ACallbackListen, ACallbackStopListen: TProc);
 begin
   SetPort(APort);
   SetHost(AHost);
-  SetOnListen(ACallback);
+  SetOnListen(ACallbackListen);
+  SetOnStopListen(ACallbackStopListen);
   InternalListen;
 end;
 
-class procedure THorseProvider.Listen(const AHost: string; const ACallback: TProc);
+class procedure THorseProvider.Listen(const APort: Integer; const ACallbackListen, ACallbackStopListen: TProc);
 begin
-  Listen(FPort, AHost, ACallback);
+  Listen(APort, FHost, ACallbackListen, ACallbackStopListen);
 end;
 
-class procedure THorseProvider.Listen(const ACallback: TProc);
+class procedure THorseProvider.Listen(const AHost: string; const ACallbackListen, ACallbackStopListen: TProc);
 begin
-  Listen(FPort, FHost, ACallback);
+  Listen(FPort, AHost, ACallbackListen, ACallbackStopListen);
 end;
 
-class procedure THorseProvider.Listen(const APort: Integer; const ACallback: TProc);
+class procedure THorseProvider.Listen(const ACallbackListen, ACallbackStopListen: TProc);
 begin
-  Listen(APort, FHost, ACallback);
+  Listen(FPort, FHost, ACallbackListen, ACallbackStopListen);
 end;
 
 // PATCH-FPCHTTP-1

--- a/tests/src/tests/Tests.Horse.Core.MemoryBufferPool.pas
+++ b/tests/src/tests/Tests.Horse.Core.MemoryBufferPool.pas
@@ -107,7 +107,7 @@ begin
 
     LStream := LPool.AcquireStream;
     try
-      Assert.AreEqual(512, Length(LStream.InternalBuffer), 'O buffer reciclado não deve ser o superdimensionado.');
+      Assert.IsTrue(Length(LStream.InternalBuffer) = 512, 'O buffer reciclado não deve ser o superdimensionado.');
     finally
       LStream.Free;
     end;

--- a/tests/src/tests/Tests.Horse.Core.Middleware.pas
+++ b/tests/src/tests/Tests.Horse.Core.Middleware.pas
@@ -2,6 +2,8 @@ unit Tests.Horse.Core.Middleware;
 
 interface
 
+{$X+}
+
 uses
   DUnitX.TestFramework, Horse.Core.RouterTree, Horse.Request, Horse.Response,
   System.SysUtils, System.Generics.Collections,
@@ -59,39 +61,40 @@ end;
 procedure TTestHorseCoreMiddleware.TestMiddlewareNormalExecutionChain;
 var
   LTrace: TList<string>;
+  LCallback: THorseCallback;
 begin
   LTrace := TList<string>.Create;
   try
     // Registramos middleware 1
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M1_START');
         Next();
         LTrace.Add('M1_END');
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
     // Registramos middleware 2
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M2_START');
         Next();
         LTrace.Add('M2_END');
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
     // Registramos a rota final
-    FRouterTree.RegisterRoute(mtGet, '/test',
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('ROUTE');
-      end);
+      end;
+    FRouterTree.RegisterRoute(mtGet, '/test', LCallback);
 
     FRequest.Populate('GET', mtGet, '/test', '', '');
     Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
 
     // Validamos se a ordem de execução da pilha seguiu o modelo FIFO/LIFO correto
-    Assert.AreEqual(5, LTrace.Count);
+    Assert.IsTrue(LTrace.Count = 5);
     Assert.AreEqual('M1_START', LTrace[0]);
     Assert.AreEqual('M2_START', LTrace[1]);
     Assert.AreEqual('ROUTE', LTrace[2]);
@@ -105,43 +108,46 @@ end;
 procedure TTestHorseCoreMiddleware.TestMiddlewareEarlyInterruption;
 var
   LTrace: TList<string>;
+  LCallback: THorseCallback;
+  LMethod: TProc;
 begin
   LTrace := TList<string>.Create;
   try
     // Middleware 1 interrompe o fluxo lancando EHorseCallbackInterrupted
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M1_INTERRUPT');
         raise EHorseCallbackInterrupted.Create;
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
     // Middleware 2 que nunca deve rodar
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M2');
         Next();
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
     // Rota que nunca deve rodar
-    FRouterTree.RegisterRoute(mtGet, '/test',
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('ROUTE');
-      end);
+      end;
+    FRouterTree.RegisterRoute(mtGet, '/test', LCallback);
 
     FRequest.Populate('GET', mtGet, '/test', '', '');
 
-    Assert.WillRaise(
-      procedure
+    LMethod := procedure
+      var
+        LRet: Boolean;
       begin
-        FRouterTree.Execute(FRequest, FResponse);
-      end,
-      EHorseCallbackInterrupted);
+        LRet := FRouterTree.Execute(FRequest, FResponse);
+      end;
+    Assert.WillRaise(LMethod, EHorseCallbackInterrupted);
 
     // Apenas o Middleware 1 deve ter executado
-    Assert.AreEqual(1, LTrace.Count);
+    Assert.IsTrue(LTrace.Count = 1);
     Assert.AreEqual('M1_INTERRUPT', LTrace[0]);
   finally
     LTrace.Free;
@@ -149,59 +155,64 @@ begin
 end;
 
 procedure TTestHorseCoreMiddleware.TestMiddlewareExceptionPropagation;
+var
+  LCallback: THorseCallback;
+  LMethod: TProc;
 begin
   // Middleware lança exceção
-  FRouterTree.RegisterMiddleware(
-    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+  LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
     begin
       raise EOSError.Create('Database connection error');
-    end);
+    end;
+  FRouterTree.RegisterMiddleware(LCallback);
 
-  FRouterTree.RegisterRoute(mtGet, '/test',
-    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+  LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
     begin
       // Rota final
-    end);
+    end;
+  FRouterTree.RegisterRoute(mtGet, '/test', LCallback);
 
   FRequest.Populate('GET', mtGet, '/test', '', '');
 
   // A exceção deve propagar para fora do Execute
-  Assert.WillRaise(
-    procedure
+  LMethod := procedure
+    var
+      LRet: Boolean;
     begin
-      FRouterTree.Execute(FRequest, FResponse);
-    end,
-    EOSError);
+      LRet := FRouterTree.Execute(FRequest, FResponse);
+    end;
+  Assert.WillRaise(LMethod, EOSError);
 end;
 
 procedure TTestHorseCoreMiddleware.TestMultipleMiddlewaresInRouterTree;
 var
   I: Integer;
   LTrace: TList<Integer>;
+  LCallback: THorseCallback;
 begin
   LTrace := TList<Integer>.Create;
   try
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
+      begin
+        LTrace.Add(1);
+        Next();
+        LTrace.Add(-1);
+      end;
     for I := 1 to 15 do
     begin
-      FRouterTree.RegisterMiddleware(
-        procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
-        begin
-          LTrace.Add(1);
-          Next();
-          LTrace.Add(-1);
-        end);
+      FRouterTree.RegisterMiddleware(LCallback);
     end;
 
-    FRouterTree.RegisterRoute(mtGet, '/test',
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add(100);
-      end);
+      end;
+    FRouterTree.RegisterRoute(mtGet, '/test', LCallback);
 
     FRequest.Populate('GET', mtGet, '/test', '', '');
     Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
 
-    Assert.AreEqual(31, LTrace.Count);
+    Assert.IsTrue(LTrace.Count = 31);
     for I := 0 to 14 do
       Assert.AreEqual(1, LTrace[I]);
     
@@ -237,34 +248,35 @@ end;
 procedure TTestHorseCoreMiddleware.TestMiddlewareExceptionFreeAbort;
 var
   LTrace: TList<string>;
+  LCallback: THorseCallback;
 begin
   LTrace := TList<string>.Create;
   try
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M1_START');
         Res.Status(THTTPStatus.BadRequest).Abort;
         LTrace.Add('M1_ABORTED');
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
-    FRouterTree.RegisterMiddleware(
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('M2');
         Next();
-      end);
+      end;
+    FRouterTree.RegisterMiddleware(LCallback);
 
-    FRouterTree.RegisterRoute(mtGet, '/test',
-      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    LCallback := procedure(Req: THorseRequest; Res: THorseResponse; Next: TNextProc)
       begin
         LTrace.Add('ROUTE');
-      end);
+      end;
+    FRouterTree.RegisterRoute(mtGet, '/test', LCallback);
 
     FRequest.Populate('GET', mtGet, '/test', '', '');
     Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
 
-    Assert.AreEqual(2, LTrace.Count);
+    Assert.IsTrue(LTrace.Count = 2);
     Assert.AreEqual('M1_START', LTrace[0]);
     Assert.AreEqual('M1_ABORTED', LTrace[1]);
     Assert.IsTrue(FResponse.Aborted);

--- a/tests/src/tests/Tests.Integration.ServerLifecycle.pas
+++ b/tests/src/tests/Tests.Integration.ServerLifecycle.pas
@@ -203,7 +203,7 @@ begin
     Assert.AreEqual(1, FMethodAfterStopCount, 'MethodAfterStop should fire once');
 
     // 5. Valida sequencia de execucao dos eventos
-    Assert.AreEqual(8, FOrderList.Count, 'Should have 8 events logged in total');
+    Assert.IsTrue(FOrderList.Count = 8, 'Should have 8 events logged in total');
     
     // As chamadas multicast executam na ordem de registro: primeiro closure, depois metodo of object
     Assert.AreEqual('BeforeListen', FOrderList[0]);
@@ -233,6 +233,7 @@ var
   LThread: TThread;
   LMultiBefore1: Integer;
   LMultiBefore2: Integer;
+  LCallback: THorseServerLifecycleProc;
 begin
   LInstance := THorseInstance.Create;
   LThread := nil;
@@ -240,17 +241,17 @@ begin
     LMultiBefore1 := 0;
     LMultiBefore2 := 0;
 
-    LInstance
-      .AddOnBeforeListen(
-        procedure(const AInst: THorseInstance)
-        begin
-          Inc(LMultiBefore1);
-        end)
-      .AddOnBeforeListen(
-        procedure(const AInst: THorseInstance)
-        begin
-          Inc(LMultiBefore2);
-        end);
+    LCallback := procedure(const AInst: THorseInstance)
+      begin
+        Inc(LMultiBefore1);
+      end;
+    LInstance.AddOnBeforeListen(LCallback);
+
+    LCallback := procedure(const AInst: THorseInstance)
+      begin
+        Inc(LMultiBefore2);
+      end;
+    LInstance.AddOnBeforeListen(LCallback);
 
     LThread := TThread.CreateAnonymousThread(
       procedure
@@ -282,15 +283,16 @@ procedure TTestIntegrationServerLifecycle.TestBeforeListenExceptionAbortsStartup
 var
   LInstance: THorseInstance;
   LThread: TThread;
+  LCallback: THorseServerLifecycleProc;
 begin
   LInstance := THorseInstance.Create;
   LThread := nil;
   try
-    LInstance.AddOnBeforeListen(
-      procedure(const AInst: THorseInstance)
+    LCallback := procedure(const AInst: THorseInstance)
       begin
         raise Exception.Create('Simulated DB connection failure');
-      end);
+      end;
+    LInstance.AddOnBeforeListen(LCallback);
 
     LThread := TThread.CreateAnonymousThread(
       procedure


### PR DESCRIPTION
# fix: Resolvida a Issue #524 e restaurada compilação cruzada no Delphi Linux 64-bit

## Descrição
Este Pull Request introduz melhorias de compatibilidade multiplataforma para o framework Horse e sua suíte de testes, corrigindo a assinatura de escuta do provedor FPC `HTTPApplication` e resolvendo erros rigorosos de compilação apontados pelo compilador LLVM de 64 bits do Delphi para Linux (`dcclinux64`).

---

## Alterações Efetuadas

### 1. Provedores e Core do Framework
* **`src/Horse.Provider.FPC.HTTPApplication.pas`**: Adicionado o parâmetro opcional `const ACallbackStopListen: TProc = nil` em todas as assinaturas do método `Listen`, direcionando à rotina interna `SetOnStopListen(ACallbackStopListen)`. Isso resolve o erro de chamada do core (`THorseCore`/`THorseInstance`) relatado na **Issue #524**.
* **`src/Horse.Core.Regex.pas`**: Ajustado o namespace de importação da unit `SysUtils`. Agora importa `SysUtils` (sem prefixo) sob FPC e `System.SysUtils` sob Delphi, garantindo compilação nativa em ambos os compiladores sem conflito de linker.

### 2. Compatibilidade da Suíte de Testes Unitários com o Compilador Delphi Linux (`dcclinux64`)
O compilador LLVM de 64 bits para Linux possui restrições severas sobre inferência de tipos genéricos e typecasts de métodos anônimos. Aplicamos correções de arquitetura de testes sem alterar o comportamento ou a lógica original:

* **`tests/src/tests/Tests.Horse.Core.Middleware.pas`**:
  * **Coerção de Callbacks**: O compilador LLVM falhava na resolução de tipo de procedimentos anônimos declarados em linha (`procedure begin ... end`) para chamadas de métodos sobrecarregados de registro. Substituímos pelo uso de variáveis locais fortemente tipadas (`LCallback: THorseCallback` e `LMethod: TProc`).
  * **Syntax Strict ($X)**: Adicionada a diretiva `{$X+}` e introduzida atribuição a variáveis locais descartáveis (`LRet`) ao invocar funções cujo retorno é intencionalmente ignorado nos blocos `Assert.WillRaise` de modo a evitar erros de *Statement Expected*.
  * **Conflito de Inferência Genérica**: Substituídas as chamadas de asserção de contagem `Assert.AreEqual` por comparações explícitas de booleanos `Assert.IsTrue(LTrace.Count = X)` de modo a neutralizar colisões de tipo entre literais de 32 bits e NativeInt/Int64 nas plataformas de 64 bits.
* **`tests/src/tests/Tests.Integration.ServerLifecycle.pas`**:
  * Declaradas variáveis locais de tipo `THorseServerLifecycleProc` para passagens em callbacks de eventos multicast e simulações de exceção.
* **`tests/src/tests/Tests.Horse.Core.MemoryBufferPool.pas`**:
  * Ajustada a asserção de comparação de bytes com `Assert.IsTrue` para evitar conflito de tamanho de tipo inteiro de 64 bits.

---

## Validação e Testes
Todas as modificações foram devidamente compiladas e atestadas como operacionais nas seguintes matrizes de ambiente:

1. **Delphi no Windows (32-bit/64-bit)**: Testes rápidos executados via `dcc32` com 100% de sucesso.
2. **Delphi no Linux (64-bit)**: Compilado com o `dcclinux64` apontando para o SDK do Ubuntu 22.04. Compilação concluída com sucesso.
3. **Lazarus/FPC no Linux**: Imagem de testes compilada e executada via Docker Compose. Todos os testes unitários e de ciclo de vida de middlewares foram concluídos com sucesso.
4. **Lazarus/FPC no Windows**: Compilação local validada.
