### PR TITLE
fix(streaming): exclude HORSE_PROVIDER_NGHTTP2 from the default stream-writer registration

### DIFF
--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -1359,9 +1359,25 @@ begin
 end;
 
 initialization
+{ FIX-STREAM-FACTORY — every provider that supplies its own stream writer must
+  be excluded here, because FStreamWriterFactory is a last-writer-wins class var
+  and BOTH registrations run from unit initialization sections. Whichever
+  initializes second silently wins, and that order is decided by the compiler's
+  dependency walk — not by anything in this source.
+
+  HORSE_PROVIDER_NGHTTP2 was missing from this list. On FPC trunk the provider's
+  own factory happened to initialize last and streaming worked; on FPC 3.2.2 the
+  order differs, this WebBroker default won, and the nghttp2 transport answered
+  every streaming request with total silence — no headers, no body, client
+  timeout. Nothing else was affected, which is what made it hard to find.
+
+  Note that the three providers already listed were excluded for exactly this
+  reason. Adding the fourth restores the intent; it does not change behaviour on
+  any build where the order already happened to favour the provider. }
 {$IF NOT DEFINED(HORSE_PROVIDER_IOCP) AND
      NOT DEFINED(HORSE_PROVIDER_HTTPSYS) AND
-     NOT DEFINED(HORSE_PROVIDER_EPOLL)}
+     NOT DEFINED(HORSE_PROVIDER_EPOLL) AND
+     NOT DEFINED(HORSE_PROVIDER_NGHTTP2)}
   THorseResponse.RegisterStreamWriterFactory(DefaultWebBrokerStreamWriterFactory);
 {$ENDIF}
 


### PR DESCRIPTION
<!-- PR TITLE (paste into the title field, not the body):
fix(streaming): exclude HORSE_PROVIDER_NGHTTP2 from the default stream-writer registration
-->
<!-- BRANCH: fix/stream-writer-factory-guard  →  HashLoad/horse:master -->
<!-- FILE:   src/Horse.Response.pas (only) -->

## Summary

`Horse.Response.pas` registers its default WebBroker stream writer from a unit
initialization section, guarded to exclude providers that supply their own.
**`HORSE_PROVIDER_NGHTTP2` is missing from that guard.**

Because `FStreamWriterFactory` is a last-writer-wins class var, and both Horse
core and the provider register into it from initialization sections, **the
compiler's dependency walk decides which one survives** — nothing in either
source file does.

`src/Horse.Response.pas:1361` (at `master`, `ff41415`):

```pascal
initialization
{$IF NOT DEFINED(HORSE_PROVIDER_IOCP) AND
     NOT DEFINED(HORSE_PROVIDER_HTTPSYS) AND
     NOT DEFINED(HORSE_PROVIDER_EPOLL)}
  THorseResponse.RegisterStreamWriterFactory(DefaultWebBrokerStreamWriterFactory);
{$ENDIF}
```

Three providers are already excluded for exactly this reason. Adding the fourth
restores the evident intent.

## Why it matters more than a missing define

On FPC **trunk 3.3.1** the provider's factory happens to initialize last, so it
wins and streaming works. On FPC **3.2.2** the order differs, the WebBroker
default wins, and it cannot write to an HTTP/2 stream — so every streaming
request returns **complete silence**: no headers, no body, no error. The client
simply waits until it times out.

That means streaming on trunk has been passing **by accident of initialization
order**, not by design. A compiler upgrade, a new unit, or a reordered `uses`
clause could flip it at any time, in either direction, silently.

Nothing else is affected — which is what made it hard to find. Ordinary
requests, TLS, mTLS, graceful shutdown and WebSocket all work normally; only
`Res.SendStream` is silently redirected to a writer that cannot serve it.

## Reproduction

Build an nghttp2-provider server on FPC 3.2.2 with a `Res.SendStream` route:

```
$ curl -N --http2-prior-knowledge -s --max-time 8 http://127.0.0.1:9010/stream/pull
$ echo "exit=$?"
exit=28
```

`exit=28` is curl's timeout, with **zero bytes received**. Verbose output shows
the request sent and no response line at all — not even `< HTTP/2 200`, which
distinguishes this from a stalled body.

With the one-line fix:

```
$ curl -N --http2-prior-knowledge -s --max-time 8 http://127.0.0.1:9010/stream/pull
{"id":1}
{"id":2}
{"id":3}
{"id":4}
{"id":5}
exit=0
```

Full suite on FPC 3.2.2 after the fix: 24 stages pass, 0 fail, 1 explicit skip
(gRPC, which needs trunk for `TCustomAttribute`). On FPC trunk 3.3.1: 27/27
unchanged, confirming the fix is a no-op where the ordering already favoured the
provider.

## The change

```pascal
{$IF NOT DEFINED(HORSE_PROVIDER_IOCP) AND
     NOT DEFINED(HORSE_PROVIDER_HTTPSYS) AND
     NOT DEFINED(HORSE_PROVIDER_EPOLL) AND
     NOT DEFINED(HORSE_PROVIDER_NGHTTP2)}
```

One condition, plus a comment recording why the list exists — the failure mode
is invisible enough that the next person adding a provider will want to know.

No behavioural change on any build where the ordering already favoured the
provider, and none at all on Delphi or on builds that use the WebBroker writer.

## A suggestion, not part of this PR

This guard scales by requiring every new provider to remember to add itself,
and forgetting produces a silent failure rather than an error. Two sturdier
shapes, if you would like either as a follow-up:

- Have `RegisterStreamWriterFactory` refuse to overwrite an already-registered
  factory, so the first specific registration wins and core's default only
  applies when nothing else claimed it.
- Or register core's default lazily at first use, rather than from
  `initialization`, removing the ordering dependency entirely.

Both are larger changes than this one, and this PR fixes the immediate bug
without prejudging either.

## Context

Found while making `horse-provider-nghttp2` build on the FPC that Horse's own CI
installs (`apt-get install -y fpc` → 3.2.2). Companion to #549, #550 and #551.
