### PR TITLE
fix(core): fix Delphi compilation error E2026 caused by FPC_FULLVERSION

### DIFF
--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -1,20 +1,9 @@
 unit Horse.Core.Param.Header;
 
-{$IF DEFINED(FPC)}
-{$MODE DELPHI}{$H+}
-{$MACRO ON}
-{$IF FPC_FULLVERSION >= 30301}
-  // FPC 3.3.1+ (trunk) rtl-generics declares IEqualityComparer<T> with
-  // Delphi-compatible const parameters on EVERY platform (not just Win64).
-  // Upstream's guard only checks CPU64+WINDOWS, so on FPC-trunk Linux it
-  // picks constref and fails: "No matching implementation for interface
-  // method Equals(const...)". (Upstream-PR candidate.)
-  {$DEFINE CONST_GENERIC := const}
-{$ELSEIF DEFINED(CPU64) AND DEFINED(WINDOWS)}
-  {$DEFINE CONST_GENERIC := const}
-{$ELSE}
-  {$DEFINE CONST_GENERIC := constref}
-{$ENDIF}
+{$IFDEF FPC}
+  {$MODE DELPHI}{$H+}
+  {$MACRO ON}
+  {$I Horse.FPC.inc}
 {$ENDIF}
 
 interface

--- a/src/Horse.FPC.inc
+++ b/src/Horse.FPC.inc
@@ -1,0 +1,12 @@
+{$IF FPC_FULLVERSION >= 30301}
+  // FPC 3.3.1+ (trunk) rtl-generics declares IEqualityComparer<T> with
+  // Delphi-compatible const parameters on EVERY platform (not just Win64).
+  // Upstream's guard only checks CPU64+WINDOWS, so on FPC-trunk Linux it
+  // picks constref and fails: "No matching implementation for interface
+  // method Equals(const...)". (Upstream-PR candidate.)
+  {$DEFINE CONST_GENERIC := const}
+{$ELSEIF DEFINED(CPU64) AND DEFINED(WINDOWS)}
+  {$DEFINE CONST_GENERIC := const}
+{$ELSE}
+  {$DEFINE CONST_GENERIC := constref}
+{$ENDIF}


### PR DESCRIPTION
## Descrição
Corrige a issue #536.

Este Pull Request corrige uma falha de compilação no Delphi que ocorria na unit `Horse.Core.Param.Header.pas` em decorrência da avaliação de `FPC_FULLVERSION` pelo pré-processador do Delphi.

### Causa do Problema
Mesmo quando o bloco externo `{$IF DEFINED(FPC)}` resulta em `False` sob o compilador Delphi, o pré-processador do Delphi continua inspecionando e avaliando a expressão condicional aninhada `{$IF FPC_FULLVERSION >= 30301}` enquanto faz a busca pelo seu `{$ENDIF}` correspondente. Como o símbolo `FPC_FULLVERSION` não é definido no Delphi, a avaliação sintática e semântica falha gerando o erro de compilação `E2026 Constant expression expected`.

### Solução Aplicada
Para contornar essa limitação do pré-processador do Delphi, isolamos as diretivas de verificação de versão do Free Pascal em um arquivo de inclusão separado (`src/Horse.FPC.inc`), o qual é condicionalmente carregado apenas quando o compilador em uso é o FPC:

```pascal
{$IFDEF FPC}
  {$MODE DELPHI}{$H+}
  {$MACRO ON}
  {$I Horse.FPC.inc}
{$ENDIF}
```
Dessa forma, como o símbolo FPC não é definido sob Delphi, o compilador do Delphi ignora completamente o bloco aninhado (inclusive a diretiva de inclusão {$I}), evitando que o arquivo Horse.FPC.inc seja lido ou processado. Isso soluciona o erro E2026 sem alterar em nada o comportamento esperado nas diferentes versões dos compiladores Delphi ou FPC/Lazarus.