### PR TITLE
feat(websocket): let providers signal a WebSocket upgrade without the HTTP/1.1 Upgrade header (RFC 8441)

### DIFF
--- a/src/Horse.Request.pas
+++ b/src/Horse.Request.pas
@@ -50,6 +50,25 @@ type
     FCSPathInfo:    string;
     FCSContentType: string;
     FCSRemoteAddr:  string;
+{ ===========================================================================
+  FIX-WS-8441  transport-signalled WebSocket upgrade.
+
+  IsWebSocket tests for `Upgrade: websocket`, which HTTP/2 cannot carry:
+  connection-specific headers are forbidden outright (RFC 9113 8.2.2), and a
+  conforming HTTP/2 server must reject a request that sends one. RFC 8441
+  replaces the whole mechanism with extended CONNECT  `:method CONNECT` plus
+  a `:protocol: websocket` pseudo-header.
+
+  Pseudo-headers are deliberately stripped before they reach Req.Headers (they
+  are not real headers and would confuse Indy-style middleware), so core
+  cannot see `:protocol`. A provider that recognises the upgrade at transport
+  level sets this flag instead during request population.
+
+  Deliberately protocol-agnostic: HTTP/3 uses the same extended-CONNECT
+  mechanism, and a boolean covers both without core knowing either. Defaults
+  to False, so every existing provider behaves exactly as before.
+  =========================================================================== }
+    FWebSocketUpgrade: Boolean;
 { PATCH-REQ-9  cached decoded body string for the CrossSocket path.
   Populated once at populate time by SetBodyString (called from
   TRequestBridge.MapBody); returned directly by Body: string so the stream
@@ -123,6 +142,9 @@ type
     function ContentType: string; virtual;
     function Host: string; virtual;
     function IsWebSocket: Boolean; virtual;
+{ FIX-WS-8441  set by providers whose transport signals a WebSocket upgrade by
+  means other than the HTTP/1.1 `Upgrade` header. See FWebSocketUpgrade. }
+    procedure SetWebSocketUpgrade(const AValue: Boolean); virtual;
     function WebSocketKey: string; virtual;
     property Arena: THorseArenaAllocator read GetArena write FArena;
     function PathInfo: string; virtual;
@@ -366,6 +388,10 @@ begin
   FCSContentType := '';
   FCSRemoteAddr  := '';
 { end PATCH-REQ-3 }
+{ FIX-WS-8441  must be wiped with the other shadow fields. THorseRequest is
+  pooled; leaving this set would make the next request served by this instance
+  report IsWebSocket=True with no upgrade of its own. }
+  FWebSocketUpgrade := False;
 { PATCH-REQ-8  free the per-request TWebRequest adapter (owned).
   Nil on the Indy path (never assigned there); owned on CrossSocket path. }
   if Assigned(FCSRawWebRequest) then
@@ -964,7 +990,17 @@ end;
 
 function THorseRequest.IsWebSocket: Boolean;
 begin
-  Result := Headers.ContainsKey('upgrade') and (Pos('websocket', LowerCase(Headers['upgrade'])) > 0);
+{ FIX-WS-8441  the flag is checked first and short-circuits, so an HTTP/2
+  provider never pays the header lookup. On HTTP/1.1 nothing sets it and the
+  original test runs unchanged. }
+  Result := FWebSocketUpgrade
+            or (Headers.ContainsKey('upgrade') and (Pos('websocket', LowerCase(Headers['upgrade'])) > 0));
+end;
+
+{ FIX-WS-8441 }
+procedure THorseRequest.SetWebSocketUpgrade(const AValue: Boolean);
+begin
+  FWebSocketUpgrade := AValue;
 end;
 
 function THorseRequest.WebSocketKey: string;

--- a/tests/src/tests/Tests.Horse.Request.Recycle.pas
+++ b/tests/src/tests/Tests.Horse.Request.Recycle.pas
@@ -26,6 +26,16 @@ type
     procedure TestResponseSendBytesOverload;
     [Test]
     procedure TestRequestStateAndMatchedRouteCycle;
+
+    { FIX-WS-8441: IsWebSocket detection and Clear-reset coverage }
+    [Test]
+    procedure TestIsWebSocketDefaultFalse;
+    [Test]
+    procedure TestIsWebSocketDetectedByUpgradeHeader;
+    [Test]
+    procedure TestIsWebSocketDetectedByExplicitSignal;
+    [Test]
+    procedure TestIsWebSocketResetByClear;
   end;
 
 implementation
@@ -171,6 +181,43 @@ begin
   Assert.AreEqual('', FRequest.MatchedRoute, 'MatchedRoute should be empty after Clear');
   Assert.AreEqual<Integer>(0, FRequest.State.Count, 'State dictionary should be empty after Clear');
   Assert.IsTrue(LDestroyed, 'State values should be automatically freed after Clear due to doOwnsValues');
+end;
+
+{ FIX-WS-8441 ----------------------------------------------------------------
+  Four tests covering the provider-signal WebSocket upgrade path:
+  1. default is False (no false positives on HTTP/1.1 non-upgrade requests)
+  2. detection via the HTTP/1.1 `Upgrade: websocket` header (existing path)
+  3. detection via the explicit SetWebSocketUpgrade signal (HTTP/2 / RFC 8441)
+  4. FWebSocketUpgrade is reset to False by Clear (pooled-request safety)
+---------------------------------------------------------------------------- }
+
+procedure TTestHorseRequestRecycle.TestIsWebSocketDefaultFalse;
+begin
+  Assert.IsFalse(FRequest.IsWebSocket,
+    'IsWebSocket must be False on a freshly created request with no header and no provider signal');
+end;
+
+procedure TTestHorseRequestRecycle.TestIsWebSocketDetectedByUpgradeHeader;
+begin
+  FRequest.Headers.Dictionary.AddOrSetValue('Upgrade', 'websocket');
+  Assert.IsTrue(FRequest.IsWebSocket,
+    'IsWebSocket must be True when the Upgrade: websocket header is present (HTTP/1.1 path)');
+end;
+
+procedure TTestHorseRequestRecycle.TestIsWebSocketDetectedByExplicitSignal;
+begin
+  FRequest.SetWebSocketUpgrade(True);
+  Assert.IsTrue(FRequest.IsWebSocket,
+    'IsWebSocket must be True when the provider sets the explicit upgrade signal (HTTP/2 / RFC 8441 path)');
+end;
+
+procedure TTestHorseRequestRecycle.TestIsWebSocketResetByClear;
+begin
+  FRequest.SetWebSocketUpgrade(True);
+  Assert.IsTrue(FRequest.IsWebSocket, 'Precondition: upgrade signal must be set before Clear');
+  FRequest.Clear;
+  Assert.IsFalse(FRequest.IsWebSocket,
+    'IsWebSocket must be False after Clear — FWebSocketUpgrade must be reset for safe request recycling');
 end;
 
 initialization


### PR DESCRIPTION
<!-- PR TITLE:
feat(websocket): let providers signal a WebSocket upgrade without the HTTP/1.1 Upgrade header (RFC 8441)
-->
<!-- BRANCH: feat/websocket-rfc8441-flag  →  HashLoad/horse:master -->
<!-- FILE:   src/Horse.Request.pas (only) -->

Closes #548.

## Summary

`THorseRequest.IsWebSocket` tests for the HTTP/1.1 `Upgrade: websocket` header.
HTTP/2 cannot carry that header — connection-specific headers are forbidden
outright (RFC 9113 §8.2.2), and a conforming HTTP/2 server must *reject* a
request that sends one. RFC 8441 replaces the whole mechanism with extended
CONNECT: `:method CONNECT` plus a `:protocol: websocket` pseudo-header.

So a perfectly valid HTTP/2 upgrade is refused by `UpgradeToWebSocket` with
`400 Request is not a WebSocket upgrade request.`

**This is not a defect in anything Horse currently ships.** Every bundled
provider speaks HTTP/1.1, where the existing check is exactly right. It only
becomes a gap once a provider serves HTTP/2.

## The change

Ten lines in one unit. A flag a provider can set during request population, and
`IsWebSocket` honours it:

```pascal
private
  FWebSocketUpgrade: Boolean;
public
  procedure SetWebSocketUpgrade(const AValue: Boolean); virtual;

function THorseRequest.IsWebSocket: Boolean;
begin
  Result := FWebSocketUpgrade
            or (Headers.ContainsKey('upgrade')
                and (Pos('websocket', LowerCase(Headers['upgrade'])) > 0));
end;
```

The flag is checked first and short-circuits, so an HTTP/2 provider never pays
the header lookup; on HTTP/1.1 nothing sets it and the original test runs
unchanged.

`FWebSocketUpgrade` is also reset in `Clear`, alongside the other shadow fields.
`THorseRequest` is pooled, so without that the next request served by the same
instance would report `IsWebSocket = True` with no upgrade of its own.

## Why a flag rather than reading `:protocol` in core

- **Pseudo-headers are deliberately absent from `Req.Headers`.** Providers strip
  `:method`, `:path`, `:scheme` and `:authority` because they are not real
  headers and would confuse Indy-style middleware. Core cannot see `:protocol`
  without changing that, which is a much larger change.
- **It does not tie core to HTTP/2.** HTTP/3 uses the same extended-CONNECT
  mechanism; a boolean covers both without core knowing either.
- **Additive and backward compatible.** Defaulting to `False` means every
  existing provider behaves exactly as today.

## Compatibility

No signature changes, no behavioural change for any existing provider, no
breaking change for middleware. `SetWebSocketUpgrade` is `virtual`, consistent
with the surrounding accessors.

## Testing

Verified against an HTTP/2 provider implementing RFC 8441 extended CONNECT,
driven by an independent Python `h2` client: extended CONNECT accepted
(`:status 200`), server-pushed frame delivered and read by the client, and the
client's masked frame delivered intact to the parser.

Regression-checked on HTTP/1.1: the WebSocket path is unaffected on Indy, IOCP
and epoll, verified with a raw RFC 6455 echo test on Delphi 12 (Win64) and FPC
3.2.2 (Linux). Nothing sets the flag on those paths, so `IsWebSocket` evaluates
exactly as before.

## Context — what the workaround costs today

Without this, an HTTP/2 provider has to synthesise the headers into the parsed
view to satisfy the check:

```pascal
if SameText(AStream.Header[':method'], 'CONNECT')
   and SameText(AStream.Header[':protocol'], 'websocket') then
begin
  AHorseReq.Headers.Dictionary.AddOrSetValue('upgrade', 'websocket');
  AHorseReq.Headers.Dictionary.AddOrSetValue('connection', 'Upgrade');
end;
```

Nothing is fabricated on the wire and the provider still rejects a genuine
`upgrade` header from a peer, as HTTP/2 requires. It works — but it means
inventing headers to satisfy a check, which reads as a bug to the next person
who finds it, and every future HTTP/2 or HTTP/3 provider would repeat it.

Happy to adjust the shape if a different one fits Horse better — the naming, the
`virtual`, or exposing it as a property rather than a setter are all easy to
change.
