### PR TITLE
feat: Res.Send<TStream>(S) now writes stream bytes to the response body

### DIFF
--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -165,12 +165,30 @@ type
 { REPEATHDR-1 — lazy-allocation helper for FRepeatHeaders (mirrors EnsureCustomHeaders). }
     procedure EnsureRepeatHeaders;
 { =========================================================================== }
+{ ===========================================================================
+  PATCH-RES-8 — Send<TStream> / Send(TStream) stream body support.
+  Copies AStream into the active body slot (FCSContentStream on
+  CrossSocket/mORMot/nghttp2/IOCP/Epoll, FWebResponse.ContentStream on
+  Indy/WebBroker), applies a default Content-Type of application/octet-stream
+  if none was set, then frees AStream (ownership transfer).  Reused by both
+  the non-generic Send(TStream) overload and the generic Send<T> when T is a
+  TStream descendant.
+  =========================================================================== }
+    procedure DoSendStream(const AStream: TStream);
+{ =========================================================================== }
   public
     class procedure RegisterStreamWriterFactory(const AFactory: THorseStreamWriterFactory);
     function SendStream(const ACallback: THorseStreamProc): THorseResponse; overload;
     function SendStream(const ACallback: THorseStreamAnonProc): THorseResponse; overload;
     function Send(const AContent: string): THorseResponse; overload; virtual;
     function Send(const AContent: TBytes): THorseResponse; overload; virtual;
+{ PATCH-RES-8 — non-generic Send(TStream) overload.
+  Copies AContent into the response body, defaults Content-Type to
+  application/octet-stream if none was set, then Frees AContent
+  (Horse takes ownership).  The generic Send<T> below routes TStream
+  descendants through the same path via DoSendStream, so both
+  `Res.Send(S)` and `Res.Send<TStream>(S)` work identically. }
+    function Send(const AContent: TStream): THorseResponse; overload; virtual;
     function Send<T{$IF NOT DEFINED(FPC)}: class{$ENDIF}>(AContent: T): THorseResponse; overload;
     function RedirectTo(const ALocation: string): THorseResponse; overload; virtual;
     function RedirectTo(const ALocation: string; const AStatus: THTTPStatus): THorseResponse; overload; virtual;
@@ -696,8 +714,79 @@ end;
 
 function THorseResponse.Send<T>(AContent: T): THorseResponse;
 begin
-  FContent := AContent;
+{ PATCH-RES-8 — TStream fast path.  Prior to this patch, Send<T> stored the
+  argument in FContent (a slot for content-type middleware such as
+  horse-jhonson) and returned.  No provider bridge ever read FContent as a
+  stream, so `Res.Send<TStream>(S)` produced `HTTP 200 Content-Length: 0`
+  on every provider.  Now: if T is a TStream, route to DoSendStream which
+  copies bytes into the active body slot and takes ownership.  Non-stream
+  callers hit the else-branch below, whose behavior is identical to before. }
+  if TObject(AContent) is TStream then
+    DoSendStream(TStream(TObject(AContent)))
+  else
+    FContent := AContent;
   Result := Self;
