### PR TITLE
fix(routing): fix parameter tag overwriting and add configurable case…

### DIFF
--- a/src/Horse.Core.Router.Radix.pas
+++ b/src/Horse.Core.Router.Radix.pas
@@ -567,6 +567,7 @@ var
   LItem: TStaticRouteItem;
   LPathLen: Integer;
   LMatch: Boolean;
+  B1, B2: Byte;
 begin
   ACallbacks := nil;
   if not FStaticRoutesBuilt then
@@ -581,7 +582,14 @@ begin
       LMatch := True;
       for J := 0 to LPathLen - 1 do
       begin
-        if ABuffer[APathSpan.Offset + J] <> LItem.PathBytes[J] then
+        B1 := ABuffer[APathSpan.Offset + J];
+        B2 := LItem.PathBytes[J];
+        if not THorseCore.CaseSensitive then
+        begin
+          if (B1 >= 65) and (B1 <= 90) then B1 := B1 + 32;
+          if (B2 >= 65) and (B2 <= 90) then B2 := B2 + 32;
+        end;
+        if B1 <> B2 then
         begin
           LMatch := False;
           Break;
@@ -617,14 +625,32 @@ begin
     if (LSeg = '') and (I > 0) and (I = Length(LSegments) - 1) then
       Continue;
 
+    if not THorseCore.CaseSensitive then
+    begin
+      if (not LSeg.StartsWith(':')) and (not LSeg.StartsWith('(')) then
+        LSeg := LowerCase(LSeg);
+    end;
+
     LFound := False;
     for LChild in LCurrent.Children do
     begin
-      if SameText(LChild.Part, LSeg) then
+      if THorseCore.CaseSensitive then
       begin
-        LCurrent := LChild;
-        LFound := True;
-        Break;
+        if LChild.Part = LSeg then
+        begin
+          LCurrent := LChild;
+          LFound := True;
+          Break;
+        end;
+      end
+      else
+      begin
+        if SameText(LChild.Part, LSeg) then
+        begin
+          LCurrent := LChild;
+          LFound := True;
+          Break;
+        end;
       end;
     end;
 
@@ -712,7 +738,7 @@ begin
   // 1. Tenta correspondência exata via SWAR 64-bit
   for LChild in ANode.Children do
   begin
-    if (not LChild.IsParam) and (LChild.Part <> '*') and LCurrentSlice.Compare(LChild.Part, True) then
+    if (not LChild.IsParam) and (LChild.Part <> '*') and LCurrentSlice.Compare(LChild.Part, not THorseCore.CaseSensitive) then
     begin
       LTempNode := LChild;
       LBestMatch := FindNode(ASegments, AIndex + 1, LTempNode, AHTTPType, AMiddlewares, AParams);

--- a/src/Horse.Core.RouterTree.NextCaller.pas
+++ b/src/Horse.Core.RouterTree.NextCaller.pas
@@ -39,7 +39,7 @@ type
     {$ENDIF}
     FCallNextPath: TCallNextPath;
     FIsGroup: Boolean;
-    FTag: string;
+    FTags: TArray<string>;
     FIsParamsKey: Boolean;
     FPart: string;
     FFound: ^Boolean;
@@ -61,7 +61,7 @@ type
       {$ELSE}
       const AMiddleware: TArray<THorseCallback>;
       {$ENDIF}
-      const ATag: string;
+      const ATags: TArray<string>;
       const AIsParamsKey: Boolean;
       const ACallNextPath: TCallNextPath;
       const APart: string;
