### PR TITLE
Fix IOCP connection context lifetime

### DIFF
--- a/src/Horse.Provider.IOCP.pas
+++ b/src/Horse.Provider.IOCP.pas
@@ -218,11 +218,32 @@ type
     Closed: Integer;
     RefCount: Integer;
     LastActive: Int64;
+    Accepted: Boolean;
     ClientIP: string;
     ClientPort: Integer;
 
     constructor Create(ASocket: TSocket);
     destructor Destroy; override;
+    procedure AddRef;
+    procedure Release;
+  end;
+
+  { Registro compartilhado por todos os workers que consomem o mesmo IOCP. }
+  TIocpConnectionRegistry = class
+  private
+    FConnections: TList<TIocpConnectionContext>;
+    FSync: TCriticalSection;
+    FPendingIO: Integer;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure Add(AContext: TIocpConnectionContext);
+    procedure BeginIO(AContext: TIocpConnectionContext);
+    procedure EndIO(AContext: TIocpConnectionContext);
+    function HasPendingIO: Boolean;
+    procedure Close(AContext: TIocpConnectionContext);
+    procedure CloseAll;
+    procedure CollectExpired(AExpired: TList<TIocpConnectionContext>; const ANow: Int64);
   end;
 
   { Thread worker que consome o Completion Port do Windows }
@@ -231,8 +252,8 @@ type
     FListenSocket: TSocket;
     FIocpHandle: THandle;
     FRunning: Boolean;
-    FConnections: TList<TIocpConnectionContext>;
-    FConnectionsSync: TCriticalSection;
+    FRegistry: TIocpConnectionRegistry;
+    FChecksTimeouts: Boolean;
     procedure ProcessClientRead(AContext: TIocpConnectionContext; ABytesTransferred: DWORD);
     procedure ProcessClientWrite(AContext: TIocpConnectionContext; ABytesTransferred: DWORD);
     procedure CloseConnection(AContext: TIocpConnectionContext);
@@ -242,7 +263,8 @@ type
   protected
     procedure Execute; override;
   public
-    constructor Create(AListenSocket: TSocket; AIocpHandle: THandle);
+    constructor Create(AListenSocket: TSocket; AIocpHandle: THandle;
+      ARegistry: TIocpConnectionRegistry; AChecksTimeouts: Boolean);
     destructor Destroy; override;
     procedure TerminateWorker;
   end;
@@ -256,6 +278,7 @@ type
     class var FListenSocket: TSocket;
     class var FIocpHandle: THandle;
     class var FWorkers: TObjectList<THorseIocpWorker>;
+    class var FRegistry: TIocpConnectionRegistry;
 
     class procedure SetPort(const AValue: Integer); static;
     class procedure SetHost(const AValue: string); static;
@@ -1174,6 +1197,7 @@ begin
   Closed := 0;
   RefCount := 1;
   LastActive := GetTickCount64;
+  Accepted := False;
 end;
 
 destructor TIocpConnectionContext.Destroy;
@@ -1184,6 +1208,144 @@ begin
     Socket := INVALID_SOCKET;
   end;
   inherited;