+end;
+
+{ PATCH-RES-8 — non-generic Send(TStream) overload.  Compiler picks this over
+  the generic Send<T> when the argument's static type is TStream (or a known
+  subclass at the call site), so `Res.Send(myMemStream)` doesn't need the
+  explicit `<TStream>` generic instantiation.  Both call paths funnel through
+  DoSendStream, so ownership and Content-Type behavior are identical. }
+function THorseResponse.Send(const AContent: TStream): THorseResponse;
+begin
+  DoSendStream(AContent);
+  Result := Self;
+end;
+
+{ PATCH-RES-8 — shared stream body helper.  Copies AStream into the active
+  body slot (FCSContentStream for CrossSocket/mORMot/nghttp2/IOCP/Epoll,
+  FWebResponse.ContentStream for Indy/WebBroker) so the provider bridge's
+  existing ContentStream reader picks it up.  Sets a default Content-Type of
+  application/octet-stream only if the caller didn't already set one.
+  Frees AStream after copying — Horse takes ownership, matching the
+  historical Send<T> contract where Clear/Destroy freed FContent. }
+procedure THorseResponse.DoSendStream(const AStream: TStream);
+var
+  LCopy: TMemoryStream;
+begin
+  if not Assigned(AStream) then
+    Exit;
+
+  AStream.Position := 0;
+
+  if not Assigned(FWebResponse) then
+  begin
+    { CrossSocket-family path — mirrors PATCH-SENDFILE-1's copy-and-own pattern.
+      Free any prior owned stream first so double-Send calls don't leak. }
+    if FCSOwnsContentStream and Assigned(FCSContentStream) then
+      FreeAndNil(FCSContentStream);
+    LCopy := TMemoryStream.Create;
+    if AStream.Size > 0 then
+      LCopy.CopyFrom(AStream, AStream.Size);
+    LCopy.Position := 0;
+    FCSContentStream     := LCopy;
+    FCSOwnsContentStream := True;
+    if FCSContentType = '' then
+      FCSContentType := 'application/octet-stream';
+  end
+  else
+  begin
+    { Indy/WebBroker path — mirrors PATCH-SENDFILE-1's Indy branch.  Copy into
+      a fresh TMemoryStream and hand ownership to TWebResponse via
+      FreeContentStream := True so the caller's source stream is decoupled. }
+    LCopy := TMemoryStream.Create;
+    if AStream.Size > 0 then
+      LCopy.CopyFrom(AStream, AStream.Size);
+    LCopy.Position := 0;
+    FWebResponse.ContentStream     := LCopy;
+    FWebResponse.FreeContentStream := True;
+    FWebResponse.ContentLength     := LCopy.Size;
+    if FWebResponse.ContentType = '' then
+      FWebResponse.ContentType := 'application/octet-stream';
+  end;
+
+  AStream.Free;
 end;
 
 function THorseResponse.RedirectTo(const ALocation: string): THorseResponse;


### PR DESCRIPTION
## Summary

`Res.Send<TStream>(SomeStream).Status(200)` currently produces `HTTP 200 Content-Length: 0` on every Horse provider (Indy, HTTP.sys, IOCP, Epoll). This is because `THorseResponse.Send<T>` only assigns `FContent := AContent` — a `TObject` slot intended for content-type middleware (`horse-jhonson`, etc.) — and no provider bridge ever reads `FContent` as a stream.

This PR adds a `DoSendStream` helper and a runtime `is TStream` branch in `Send<T>` so that stream bodies are copied into the existing `FCSContentStream` / `FWebResponse.ContentStream` slots that every provider already reads. A non-generic typed `Send(TStream)` overload is also added so `Res.Send(S)` works without an explicit generic type argument.

Third-party providers (CrossSocket, mORMot, nghttp2) benefit automatically because the fix operates on the same shared shadow-field slots — no provider-side changes needed anywhere in the ecosystem.

## The user-visible change

Before:
```pascal
Res.ContentType('text/plain').Send<TStream>(MyStream).Status(200);
// → HTTP 200 Content-Length: 0  (stream never reaches the wire)
```

After:
```pascal
Res.ContentType('text/plain').Send<TStream>(MyStream).Status(200);
// → HTTP 200 Content-Length: N  (stream contents in body)

Res.Send(MyStream).Status(200);  // typed overload — no <TStream> needed
// → HTTP 200 Content-Type: application/octet-stream  (default if none set)
```

## Design

Three additions to `src/Horse.Response.pas`:

1. **Private `DoSendStream(AStream: TStream)`** — copies the source stream into the active body slot:
   - `FCSContentStream` (HTTP.sys, IOCP, Epoll, and third-party providers via the shadow-field path)
   - `FWebResponse.ContentStream` (Indy / WebBroker — the traditional TWebResponse path)
   
   Follows the exact copy-and-own pattern already used by the existing `SendFile(TStream, ...)` method. Defaults `Content-Type` to `application/octet-stream` if the caller hasn't set one. Resets `Position := 0` before copying so the common "position at end after writing" gotcha doesn't produce empty bodies.

2. **Non-generic overload `Send(const AContent: TStream): THorseResponse`** — declared alongside the existing `Send(string)` and `Send(TBytes)` overloads. Compiler picks it when the argument's static type is `TStream` (or a known subclass), so `Res.Send(MyStream)` works without `<TStream>`.

3. **Modified `Send<T>` body** — runtime `TObject(AContent) is TStream` branch routes to `DoSendStream`; the else-path `FContent := AContent` is unchanged, so all existing non-stream `Send<T>` callers (JSON serializers via `horse-jhonson`, etc.) keep working identically.

## Ownership contract

Horse takes ownership of the stream — `DoSendStream` copies the bytes into an internal `TMemoryStream` and then calls `AStream.Free`. Matches the historical `Send<T>` contract where `Clear`/`Destroy` freed `FContent`. Callers must NOT wrap in `try/finally S.Free` (double-free).

`SendFile(AStream, name, type)` is unchanged — it still does NOT take ownership. Existing `SendFile` code continues to work identically.

## Backward compatibility

- Non-stream `Send<T>` callers hit the unchanged `else FContent := AContent` branch — JSON middleware and any other `TObject`-slot users see identical behavior.
- Double `Send<TStream>(S1).Send<TStream>(S2)` on the same response replaces the first body with the second (via the existing `FCSOwnsContentStream` free-first guard on the shadow path; via `FWebResponse.ContentStream :=` overwrite on the Indy path).
- `Res.Send(nil)` is a no-op via nil-guard in `DoSendStream` (matches `Send('')` behavior).
- No provider unit is touched — the fix works everywhere because every provider bridge already reads `ContentStream`.

## Behavioral change to be aware of

Any code that currently calls `Res.Send<TStream>(S)` and expected an empty body (either as a workaround or because they tested against the broken behavior) will now receive the stream contents. This is the intended fix, but downstream test mocks that relied on receiving empty responses may need updating.

## Verification

A comprehensive reproducer + regression suite is available at `patches/horse-provider-crosssocket/samples/stream-demo/` in [freitasjca/horse-crosssocket-workspace](https://github.com/freitasjca/horse-provider-crosssocket/tree/dev/samples/stream-demo). Runs on the CrossSocket provider by default; the same handler code works on any Horse provider once this PR is merged.

Test coverage in the demo:
- 7 endpoints exercising `Send<TStream>(S)` with `TMemoryStream`, position-at-end, position-reset, 30 bytes, 1024-byte pattern, 64 KB payload, `TFDMemTable` in `sfBinary`/`sfXML`/`sfJSON`
- 3 regression endpoints using `SendFile` (unchanged) that produce byte-identical output to the new `Send<TStream>` path — validates the fix produces the same wire bytes as the pre-existing working API

Result: 47/47 assertions PASS on CrossSocket Win32 (Delphi 12.1).

## Files changed

- `src/Horse.Response.pas` — one file, 90 lines added, 1 line modified (only the generic `Send<T>` body changes)
- Zero provider changes
- Zero breaking API changes

## Base version

Branched off `master` at Horse 3.3.2 (commit `72cc45f`). Applies cleanly on top of the current release.