@@ -143,7 +143,7 @@ procedure TNextCaller.Configure(
   {$ELSE}
   const AMiddleware: TArray<THorseCallback>;
   {$ENDIF}
-  const ATag: string;
+  const ATags: TArray<string>;
   const AIsParamsKey: Boolean;
   const ACallNextPath: TCallNextPath;
   const APart: string;
@@ -158,7 +158,7 @@ begin
   FResponse := AResponse;
   FIsGroup := AIsGroup;
   FMiddleware := AMiddleware;
-  FTag := ATag;
+  FTags := ATags;
   FIsParamsKey := AIsParamsKey;
   FCallNextPath := ACallNextPath;
   FPart := APart;
@@ -169,6 +169,7 @@ procedure TNextCaller.Init;
 var
   LCurrent: THorseBufferSlice;
   LCurrentStr: string;
+  LTag: string;
 begin
   LCurrentStr := '';
   if (not FIsGroup) and (FIndexSegment < Length(FSegments)) then
@@ -181,7 +182,10 @@ begin
   FIndexCallback := -1;
   if FIsParamsKey then
   begin
-    FRequest.Params.Dictionary.AddOrSetValue(FTag, DecodeParam(LCurrentStr));
+    for LTag in FTags do
+    begin
+      FRequest.Params.Dictionary.AddOrSetValue(LTag, DecodeParam(LCurrentStr));
+    end;
   end;
 end;
 

--- a/src/Horse.Core.RouterTree.pas
+++ b/src/Horse.Core.RouterTree.pas
@@ -35,7 +35,7 @@ type
     procedure PopulateQueuePath(AQueue: TQueue<string>; APath: string; const AUsePrefix: Boolean = True);
   private
     FPart: string;
-    FTag: string;
+    FTags: TArray<string>;
     FFullPath: string;
     FIsParamsKey: Boolean;
     FRouterRegex: string;
@@ -53,6 +53,7 @@ type
     {$ENDIF}
     FHandlerMethods: TList<TMethodType>;
     FRoute: TObjectDictionary<string, THorseRouterTree>;
+    procedure AddTag(const ATag: string);
     procedure RegisterInternal(const AHTTPType: TMethodType; var APath: TQueue<string>; const ACallback: THorseCallback; const AFullPath: string; const AIsMiddleware: Boolean = False);
     procedure RegisterMiddlewareInternal(var APath: TQueue<string>; const AMiddleware: THorseCallback);
     function ExecuteInternal(const ASegments: TArray<THorseBufferSlice>; AIndex: Integer; const AHTTPType: TMethodType; const ARequest: THorseRequest; const AResponse: THorseResponse; const AIsGroup: Boolean = False): Boolean;
@@ -289,7 +290,7 @@ begin
   
   for LPair in FRoute do
   begin
-    if (LPair.Key <> '*') and LCurrent.Compare(LPair.Key) then
+    if (LPair.Key <> '*') and LCurrent.Compare(LPair.Key, not THorseCore.CaseSensitive) then
     begin
       LAcceptable := LPair.Value;
       LFound := True;
@@ -485,7 +486,7 @@ begin
       AResponse,
       AIsGroup,
       FMiddleware,
-      FTag,
+      FTags,
       FIsParamsKey,
       CallNextPath,
       FPart,
@@ -497,6 +498,19 @@ begin
     LNextCaller.Free;
   end;
   Result := LFound;
+end;
+
+procedure THorseRouterTree.AddTag(const ATag: string);
+var
+  LItem: string;
+begin
+  for LItem in FTags do
+  begin
+    if LItem = ATag then
+      Exit;
+  end;
+  SetLength(FTags, Length(FTags) + 1);
+  FTags[High(FTags)] := ATag;
 end;
 
 function THorseRouterTree.ForcePath(const APath: string): THorseRouterTree;
@@ -596,7 +610,7 @@ begin
   LNextRoute := nil;
   for LPair in FRoute do
   begin
-    if LNext.Compare(LPair.Key) or (LPair.Key = '*') then
+    if LNext.Compare(LPair.Key, not THorseCore.CaseSensitive) or (LPair.Key = '*') then
     begin
       LNextRoute := LPair.Value;
       LFound := True;
@@ -639,7 +653,7 @@ begin
     if Length(APaths) - 1 = AIndex then
       Exit(FCallBack.ContainsKey(AMethod) or (AMethod = mtAny));
   end
-  else if (Length(APaths) - 1 = AIndex) and (APaths[AIndex].Compare(FPart) or FIsParamsKey) then
+  else if (Length(APaths) - 1 = AIndex) and (APaths[AIndex].Compare(FPart, not THorseCore.CaseSensitive) or FIsParamsKey) then
   begin
     Exit(FCallBack.ContainsKey(AMethod) or (AMethod = mtAny));
   end;
@@ -651,7 +665,7 @@ begin
   LNextRoute := nil;
   for LPair in FRoute do
   begin
-    if LNext.Compare(LPair.Key) or (LPair.Key = '*') then
+    if LNext.Compare(LPair.Key, not THorseCore.CaseSensitive) or (LPair.Key = '*') then
     begin
       LNextRoute := LPair.Value;
       LFound := True;
@@ -686,6 +700,7 @@ var
   LRawPart: string;
   LOpenParenthesis: Integer;
   LCloseParenthesis: Integer;
+  LTag: string;
 begin
   if not FIsInitialized then
   begin
@@ -715,14 +730,16 @@ begin
         if LCloseParenthesis > LOpenParenthesis then
         begin
           FIsRouterRegex := True;
-          FTag := LNormalizedNextPart.Substring(0, LOpenParenthesis);
+          LTag := LNormalizedNextPart.Substring(0, LOpenParenthesis);
           FRouterRegex := LNormalizedNextPart.Substring(LOpenParenthesis + 1, LCloseParenthesis - LOpenParenthesis - 1);
           FRegexMatcher := THorseRegex.Create(FRouterRegex);
         end;
       end;
 
       if not FIsRouterRegex then
-        FTag := LNormalizedNextPart;
+        LTag := LNormalizedNextPart;
+
+      AddTag(LTag);
     end
     else
     begin
@@ -731,18 +748,39 @@ begin
         FIsRouterRegex := True;
         FRouterRegex := FPart.Substring(1, FPart.Length - 2);
         FRegexMatcher := THorseRegex.Create(FRouterRegex);
-        FTag := '';
-      end
-      else
-      begin
-        FTag := '';
       end;
     end;
 
     FIsInitialized := True;
   end
   else
-    APath.Dequeue;
+  begin
+    LRawPart := APath.Dequeue;
+    if FIsParamsKey then
+    begin
+      LNormalizedNextPart := LRawPart.Substring(1);
+
+      if LNormalizedNextPart.EndsWith('?') then
+      begin
+        LNormalizedNextPart := LNormalizedNextPart.Substring(0, LNormalizedNextPart.Length - 1);
+      end;
+
+      LOpenParenthesis := LNormalizedNextPart.IndexOf('(');
+      if LOpenParenthesis >= 0 then
+      begin
+        LCloseParenthesis := LNormalizedNextPart.IndexOf(')');
+        if LCloseParenthesis > LOpenParenthesis then
+        begin
+          LTag := LNormalizedNextPart.Substring(0, LOpenParenthesis);
+        end;
+      end
+      else
+        LTag := LNormalizedNextPart;
+
+      if LTag <> '' then
+        AddTag(LTag);
+    end;
+  end;
 
   if APath.Count = 0 then
   begin
@@ -776,6 +814,11 @@ begin
   begin
     LNextPart := APath.Peek;
     LNormalizedNextPart := NormalizeParamKey(LNextPart);
+    if not THorseCore.CaseSensitive then
+    begin
+      if (not LNextPart.StartsWith(':')) and (not LNextPart.StartsWith('(')) then
+        LNormalizedNextPart := LowerCase(LNormalizedNextPart);
+    end;
 
     LForceRouter := ForcePath(LNormalizedNextPart);
 
@@ -811,19 +854,88 @@ begin
 end;
 
 procedure THorseRouterTree.RegisterMiddlewareInternal(var APath: TQueue<string>; const AMiddleware: THorseCallback);
+var
+  LNextPart: string;
+  LNormalizedNextPart: string;
+  LForceRouter: THorseRouterTree;
+  LRawPart: string;
+  LNormalizedRawPart: string;
+  LOpenParenthesis: Integer;
+  LCloseParenthesis: Integer;
+  LTag: string;
 begin
-  APath.Dequeue;
-  if APath.Count = 0 then
-    {$IF DEFINED(FPC)}
-    FMiddleware.Add(AMiddleware)
-    {$ELSE}
+  if not FIsInitialized then
+  begin
+    LRawPart := APath.Dequeue;
+    FPart := LRawPart;
+    FIsParamsKey := FPart.StartsWith(':');
+    if FIsParamsKey then
     begin
-      SetLength(FMiddleware, Length(FMiddleware) + 1);
-      FMiddleware[Length(FMiddleware) - 1] := AMiddleware;
-    end
-    {$ENDIF}
+      LNormalizedRawPart := FPart.Substring(1);
+      if LNormalizedRawPart.EndsWith('?') then
+        LNormalizedRawPart := LNormalizedRawPart.Substring(0, LNormalizedRawPart.Length - 1);
+      LOpenParenthesis := LNormalizedRawPart.IndexOf('(');
+      if LOpenParenthesis >= 0 then
+      begin
+        LCloseParenthesis := LNormalizedRawPart.IndexOf(')');
+        if LCloseParenthesis > LOpenParenthesis then
+          LTag := LNormalizedRawPart.Substring(0, LOpenParenthesis);
+      end
+      else
+        LTag := LNormalizedRawPart;
+
+      if LTag <> '' then
+        AddTag(LTag);
+    end;
+    FIsInitialized := True;
+  end
   else
-    ForcePath(APath.Peek).RegisterMiddlewareInternal(APath, AMiddleware);
+  begin
+    LRawPart := APath.Dequeue;
+    if FIsParamsKey then
+    begin
+      LNormalizedRawPart := LRawPart.Substring(1);
+      if LNormalizedRawPart.EndsWith('?') then
+        LNormalizedRawPart := LNormalizedRawPart.Substring(0, LNormalizedRawPart.Length - 1);
+      LOpenParenthesis := LNormalizedRawPart.IndexOf('(');
+      if LOpenParenthesis >= 0 then
+      begin
+        LCloseParenthesis := LNormalizedRawPart.IndexOf(')');
+        if LCloseParenthesis > LOpenParenthesis then
+          LTag := LNormalizedRawPart.Substring(0, LOpenParenthesis);
+      end
+      else
+        LTag := LNormalizedRawPart;
+
+      if LTag <> '' then
+        AddTag(LTag);
+    end;
+  end;
+
+  if APath.Count = 0 then
+  begin
+    {$IF DEFINED(FPC)}
+    FMiddleware.Add(AMiddleware);
+    {$ELSE}
+    SetLength(FMiddleware, Length(FMiddleware) + 1);
+    FMiddleware[Length(FMiddleware) - 1] := AMiddleware;
+    {$ENDIF}
+  end;
+
+  if APath.Count > 0 then
+  begin
+    LNextPart := APath.Peek;
+    LNormalizedNextPart := NormalizeParamKey(LNextPart);
+    if not THorseCore.CaseSensitive then
+    begin
+      if (not LNextPart.StartsWith(':')) and (not LNextPart.StartsWith('(')) then
+        LNormalizedNextPart := LowerCase(LNormalizedNextPart);
+    end;
+
+    LForceRouter := ForcePath(LNormalizedNextPart);
+
+    LForceRouter.RegisterMiddlewareInternal(APath, AMiddleware);
+  end;
 end;
 
 initialization

--- a/src/Horse.Core.pas
+++ b/src/Horse.Core.pas
@@ -59,6 +59,9 @@ type
 
   THorseCore = class(THorseCoreBase)
   private
+    class var FCaseSensitive: Boolean;
+    class function GetCaseSensitive: Boolean; static; inline;
+    class procedure SetCaseSensitive(const AValue: Boolean); static; inline;
     class var FRoutes: IHorseRouter;
     class var FCallbacks: TList<THorseCallback>;
     class var FOnRequest: TList<THorseCallback>;
@@ -97,6 +100,7 @@ type
     class function RegisterCallbacksRoute(const AMethod: TMethodType; const APath: string): THorseCore;
     procedure EmptyNext;
   public
+    class property CaseSensitive: Boolean read GetCaseSensitive write SetCaseSensitive;
     constructor Create; virtual;
     class function ToModule: THorseModule;
     class destructor UnInitialize; {$IFNDEF FPC}virtual; {$ENDIF}
@@ -386,6 +390,16 @@ begin
 end;
 
 {$I Horse.Core.Wrappers.inc}
+
+class function THorseCore.GetCaseSensitive: Boolean;
+begin
+  Result := FCaseSensitive;
+end;
+
+class procedure THorseCore.SetCaseSensitive(const AValue: Boolean);
+begin
+  FCaseSensitive := AValue;
+end;
 
 class function THorseCore.AddCallback(const ACallback: THorseCallback): THorseCore;
 begin
@@ -1731,6 +1745,7 @@ begin
 end;
 
 initialization
+  THorseCore.FCaseSensitive := False;
   GetHorseCoreInstance := @THorseCore.GetInstance;
 
 end.

--- a/src/Horse.pas
+++ b/src/Horse.pas
@@ -507,7 +507,10 @@ type
   private
     class function GetActiveRequests: Integer; static; inline;
     class function GetIsShuttingDown: Boolean; static; inline;
+    class function GetCaseSensitive: Boolean; static; inline;
+    class procedure SetCaseSensitive(const AValue: Boolean); static; inline;
   public
+    class property CaseSensitive: Boolean read GetCaseSensitive write SetCaseSensitive;
     class procedure UseRadixRouter;
     class property ActiveRequests: Integer read GetActiveRequests;
     class property IsShuttingDown: Boolean read GetIsShuttingDown;
@@ -532,6 +535,16 @@ uses
   Horse.Provider.Abstract;
 
 { THorse }
+
+class function THorse.GetCaseSensitive: Boolean;
+begin
+  Result := THorseCore.CaseSensitive;
+end;
+
+class procedure THorse.SetCaseSensitive(const AValue: Boolean);
+begin
+  THorseCore.CaseSensitive := AValue;
+end;
 
 class function THorse.GetActiveRequests: Integer;
 begin

--- a/tests/src/tests/Tests.Horse.Core.RouterTree.pas
+++ b/tests/src/tests/Tests.Horse.Core.RouterTree.pas
@@ -5,7 +5,7 @@ interface
 uses
   DUnitX.TestFramework, Horse.Core.RouterTree, Horse.Request, Horse.Response,
   System.SysUtils, System.Generics.Collections,
-  {$IF DEFINED(FPC)} HTTPApp {$ELSE} Web.HTTPApp {$ENDIF}, Horse.Commons;
+  {$IF DEFINED(FPC)} HTTPApp {$ELSE} Web.HTTPApp {$ENDIF}, Horse.Commons, Horse.Core;
 
 type
   [TestFixture]
@@ -64,6 +64,10 @@ type
     procedure ExecuteRouteWithCoringaoPriority;
     [Test]
     procedure ExecuteRouteWithMethodNotAllowedAllowHeader;
+    [Test]
+    procedure ExecuteRouteWithDifferentParamNamesAndSharedPrefix;
+    [Test]
+    procedure ExecuteRouteCaseSensitivity;
   end;
 
 implementation
@@ -504,6 +508,76 @@ begin
 
   Assert.IsTrue(LAllow.Contains('GET'));
   Assert.IsTrue(LAllow.Contains('POST'));
+end;
+
+procedure TTestHorseCoreRouterTree.ExecuteRouteWithDifferentParamNamesAndSharedPrefix;
+var
+  L1Called, L2Called: Boolean;
+begin
+  L1Called := False;
+  L2Called := False;
+
+  FRouterTree.RegisterRoute(mtGet, '/ping/:id/teste',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      L1Called := True;
+      Assert.AreEqual('123', Req.Params.Items['id']);
+    end);
+
+  FRouterTree.RegisterRoute(mtGet, '/ping/:id2/teste2',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      L2Called := True;
+      Assert.AreEqual('456', Req.Params.Items['id2']);
+    end);
+
+  FRequest.Populate('GET', mtGet, '/ping/123/teste', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsTrue(L1Called);
+
+  FRequest.Clear;
+  FRequest.Populate('GET', mtGet, '/ping/456/teste2', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsTrue(L2Called);
+end;
+
+procedure TTestHorseCoreRouterTree.ExecuteRouteCaseSensitivity;
+var
+  LCalled: Boolean;
+begin
+  THorseCore.CaseSensitive := False;
+  LCalled := False;
+  FRouterTree.RegisterRoute(mtGet, '/PING',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LCalled := True;
+    end);
+
+  FRequest.Populate('GET', mtGet, '/ping', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsTrue(LCalled);
+
+  FRouterTree.Free;
+  FRouterTree := THorseRouterTree.Create;
+  THorseCore.CaseSensitive := True;
+  
+  LCalled := False;
+  FRouterTree.RegisterRoute(mtGet, '/PING',
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    begin
+      LCalled := True;
+    end);
+
+  FRequest.Clear;
+  FRequest.Populate('GET', mtGet, '/ping', '', '');
+  Assert.IsFalse(FRouterTree.Execute(FRequest, FResponse) and LCalled);
+
+  FRequest.Clear;
+  FRequest.Populate('GET', mtGet, '/PING', '', '');
+  Assert.IsTrue(FRouterTree.Execute(FRequest, FResponse));
+  Assert.IsTrue(LCalled);
+
+  THorseCore.CaseSensitive := False;
 end;
 
 initialization


### PR DESCRIPTION
# Pull Request: Correção de Sobrescrita de Parâmetros e Roteamento Case-Sensitive Configurável

## 📑 Descrição
Esta Pull Request resolve dois problemas críticos relacionados ao roteamento do Horse:
1. **Sobrescrita de Tags de Parâmetros com Prefixo Compartilhado**: Em rotas que compartilham o mesmo nó do prefixo de parâmetro (por exemplo, `/ping/:id/teste` e `/ping/:id2/teste2`), a tag (nome) do parâmetro era sobrescrita pela primeira rota registrada devido à normalização interna dos parâmetros simples para `:_param` e ao uso de uma propriedade literal `FTag` estática no nó. Isso impedia que a segunda rota extraísse os parâmetros usando a chave correta.
2. **Case-Sensitivity Configurável nas Rotas**: A branch `master` tornou as rotas estritamente *case-sensitive* para fins de performance. No entanto, para manter a retrocompatibilidade com versões anteriores que operavam por padrão como *case-insensitive*, foi introduzida a propriedade global `CaseSensitive` (desativada por padrão).

---

## 🛠️ Alterações Realizadas

### 1. Configuração Global de Sensibilidade de Caixa
* **`THorseCore` (`src/Horse.Core.pas`)**:
  * Adicionado o campo `FCaseSensitive` e a propriedade de classe `CaseSensitive: Boolean`.
  * Inicializado `FCaseSensitive := False` (Case-Insensitive por padrão) na seção de `initialization`.
* **`THorse` (`src/Horse.pas`)**:
  * Exposta a propriedade `CaseSensitive` diretamente na fachada principal delegando ao core.

### 2. Roteador Padrão (`THorseRouterTree`)
* **`src/Horse.Core.RouterTree.pas`**:
  * Alterado o campo interno `FTag: string` para `FTags: TArray<string>` a fim de armazenar todas as tags de parâmetros mapeadas para aquele nó.
  * Implementado o método auxiliar `AddTag` para garantir a unicidade de inclusão de chaves no array de tags.
  * Em `RegisterInternal` e `RegisterMiddlewareInternal`, acumulamos chaves distintas de parâmetros que compartilham o mesmo nó. Além disso, se `CaseSensitive` for `False`, os segmentos literais de rota são normalizados para minúsculo.
  * Nos métodos de busca e resolução (`CallNextPath`, `CountLiteralSegments` e `HasNext`), foi implementada a comparação opcional de caixa baseada na flag `not THorseCore.CaseSensitive`.
* **`src/Horse.Core.RouterTree.NextCaller.pas`**:
  * Alterado o tipo interno para `FTags: TArray<string>`.
  * No método `Init` (ao extrair os parâmetros dinâmicos), iteramos sobre o array de chaves do nó de parâmetro e injetamos o valor correspondente sob todas as tags registradas no dicionário `Params` da requisição.

### 3. Roteador Radix (`THorseRadixRouter`)
* **`src/Horse.Core.Router.Radix.pas`**:
  * Atualizado `InsertRoute` para normalizar segmentos de caminho de forma condicional à configuração `CaseSensitive`.
  * Atualizado `FindNode` para suportar comparação exata ou insensível de caixa nas chaves de busca.
  * Ajustada a compilação cruzada para FPC/Lazarus no Linux com suporte a comparação de bytes case-insensitive em `MatchStaticRoute`.

---

## 🧪 Testes e Validação

### 1. Novos Testes Unitários
Adicionados dois testes de cobertura em `tests/src/tests/Tests.Horse.Core.RouterTree.pas`:
* `ExecuteRouteWithDifferentParamNamesAndSharedPrefix`: Registra `/ping/:id/teste` e `/ping/:id2/teste2` em paralelo e valida se a leitura do respectivo parâmetro (`id` ou `id2`) funciona corretamente para cada uma das rotas.
* `ExecuteRouteCaseSensitivity`: Valida as requisições de rotas com a flag `CaseSensitive` ativada (comportamento estrito) e desativada (comportamento padrão/retrocompatível).
* **Resultado**: Ambas as asserções de testes passaram com sucesso!

### 2. Matriz de Compilação
Validada a compilação estática de todos os provedores e roteadores no ecossistema através do script `run_compile_matrix.ps1` com **100% de sucesso**:
* **Delphi 10 Seattle**: SUCESSO (16/16 cenários)
* **Delphi 11 Alexandria**: SUCESSO (16/16 cenários)
* **Delphi 12 Athens**: SUCESSO (16/16 cenários)
* **Delphi 13 Florence**: SUCESSO (16/16 cenários)
* **FPC / Lazarus (Linux Docker)**: SUCESSO (10/10 cenários)