+end;
+
+procedure TIocpConnectionContext.AddRef;
+begin
+  InterlockedIncrement(RefCount);
+end;
+
+procedure TIocpConnectionContext.Release;
+begin
+  if InterlockedDecrement(RefCount) = 0 then
+    Free;
+end;
+
+{ TIocpConnectionRegistry }
+
+constructor TIocpConnectionRegistry.Create;
+begin
+  inherited Create;
+  FConnections := TList<TIocpConnectionContext>.Create;
+  FSync := TCriticalSection.Create;
+  FPendingIO := 0;
+end;
+
+procedure TIocpConnectionRegistry.BeginIO(AContext: TIocpConnectionContext);
+begin
+  AContext.AddRef;
+  InterlockedIncrement(FPendingIO);
+end;
+
+procedure TIocpConnectionRegistry.EndIO(AContext: TIocpConnectionContext);
+begin
+  InterlockedDecrement(FPendingIO);
+  AContext.Release;
+end;
+
+function TIocpConnectionRegistry.HasPendingIO: Boolean;
+begin
+  Result := InterlockedCompareExchange(FPendingIO, 0, 0) <> 0;
+end;
+
+destructor TIocpConnectionRegistry.Destroy;
+begin
+  CloseAll;
+  FConnections.Free;
+  FSync.Free;
+  inherited;
+end;
+
+procedure TIocpConnectionRegistry.Add(AContext: TIocpConnectionContext);
+begin
+  FSync.Enter;
+  try
+    FConnections.Add(AContext);
+  finally
+    FSync.Leave;
+  end;
+end;
+
+procedure TIocpConnectionRegistry.Close(AContext: TIocpConnectionContext);
+var
+  LRemoved: Boolean;
+  LSocketToClose: TSocket;
+begin
+  if AContext = nil then
+    Exit;
+
+  if InterlockedExchange(AContext.Closed, 1) <> 0 then
+    Exit;
+
+  FSync.Enter;
+  try
+    LRemoved := FConnections.Remove(AContext) >= 0;
+  finally
+    FSync.Leave;
+  end;
+
+  LSocketToClose := AContext.Socket;
+  AContext.Socket := INVALID_SOCKET;
+  if LSocketToClose <> INVALID_SOCKET then
+    closesocket(LSocketToClose);
+
+  { The initial reference belongs to the registry and may only be released
+    when this registry actually removed the context. }
+  if LRemoved then
+    AContext.Release;
+end;
+
+procedure TIocpConnectionRegistry.CloseAll;
+var
+  I: Integer;
+  LContexts: TList<TIocpConnectionContext>;
+begin
+  LContexts := TList<TIocpConnectionContext>.Create;
+  try
+    FSync.Enter;
+    try
+      for I := 0 to FConnections.Count - 1 do
+      begin
+        FConnections[I].AddRef;
+        LContexts.Add(FConnections[I]);
+      end;
+    finally
+      FSync.Leave;
+    end;
+
+    for I := 0 to LContexts.Count - 1 do
+    begin
+      Close(LContexts[I]);
+      LContexts[I].Release;
+    end;
+  finally
+    LContexts.Free;
+  end;
+end;
+
+procedure TIocpConnectionRegistry.CollectExpired(
+  AExpired: TList<TIocpConnectionContext>; const ANow: Int64);
+var
+  I: Integer;
+  LContext: TIocpConnectionContext;
+begin
+  FSync.Enter;
+  try
+    for I := FConnections.Count - 1 downto 0 do
+    begin
+      LContext := FConnections[I];
+      if (not LContext.Accepted) or LContext.Processing then
+        Continue;
+      if ANow - LContext.LastActive > 60000 then
+      begin
+        { Keep the context alive after leaving the registry lock. }
+        LContext.AddRef;
+        AExpired.Add(LContext);
+      end;
+    end;
+  finally
+    FSync.Leave;
+  end;
 end;
 
 { Callback de processamento no Windows Thread Pool }
@@ -1236,50 +1398,27 @@ begin
     {$ENDIF}
     Dispose(LData);
 
-    if (LContext <> nil) and (InterlockedDecrement(LContext.RefCount) = 0) then
-      LContext.Free;
+    if LContext <> nil then
+      LContext.Release;
   end;
 end;
 
 { THorseIocpWorker }
 
-constructor THorseIocpWorker.Create(AListenSocket: TSocket; AIocpHandle: THandle);
+constructor THorseIocpWorker.Create(AListenSocket: TSocket; AIocpHandle: THandle;
+  ARegistry: TIocpConnectionRegistry; AChecksTimeouts: Boolean);
 begin
   inherited Create(False);
   FListenSocket := AListenSocket;
   FIocpHandle := AIocpHandle;
+  FRegistry := ARegistry;
+  FChecksTimeouts := AChecksTimeouts;
   FRunning := True;
-  FConnections := TList<TIocpConnectionContext>.Create;
-  FConnectionsSync := TCriticalSection.Create;
+  FreeOnTerminate := False;
 end;
 
 destructor THorseIocpWorker.Destroy;
-var
-  I: Integer;
-  LContext: TIocpConnectionContext;
 begin
