### PR TITLE
fix(fpc): fix constref incompatibility in IEqualityComparer<string> u…

### DIFF
--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -2,6 +2,12 @@ unit Horse.Core.Param.Header;
 
 {$IF DEFINED(FPC)}
 {$MODE DELPHI}{$H+}
+{$MACRO ON}
+{$IFDEF CPU32}
+  {$DEFINE CONST_GENERIC := constref}
+{$ELSE}
+  {$DEFINE CONST_GENERIC := const}
+{$ENDIF}
 {$ENDIF}
 
 interface
@@ -34,8 +40,8 @@ type
 {$IF DEFINED(FPC)}
   THorseHeaderComparer = class(TInterfacedObject, IEqualityComparer<string>)
   public
-    function Equals(constref A, B: string): Boolean;
-    function GetHashCode(constref Value: string): DWord;
+    function Equals(CONST_GENERIC A, B: string): Boolean;
+    function GetHashCode(CONST_GENERIC Value: string): DWord;
   end;
 {$ENDIF}
 
@@ -66,7 +72,7 @@ uses
   Horse.Rtti;
 
 {$IF DEFINED(FPC)}
-function THorseHeaderComparer.Equals(constref A, B: string): Boolean;
+function THorseHeaderComparer.Equals(CONST_GENERIC A, B: string): Boolean;
 begin
   Result := SameText(A, B);
 end;
@@ -75,7 +81,7 @@ end;
   zero-allocation para evitar a alocacao temporaria gerada por LowerCase no FPC.
   Isso otimiza o hot path de busca de headers e resolve problemas de link de
   comparadores nativos sob FPC. }
-function THorseHeaderComparer.GetHashCode(constref Value: string): DWord;
+function THorseHeaderComparer.GetHashCode(CONST_GENERIC Value: string): DWord;
 var
   I: Integer;
   LChar: Char;


### PR DESCRIPTION
## Descrição
Corrige o erro de compilação em ambientes Lazarus/FPC com o modo de compatibilidade Delphi ativado (`{$MODE DELPHI}{$H+}`). O compilador falhava ao tentar acoplar a classe `THorseHeaderComparer` à interface `IEqualityComparer<string>` devido ao uso inadequado do modificador `constref` na assinatura em arquiteturas de 64 bits.

## Causa Raiz
O compilador FPC altera a forma de resolver parâmetros constantes genéricos em `IEqualityComparer<T>` conforme a arquitetura da CPU:
* Em **32 bits (i386)**, a interface genérica espera parâmetros definidos com `constref`.
* Em **64 bits (x86_64)**, ela espera parâmetros do tipo `const`.

A definição anterior forçava `constref` estaticamente, quebrando a compilação em arquiteturas de 64 bits (conforme relatado na issue #527) e quebrando em 32 bits se alterássemos apenas para `const`.

## Solução
Implementada a macro condicional de compilação `CONST_GENERIC` baseada na arquitetura da CPU da unit `Horse.Core.Param.Header.pas`:
* Em CPUs de 32 bits (`CPU32`), ela resolve para `constref`.
* Nas demais (como `CPU64`), ela resolve para `const`.

## Validação Efetuada
O framework foi compilado e verificado com sucesso nas seguintes plataformas locais:
* **Delphi 10 Seattle, 11 Alexandria, 12 Athens e 13 Florence** (Win32) -> **SUCESSO**
* **Lazarus/FPC 3.2.2** (Win32 / i386) -> **SUCESSO**