-  FConnectionsSync.Enter;
-  try
-    for I := 0 to FConnections.Count - 1 do
-    begin
-      LContext := FConnections[I];
-      if LContext <> nil then
-      begin
-        if LContext.Socket <> INVALID_SOCKET then
-        begin
-          closesocket(LContext.Socket);
-          LContext.Socket := INVALID_SOCKET;
-        end;
-        if InterlockedDecrement(LContext.RefCount) = 0 then
-          LContext.Free;
-      end;
-    end;
-    FConnections.Clear;
-  finally
-    FConnectionsSync.Leave;
-  end;
-  FConnections.Free;
-  FConnectionsSync.Free;
   inherited;
 end;
 
@@ -1289,27 +1428,8 @@ begin
 end;
 
 procedure THorseIocpWorker.CloseConnection(AContext: TIocpConnectionContext);
-var
-  LSocketToClose: TSocket;
 begin
-  if AContext = nil then Exit;
-  if InterlockedExchange(AContext.Closed, 1) = 0 then
-  begin
-    FConnectionsSync.Enter;
-    try
-      FConnections.Remove(AContext);
-    finally
-      FConnectionsSync.Leave;
-    end;
-    
-    LSocketToClose := AContext.Socket;
-    AContext.Socket := INVALID_SOCKET;
-    if LSocketToClose <> INVALID_SOCKET then
-      closesocket(LSocketToClose);
-
-    if InterlockedDecrement(AContext.RefCount) = 0 then
-      AContext.Free;
-  end;
+  FRegistry.Close(AContext);
 end;
 
 procedure THorseIocpWorker.CheckTimeouts;
@@ -1322,22 +1442,17 @@ begin
   LNow := GetTickCount64;
   LExpired := TList<TIocpConnectionContext>.Create;
   try
-    FConnectionsSync.Enter;
-    try
-      for I := FConnections.Count - 1 downto 0 do
-      begin
-        LContext := FConnections[I];
-        if LContext.Processing then
-          Continue;
-        if LNow - LContext.LastActive > 60000 then // Keep-Alive timeout de 60s
-          LExpired.Add(LContext);
-      end;
-    finally
-      FConnectionsSync.Leave;
-    end;
+    FRegistry.CollectExpired(LExpired, LNow);
 
     for I := 0 to LExpired.Count - 1 do
-      CloseConnection(LExpired[I]);
+    begin
+      LContext := LExpired[I];
+      try
+        CloseConnection(LContext);
+      finally
+        LContext.Release;
+      end;
+    end;
   finally
     LExpired.Free;
   end;
@@ -1354,19 +1469,18 @@ begin
     Exit;
 
   LContext := TIocpConnectionContext.Create(LAcceptSocket);
-  FConnectionsSync.Enter;
-  try
-    FConnections.Add(LContext);
-  finally
-    FConnectionsSync.Leave;
-  end;
+  FRegistry.Add(LContext);
 
   // Inicia AcceptEx assíncrono
+  FRegistry.BeginIO(LContext);
   if not fnAcceptEx(FListenSocket, LAcceptSocket, @LContext.AcceptOverlapped.Buffer[0],
     0, SizeOf(TSockAddrIn) + 16, SizeOf(TSockAddrIn) + 16, dwBytes, @LContext.AcceptOverlapped.Overlapped) then
   begin
     if WSAGetLastError <> WSA_IO_PENDING then
+    begin
+      FRegistry.EndIO(LContext);
       CloseConnection(LContext);
+    end;
   end;
 end;
 
@@ -1536,6 +1650,7 @@ var
   pOverlap: POverlapped;
   LContext: TIocpConnectionContext;
   LOverlap: PIocpOverlapped;
+  LOpType: TIocpOpType;
   LResult: BOOL;
   LCurrentTime, LLastTimeoutCheck: Int64;
   LOptVal: Integer;
@@ -1545,7 +1660,7 @@ var
 begin
   LLastTimeoutCheck := GetTickCount64;
 
-  while FRunning do
+  while FRunning or FRegistry.HasPendingIO do
   begin
     pOverlap := nil;
     LResult := GetQueuedCompletionStatus(FIocpHandle, dwBytes, dwKey, pOverlap, 500);
@@ -1554,11 +1669,23 @@ begin
     begin
       LOverlap := PIocpOverlapped(pOverlap);
       LContext := TIocpConnectionContext(LOverlap.Context);
+      LOpType := LOverlap.OpType;
+      try
+        if LOpType = ioAccept then
+        begin
+          if not LResult then
+          begin
+            CloseConnection(LContext);
+            if FRunning then
+              PostAccept;
+            Continue;
+          end;
 
-      if LOverlap.OpType = ioAccept then
-      begin
-        // Atualiza o contexto do soquete aceito com as propriedades do soquete de escuta
-        setsockopt(LOverlap.Socket, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, PAnsiChar(@FListenSocket), SizeOf(FListenSocket));
+          LContext.Accepted := True;
+          LContext.LastActive := GetTickCount64;
+
+          // Atualiza o contexto do soquete aceito com as propriedades do soquete de escuta
+          setsockopt(LOverlap.Socket, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, PAnsiChar(@FListenSocket), SizeOf(FListenSocket));
         
         // Desativa Algoritmo de Nagle (TCP_NODELAY) para latência ultra-baixa em APIs
         LOptVal := 1;
@@ -1586,41 +1713,49 @@ begin
         if LRemoteAddr <> nil then
           LContext.ClientIP := string(inet_ntoa(PSockAddrIn(LRemoteAddr)^.sin_addr));
 
-        // Associa o soquete do cliente aceito ao Completion Port
-        CreateIoCompletionPort(LOverlap.Socket, FIocpHandle, ULONG_PTR(LContext), 0);
-        
-        // Dispara a leitura inicial assíncrona usando WSARecv
-        PostRead(LContext);
-        
-        // Posta o próximo accept assíncrono para fila do IOCP
-        PostAccept;
-      end
-      else if LOverlap.OpType = ioRead then
-      begin
-        if (dwBytes = 0) or (not LResult) then
-        begin
-          CloseConnection(LContext);
+          // Associa o soquete do cliente aceito ao Completion Port
+          if CreateIoCompletionPort(LOverlap.Socket, FIocpHandle, ULONG_PTR(LContext), 0) = 0 then
+            CloseConnection(LContext)
+          else
+            // Dispara a leitura inicial assíncrona usando WSARecv
+            PostRead(LContext);
+
+          // Mantém ao menos um AcceptEx pendente por worker.
+          if FRunning then
+            PostAccept;
         end
-        else
+        else if LOpType = ioRead then
         begin
-          { ProcessClientRead is the sole owner of re-arming (#13): it PostReads
-            itself when more of the request is still to come, and deliberately does
-            NOT when it dispatched or closed the connection. Do not re-arm here — the
-            old duplicate PostRead double-posted WSARecv and raced the close/free. }
-          ProcessClientRead(LContext, dwBytes);
+          if (dwBytes = 0) or (not LResult) then
+          begin
+            CloseConnection(LContext);
+          end
+          else
+          begin
+            { ProcessClientRead is the sole owner of re-arming (#13): it PostReads
+              itself when more of the request is still to come, and deliberately does
+              NOT when it dispatched or closed the connection. Do not re-arm here — the
+              old duplicate PostRead double-posted WSARecv and raced the close/free. }
+            ProcessClientRead(LContext, dwBytes);
+          end;
+        end
+        else if LOpType = ioWrite then
+        begin
+          if (dwBytes = 0) or (not LResult) then
+            CloseConnection(LContext)
+          else
+            ProcessClientWrite(LContext, dwBytes);
         end;
-      end
-      else if LOverlap.OpType = ioWrite then
-      begin
-        if (dwBytes = 0) or (not LResult) then
-          CloseConnection(LContext)
-        else
-          ProcessClientWrite(LContext, dwBytes);
+      finally
+        { Every overlapped AcceptEx/WSARecv owns one reference until its
+          completion packet has been fully consumed. }
+        if LOpType in [ioAccept, ioRead] then
+          FRegistry.EndIO(LContext);
       end;
     end;
 
     LCurrentTime := GetTickCount64;
-    if LCurrentTime - LLastTimeoutCheck > 1000 then
+    if FChecksTimeouts and (LCurrentTime - LLastTimeoutCheck > 1000) then
     begin
       CheckTimeouts;
       LLastTimeoutCheck := LCurrentTime;
@@ -1635,12 +1770,17 @@ begin
   FPort := GetDefaultPort;
   FHost := GetDefaultHost;
   FWorkers := TObjectList<THorseIocpWorker>.Create(True);
+  FRegistry := TIocpConnectionRegistry.Create;
   FRunning := False;
 end;
 
 class destructor THorseProviderIOCP.DestroyClass;
 begin
+  if FRunning then
+    InternalStopListen;
   FWorkers.Free;
+  FRegistry.CloseAll;
+  FRegistry.Free;
 end;
 
 class procedure THorseProviderIOCP.SetPort(const AValue: Integer);
@@ -1751,7 +1891,8 @@ begin
   // Cria os workers
   for I := 1 to LCPUCount do
   begin
-    LWorker := THorseIocpWorker.Create(FListenSocket, FIocpHandle);
+    LWorker := THorseIocpWorker.Create(FListenSocket, FIocpHandle,
+      FRegistry, I = 1);
     FWorkers.Add(LWorker);
     
     // Inicia os primeiros aceites assíncronos no worker
@@ -1769,19 +1910,24 @@ begin
   for I := 0 to FWorkers.Count - 1 do
     FWorkers[I].TerminateWorker;
 
-  if FIocpHandle <> 0 then
-  begin
-    CloseHandle(FIocpHandle);
-    FIocpHandle := 0;
-  end;
-
   if FListenSocket <> INVALID_SOCKET then
   begin
     closesocket(FListenSocket);
     FListenSocket := INVALID_SOCKET;
   end;
 
+  { Closing every registered socket cancels pending AcceptEx/WSARecv calls.
+    Workers remain alive until all resulting completion packets have released
+    their operation references. }
+  FRegistry.CloseAll;
   FWorkers.Clear;
+
+  if FIocpHandle <> 0 then
+  begin
+    CloseHandle(FIocpHandle);
+    FIocpHandle := 0;
+  end;
+
   WSACleanup;
 end;
 
@@ -1799,18 +1945,22 @@ var
   LWSABuf: {$IFDEF FPC}WSABUF{$ELSE}TWSABUF{$ENDIF};
   dwFlags, dwBytes: DWORD;
 begin
+  if InterlockedCompareExchange(AContext.Closed, 0, 0) <> 0 then
+    Exit;
+
   FillChar(AContext.ReadOverlapped.Overlapped, SizeOf(OVERLAPPED), 0);
   LWSABuf.len := 16384;
   LWSABuf.buf := PAnsiChar(@AContext.ReadOverlapped.Buffer[0]);
   dwFlags := 0;
   dwBytes := 0;
   
+  FRegistry.BeginIO(AContext);
   if WSARecv(AContext.Socket, @LWSABuf, 1, dwBytes, dwFlags, @AContext.ReadOverlapped.Overlapped, nil) = SOCKET_ERROR then
   begin
     if WSAGetLastError() <> WSA_IO_PENDING then
     begin
-      closesocket(AContext.Socket);
-      AContext.Socket := INVALID_SOCKET;
+      FRegistry.EndIO(AContext);
+      FRegistry.Close(AContext);
     end;
   end;
 end;

--- a/tests/src/Console.dpr
+++ b/tests/src/Console.dpr
@@ -92,6 +92,9 @@ uses
   Tests.Integration.WebSocket in 'tests\Tests.Integration.WebSocket.pas',
   Tests.Integration.AdvancedRouting in 'tests\Tests.Integration.AdvancedRouting.pas',
   Tests.Integration.Streaming in 'tests\Tests.Integration.Streaming.pas',
+  {$IFDEF HORSE_PROVIDER_IOCP}
+  Tests.Horse.Provider.IOCP in 'tests\Tests.Horse.Provider.IOCP.pas',
+  {$ENDIF}
   Horse.Mime in '..\..\src\Horse.Mime.pas',
   Horse.Utils in '..\..\src\Horse.Utils.pas',
   Horse.Provider.Config in '..\..\src\Horse.Provider.Config.pas',

--- a/tests/src/IOCPUnitTests.dpr
+++ b/tests/src/IOCPUnitTests.dpr
@@ -1,0 +1,31 @@
+program IOCPUnitTests;
+
+{$APPTYPE CONSOLE}
+
+uses
+  System.SysUtils,
+  DUnitX.Loggers.Console,
+  DUnitX.TestFramework,
+  Tests.Horse.Provider.IOCP in 'tests\Tests.Horse.Provider.IOCP.pas';
+
+var
+  LRunner: ITestRunner;
+  LResults: IRunResults;
+begin
+  ReportMemoryLeaksOnShutdown := True;
+  try
+    LRunner := TDUnitX.CreateRunner;
+    LRunner.UseRTTI := False;
+    LRunner.FailsOnNoAsserts := True;
+    LRunner.AddLogger(TDUnitXConsoleLogger.Create(True));
+    LResults := LRunner.Execute;
+    if not LResults.AllPassed then
+      ExitCode := 1;
+  except
+    on E: Exception do
+    begin
+      Writeln(E.ClassName + ': ' + E.Message);
+      ExitCode := 1;
+    end;
+  end;
+end.

--- a/tests/src/tests/Tests.Horse.Provider.IOCP.pas
+++ b/tests/src/tests/Tests.Horse.Provider.IOCP.pas
@@ -1,0 +1,174 @@
+unit Tests.Horse.Provider.IOCP;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TTestHorseProviderIOCP = class
+  public
+    [Setup]
+    procedure Setup;
+
+    [Test]
+    procedure PendingAcceptIsNotSelectedByKeepAliveTimeout;
+
+    [Test]
+    procedure TimeoutSelectionKeepsContextAliveOutsideRegistryLock;
+
+    [Test]
+    procedure PendingIOKeepsContextAliveUntilCompletion;
+
+    [Test]
+    procedure ConnectionCanBeClosedByAThreadThatDidNotRegisterIt;
+  end;
+
+implementation
+
+uses
+  System.Classes,
+  System.Generics.Collections,
+  Horse.Provider.IOCP,
+  Winapi.Winsock2;
+
+type
+  TTrackedIocpConnectionContext = class(TIocpConnectionContext)
+  public
+    class var DestroyCount: Integer;
+    destructor Destroy; override;
+  end;
+
+destructor TTrackedIocpConnectionContext.Destroy;
+begin
+  Inc(DestroyCount);
+  inherited;
+end;
+
+procedure TTestHorseProviderIOCP.ConnectionCanBeClosedByAThreadThatDidNotRegisterIt;
+var
+  LContext: TTrackedIocpConnectionContext;
+  LRegistry: TIocpConnectionRegistry;
+  LThread: TThread;
+begin
+  LRegistry := TIocpConnectionRegistry.Create;
+  try
+    LContext := TTrackedIocpConnectionContext.Create(INVALID_SOCKET);
+    LRegistry.Add(LContext);
+    { Simulates the outstanding completion that dispatches the close on any
+      worker attached to the shared completion port. }
+    LRegistry.BeginIO(LContext);
+
+    LThread := TThread.CreateAnonymousThread(
+      procedure
+      begin
+        LRegistry.Close(LContext);
+      end);
+    try
+      LThread.FreeOnTerminate := False;
+      LThread.Start;
+      LThread.WaitFor;
+    finally
+      LThread.Free;
+    end;
+
+    Assert.AreEqual(0, TTrackedIocpConnectionContext.DestroyCount,
+      'Closing from another worker must remove the shared registry entry safely');
+    LRegistry.EndIO(LContext);
+    Assert.AreEqual(1, TTrackedIocpConnectionContext.DestroyCount);
+  finally
+    LRegistry.Free;
+  end;
+end;
+
+procedure TTestHorseProviderIOCP.Setup;
+begin
+  TTrackedIocpConnectionContext.DestroyCount := 0;
+end;
+
+procedure TTestHorseProviderIOCP.PendingAcceptIsNotSelectedByKeepAliveTimeout;
+var
+  LContext: TTrackedIocpConnectionContext;
+  LExpired: TList<TIocpConnectionContext>;
+  LRegistry: TIocpConnectionRegistry;
+begin
+  LRegistry := TIocpConnectionRegistry.Create;
+  LExpired := TList<TIocpConnectionContext>.Create;
+  try
+    LContext := TTrackedIocpConnectionContext.Create(INVALID_SOCKET);
+    LContext.Accepted := False;
+    LContext.LastActive := 0;
+    LRegistry.Add(LContext);
+
+    LRegistry.CollectExpired(LExpired, 60001);
+
+    Assert.AreEqual<Integer>(0, LExpired.Count,
+      'A pending AcceptEx must not be treated as an idle client connection');
+  finally
+    LExpired.Free;
+    LRegistry.Free;
+  end;
+
+  Assert.AreEqual(1, TTrackedIocpConnectionContext.DestroyCount);
+end;
+
+procedure TTestHorseProviderIOCP.TimeoutSelectionKeepsContextAliveOutsideRegistryLock;
+var
+  LContext: TTrackedIocpConnectionContext;
+  LExpired: TList<TIocpConnectionContext>;
+  LRegistry: TIocpConnectionRegistry;
+begin
+  LRegistry := TIocpConnectionRegistry.Create;
+  LExpired := TList<TIocpConnectionContext>.Create;
+  try
+    LContext := TTrackedIocpConnectionContext.Create(INVALID_SOCKET);
+    LContext.Accepted := True;
+    LContext.LastActive := 0;
+    LRegistry.Add(LContext);
+
+    LRegistry.CollectExpired(LExpired, 60001);
+    Assert.AreEqual<Integer>(1, LExpired.Count);
+
+    LRegistry.Close(LContext);
+    Assert.AreEqual(0, TTrackedIocpConnectionContext.DestroyCount,
+      'The timeout snapshot must hold a reference after leaving the lock');
+
+    LExpired[0].Release;
+    LExpired.Clear;
+    Assert.AreEqual(1, TTrackedIocpConnectionContext.DestroyCount);
+  finally
+    LExpired.Free;
+    LRegistry.Free;
+  end;
+end;
+
+procedure TTestHorseProviderIOCP.PendingIOKeepsContextAliveUntilCompletion;
+var
+  LContext: TTrackedIocpConnectionContext;
+  LRegistry: TIocpConnectionRegistry;
+begin
+  LRegistry := TIocpConnectionRegistry.Create;
+  try
+    LContext := TTrackedIocpConnectionContext.Create(INVALID_SOCKET);
+    LRegistry.Add(LContext);
+    LRegistry.BeginIO(LContext);
+
+    LRegistry.Close(LContext);
+    Assert.AreEqual(0, TTrackedIocpConnectionContext.DestroyCount,
+      'A posted I/O operation must keep its OVERLAPPED context alive');
+    Assert.IsTrue(LRegistry.HasPendingIO);
+
+    LRegistry.EndIO(LContext);
+    Assert.IsFalse(LRegistry.HasPendingIO);
+    Assert.AreEqual(1, TTrackedIocpConnectionContext.DestroyCount,
+      'The final completion reference must release the context');
+  finally
+    LRegistry.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestHorseProviderIOCP);
+
+end.


### PR DESCRIPTION
## Summary

Fixes the IOCP connection-context lifetime races reported in #541.

All workers consume completions from the same completion port, but connection contexts were previously stored in per-worker lists. A completion handled by a different worker could therefore free a context without removing it from the owning worker's list. In addition, pending `AcceptEx` and `WSARecv` operations did not hold references to their contexts, and pending accepts were incorrectly subject to the 60-second keep-alive timeout.

## Changes

- use one connection registry shared by all IOCP workers;
- retain contexts for every pending `AcceptEx` and `WSARecv`, releasing them after completion;
- retain timeout candidates while moving them outside the registry lock;
- distinguish pending accepts from accepted client connections;
- run timeout scanning from a single worker;
- handle failed/cancelled accept completions and immediate `WSARecv` failures through the centralized close path;
- drain pending completion references during shutdown before closing the completion port;
- add focused DUnitX regression tests and a small dedicated IOCP test runner.

## Validation

- DUnitX lifecycle tests: 4/4 passed with no leaks on Delphi 10 Win32;
- DUnitX lifecycle tests: 4/4 passed with no leaks on Delphi 12 Win32 and Win64;
- IOCP and IOCP+Radix compile checks passed;
- live IOCP server test ran beyond the 60-second timeout: 70/70 requests succeeded with no failures.

Fixes #541.
