### PR TITLE
perf(epoll): run the HTTP pipeline inline in the worker instead of hopping through TTask.Run

### DIFF
--- a/doc/epoll.md
+++ b/doc/epoll.md
@@ -84,3 +84,31 @@ end.
 ```
 
 The framework will resolve the `THorse.Listen` call to the native epoll reactor when running under Linux.
+
+## Pipeline execution modes (Delphi)
+
+By default, route handlers run in a bounded pool owned by the epoll provider. This keeps blocking handlers (database access, filesystem operations, or remote calls) away from the I/O event-loop threads without changing Delphi's process-wide `TThreadPool.Default` settings.
+
+The default worker count is eight times the processor count and the default pending-request queue capacity is 2048. Configure either value before calling `Listen`:
+
+```delphi
+uses
+  Horse,
+  Horse.Provider.Epoll;
+
+begin
+  THorseProviderEpoll.PipelineWorkerThreads := 32; // 0 = automatic
+  THorseProviderEpoll.PipelineQueueCapacity := 1024;
+  THorse.Listen(9095);
+end.
+```
+
+Applications whose handlers are known to be short and non-blocking can opt into inline execution:
+
+```delphi
+THorseProviderEpoll.PipelineMode := epmInline;
+```
+
+Inline mode removes the dispatch hop and can improve throughput and tail latency for very short handlers. It also means that one slow handler blocks its epoll worker and delays every connection assigned to that event loop. Do not use inline mode for handlers that perform blocking I/O. Pipeline settings cannot be changed while the provider is running.
+
+When the bounded queue is full, the provider closes the newly saturated connection instead of creating more threads or silently losing the request. During shutdown, it stops accepting work and drains requests already accepted by the pipeline pool before releasing their connection contexts.

--- a/doc/epoll.pt-BR.md
+++ b/doc/epoll.pt-BR.md
@@ -84,3 +84,31 @@ end.
 ```
 
 O framework resolverá automaticamente a chamada de `THorse.Listen` para o reactor nativo epoll quando executado em ambientes Linux.
+
+## Modos de execução da pipeline (Delphi)
+
+Por padrão, os handlers das rotas são executados em um pool limitado pertencente ao próprio provider epoll. Isso mantém handlers bloqueantes (acesso ao banco de dados, filesystem ou chamadas remotas) fora das threads do event loop sem alterar as configurações globais de `TThreadPool.Default` do processo Delphi.
+
+A quantidade padrão de workers é oito vezes a quantidade de processadores e a capacidade padrão da fila de requisições pendentes é 2048. Configure esses valores antes de chamar `Listen`:
+
+```delphi
+uses
+  Horse,
+  Horse.Provider.Epoll;
+
+begin
+  THorseProviderEpoll.PipelineWorkerThreads := 32; // 0 = automático
+  THorseProviderEpoll.PipelineQueueCapacity := 1024;
+  THorse.Listen(9095);
+end.
+```
+
+Aplicações cujos handlers sejam comprovadamente curtos e não bloqueantes podem optar pela execução inline:
+
+```delphi
+THorseProviderEpoll.PipelineMode := epmInline;
+```
+
+O modo inline elimina o despacho para outra thread e pode melhorar throughput e latência de cauda para handlers muito curtos. Em contrapartida, um único handler lento bloqueia seu worker epoll e atrasa todas as conexões atribuídas àquele event loop. Não use o modo inline em handlers que realizem E/S bloqueante. As configurações da pipeline não podem ser alteradas enquanto o provider estiver em execução.
+
+Quando a fila limitada está cheia, o provider fecha a nova conexão saturada em vez de criar mais threads ou perder silenciosamente a requisição. Durante o shutdown, ele deixa de aceitar trabalho e drena as requisições já aceitas pelo pool antes de liberar os contexts das conexões.

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -2340,6 +2340,7 @@ var
   LBodyOffset: Integer;
   LContentLength: Int64;
   LWorker: THorseEpollWorker;
+  LInlinePipeline: TProc;
 begin
   LWorker := Self;
   LRequestComplete := False;
@@ -2553,8 +2554,10 @@ begin
     AContext.FProcessing := True;
 
     {$IF NOT DEFINED(FPC)}
-    // Delphi Linux: Executa rotas assincronamente no Task Parallel Library
-    TTask.Run(
+    // Delphi Linux: executa rotas INLINE no proprio worker. O hop antigo via
+    // TTask.Run especulava o TThreadPool.Default ate Max=2048 e o wake por
+    // futex entre ~2000 threads explosava a cauda p99 -- divida item 93.
+    LInlinePipeline :=
       procedure
       var
         LHorseReq: THorseRequest;
@@ -2679,7 +2682,8 @@ begin
         except
           // Captura exceÃ§Ãµes para seguranÃ§a na thread
         end;
-      end);
+      end;
+    LInlinePipeline();
     {$ELSE}
     // Lazarus FPC: Despacha as rotas via GTaskPool de forma assÃ­ncrona
     {$IFNDEF HORSE_EPOLL_SYNCHRONOUS}

--- a/src/Horse.Provider.Epoll.pas
+++ b/src/Horse.Provider.Epoll.pas
@@ -27,7 +27,6 @@ uses
     System.SyncObjs,
     System.Generics.Collections,
     System.Generics.Defaults,
-    System.Threading,
     System.NetEncoding,
     Posix.Base,
     Posix.SysTypes,
@@ -54,6 +53,13 @@ uses
   Horse.Provider.Socket.WebSocket;
 
 type
+  {$IFNDEF FPC}
+  TEpollPipelineMode = (
+    epmBoundedPool,
+    epmInline
+  );
+  {$ENDIF}
+
   { Estrutura que representa os segmentos de cabeÃ§alhos indexados durante o
     parsing preguiÃ§oso para evitar alocaÃ§Ãµes desnecessÃ¡rias na heap. }
   TEpollConnectionContext = class;
@@ -281,9 +287,19 @@ type
     class var FRunning: Boolean;
     class var FListenSockets: TList<Integer>;
     class var FWorkers: TObjectList<THorseEpollWorker>;
+    {$IFNDEF FPC}
+    class var FPipelineMode: TEpollPipelineMode;
+    class var FPipelineWorkerThreads: Integer;
+    class var FPipelineQueueCapacity: Integer;
+    {$ENDIF}
 
     class procedure SetPort(const AValue: Integer); static;
     class procedure SetHost(const AValue: string); static;
+    {$IFNDEF FPC}
+    class procedure SetPipelineMode(const AValue: TEpollPipelineMode); static;
+    class procedure SetPipelineWorkerThreads(const AValue: Integer); static;
+    class procedure SetPipelineQueueCapacity(const AValue: Integer); static;
+    {$ENDIF}
     class function GetPort: Integer; static;
     class function GetHost: string; static;
     class function GetDefaultPort: Integer; static;
@@ -295,6 +311,11 @@ type
   public
     class property Host: string read GetHost write SetHost;
     class property Port: Integer read GetPort write SetPort;
+    {$IFNDEF FPC}
+    class property PipelineMode: TEpollPipelineMode read FPipelineMode write SetPipelineMode;
+    class property PipelineWorkerThreads: Integer read FPipelineWorkerThreads write SetPipelineWorkerThreads;
+    class property PipelineQueueCapacity: Integer read FPipelineQueueCapacity write SetPipelineQueueCapacity;
+    {$ENDIF}
     class procedure Listen; overload; override;
     class procedure Listen(const APort: Integer; const AHost: string = '0.0.0.0'; const ACallbackListen: TProc = nil; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
     class procedure Listen(const APort: Integer; const ACallbackListen: TProc; const ACallbackStopListen: TProc = nil); reintroduce; overload; static;
@@ -471,6 +492,38 @@ type
 
 var
   GTaskPool: TEpollFPCTaskPool = nil;
+{$ELSE}
+type
+  TEpollPipelinePool = class;
+
+  TEpollPipelineThread = class(TThread)
+  private
+    FPool: TEpollPipelinePool;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(APool: TEpollPipelinePool);
+  end;
+
+  TEpollPipelinePool = class
+  private
+    FActive: Boolean;
+    FHead: Integer;
+    FLock: TCriticalSection;
+    FQueue: TArray<TProc>;
+    FQueued: Integer;
+    FSemaphore: TSemaphore;
+    FTail: Integer;
+    FWorkers: TObjectList<TEpollPipelineThread>;
+    function Dequeue(out ATask: TProc): Boolean;
+  public
+    constructor Create(AThreadCount, AQueueCapacity: Integer);
+    destructor Destroy; override;
+    function TryQueue(const ATask: TProc): Boolean;
+  end;
+
+var
+  GPipelinePool: TEpollPipelinePool = nil;
 {$ENDIF}
 
 const
@@ -946,6 +999,128 @@ begin
       Exit;
     end;
   end;
+end;
+{$ENDIF}
+
+{$IFNDEF FPC}
+{ TEpollPipelineThread }
+
+constructor TEpollPipelineThread.Create(APool: TEpollPipelinePool);
+begin
+  inherited Create(True);
+  FPool := APool;
+  FreeOnTerminate := False;
+  Start;
+end;
+
+procedure TEpollPipelineThread.Execute;
+var
+  LTask: TProc;
+begin
+  while True do
+  begin
+    FPool.FSemaphore.WaitFor(1000);
+    if FPool.Dequeue(LTask) then
+    begin
+      try
+        LTask();
+      finally
+        LTask := nil;
+      end;
+      Continue;
+    end;
+
+    if not FPool.FActive then
+      Break;
+  end;
+end;
+
+{ TEpollPipelinePool }
+
+constructor TEpollPipelinePool.Create(AThreadCount, AQueueCapacity: Integer);
+var
+  I: Integer;
+begin
+  inherited Create;
+  if AThreadCount < 1 then
+    raise EArgumentOutOfRangeException.Create('Pipeline worker count must be greater than zero');
+  if AQueueCapacity < 1 then
+    raise EArgumentOutOfRangeException.Create('Pipeline queue capacity must be greater than zero');
+
+  FActive := True;
+  FLock := TCriticalSection.Create;
+  SetLength(FQueue, AQueueCapacity);
+  FSemaphore := TSemaphore.Create(nil, 0, AQueueCapacity + AThreadCount, '');
+  FWorkers := TObjectList<TEpollPipelineThread>.Create(True);
+  for I := 1 to AThreadCount do
+    FWorkers.Add(TEpollPipelineThread.Create(Self));
+end;
+
+destructor TEpollPipelinePool.Destroy;
+var
+  I: Integer;
+begin
+  if FLock <> nil then
+  begin
+    FLock.Enter;
+    try
+      FActive := False;
+    finally
+      FLock.Leave;
+    end;
+  end
+  else
+    FActive := False;
+
+  if FWorkers <> nil then
+  begin
+    if FSemaphore <> nil then
+      for I := 0 to FWorkers.Count - 1 do
+        FSemaphore.Release;
+    for I := 0 to FWorkers.Count - 1 do
+      FWorkers[I].WaitFor;
+    FWorkers.Free;
+  end;
+  for I := 0 to Length(FQueue) - 1 do
+    FQueue[I] := nil;
+  FLock.Free;
+  FSemaphore.Free;
+  inherited;
+end;
+
+function TEpollPipelinePool.Dequeue(out ATask: TProc): Boolean;
+begin
+  ATask := nil;
+  FLock.Enter;
+  try
+    Result := FQueued > 0;
+    if not Result then
+      Exit;
+    ATask := FQueue[FHead];
+    FQueue[FHead] := nil;
+    FHead := (FHead + 1) mod Length(FQueue);
+    Dec(FQueued);
+  finally
+    FLock.Leave;
+  end;
+end;
+
+function TEpollPipelinePool.TryQueue(const ATask: TProc): Boolean;
+begin
+  FLock.Enter;
+  try
+    Result := FActive and (FQueued < Length(FQueue));
+    if Result then
+    begin
+      FQueue[FTail] := ATask;
+      FTail := (FTail + 1) mod Length(FQueue);
+      Inc(FQueued);
+    end;
+  finally
+    FLock.Leave;
+  end;
+  if Result then
+    FSemaphore.Release;
 end;
 {$ENDIF}
 
@@ -2554,9 +2729,10 @@ begin
     AContext.FProcessing := True;
 
     {$IF NOT DEFINED(FPC)}
-    // Delphi Linux: executa rotas INLINE no proprio worker. O hop antigo via
-    // TTask.Run especulava o TThreadPool.Default ate Max=2048 e o wake por
-    // futex entre ~2000 threads explosava a cauda p99 -- divida item 93.
+    // The same pipeline can run inline for CPU-bound/short handlers or in the
+    // provider-owned bounded pool when handlers may block. Unlike
+    // TThreadPool.Default, the latter has deterministic concurrency and queue
+    // limits and does not alter process-wide thread-pool settings.
     LInlinePipeline :=
       procedure
       var
@@ -2680,10 +2856,14 @@ begin
             end;
           end;
         except
-          // Captura exceÃ§Ãµes para seguranÃ§a na thread
+          LWorker.CloseConnection(LLocalContext);
         end;
       end;
-    LInlinePipeline();
+    if THorseProviderEpoll.PipelineMode = epmInline then
+      LInlinePipeline()
+    else if (GPipelinePool = nil) or
+      (not GPipelinePool.TryQueue(LInlinePipeline)) then
+      LWorker.CloseConnection(AContext);
     {$ELSE}
     // Lazarus FPC: Despacha as rotas via GTaskPool de forma assÃ­ncrona
     {$IFNDEF HORSE_EPOLL_SYNCHRONOUS}
@@ -3183,6 +3363,11 @@ begin
   FListenSockets := TList<Integer>.Create;
   FWorkers := TObjectList<THorseEpollWorker>.Create(True);
   FRunning := False;
+  {$IFNDEF FPC}
+  FPipelineMode := epmBoundedPool;
+  FPipelineWorkerThreads := 0;
+  FPipelineQueueCapacity := 2048;
+  {$ENDIF}
 
   // Eleva o limite mÃ¡ximo de descritores de arquivos abertos (ulimit -n) do processo para 65535
   LRLimit.rlim_cur := 65535;
@@ -3191,8 +3376,6 @@ begin
   fpSetrlimit(RLIMIT_NOFILE, @LRLimit);
   {$ELSE}
   setrlimit(RLIMIT_NOFILE, LRLimit);
-  TThreadPool.Default.MaxWorkerThreads := 2048;
-  TThreadPool.Default.MinWorkerThreads := TThread.ProcessorCount * 8;
   {$ENDIF}
 end;
 
@@ -3227,6 +3410,33 @@ class procedure THorseProviderEpoll.SetHost(const AValue: string);
 begin
   FHost := AValue;
 end;
+
+{$IFNDEF FPC}
+class procedure THorseProviderEpoll.SetPipelineMode(const AValue: TEpollPipelineMode);
+begin
+  if FRunning then
+    raise EInvalidOperation.Create('Pipeline mode cannot be changed while the epoll provider is running');
+  FPipelineMode := AValue;
+end;
+
+class procedure THorseProviderEpoll.SetPipelineWorkerThreads(const AValue: Integer);
+begin
+  if FRunning then
+    raise EInvalidOperation.Create('Pipeline worker count cannot be changed while the epoll provider is running');
+  if AValue < 0 then
+    raise EArgumentOutOfRangeException.Create('Pipeline worker count cannot be negative');
+  FPipelineWorkerThreads := AValue;
+end;
+
+class procedure THorseProviderEpoll.SetPipelineQueueCapacity(const AValue: Integer);
+begin
+  if FRunning then
+    raise EInvalidOperation.Create('Pipeline queue capacity cannot be changed while the epoll provider is running');
+  if AValue < 1 then
+    raise EArgumentOutOfRangeException.Create('Pipeline queue capacity must be greater than zero');
+  FPipelineQueueCapacity := AValue;
+end;
+{$ENDIF}
 
 class procedure THorseProviderEpoll.SetPort(const AValue: Integer);
 begin
@@ -3322,10 +3532,22 @@ var
 begin
   TriggerBeforeListen;
   if FRunning then Exit;
+  FRunning := True;
 
-  LThreadCount := TThread.ProcessorCount;
-  if LThreadCount <= 0 then
-    LThreadCount := 2;
+  try
+    LThreadCount := TThread.ProcessorCount;
+    if LThreadCount <= 0 then
+      LThreadCount := 2;
+
+  {$IFNDEF FPC}
+  if FPipelineMode = epmBoundedPool then
+  begin
+    I := FPipelineWorkerThreads;
+    if I = 0 then
+      I := LThreadCount * 8;
+    GPipelinePool := TEpollPipelinePool.Create(I, FPipelineQueueCapacity);
+  end;
+  {$ENDIF}
 
   {$IFDEF FPC}
   {$IFNDEF HORSE_EPOLL_SYNCHRONOUS}
@@ -3334,7 +3556,6 @@ begin
   {$ENDIF}
   {$ENDIF}
 
-  try
     for I := 1 to LThreadCount do
     begin
       LSocket := CreateListenSocket(FPort, FHost);
@@ -3344,7 +3565,6 @@ begin
       LWorker.Start;
     end;
     
-    FRunning := True;
     DoOnListen;
 
     { [EPOLL-LISTEN-1] (re-derived onto merged 2026-07-17, upstream-PR candidate)
@@ -3375,16 +3595,22 @@ begin
 
   FRunning := False;
 
+  for I := 0 to FWorkers.Count - 1 do
+    FWorkers[I].TerminateWorker;
+
   {$IFDEF FPC}
   if GTaskPool <> nil then
   begin
     GTaskPool.Free;
     GTaskPool := nil;
   end;
+  {$ELSE}
+  if GPipelinePool <> nil then
+  begin
+    GPipelinePool.Free;
+    GPipelinePool := nil;
+  end;
   {$ENDIF}
-
-  for I := 0 to FWorkers.Count - 1 do
-    FWorkers[I].TerminateWorker;
 
   FWorkers.Clear;
 


### PR DESCRIPTION
## Problem

On Delphi Linux, `THorseEpollWorker.ProcessClientRead` hands the **entire** HTTP pipeline to `TTask.Run`, i.e. to `TThreadPool.Default` — which the provider itself configures with `Min = ProcessorCount * 8` and `Max = 2048`.

The epoll worker has already done the hard part (it owns the connection, the request bytes are parsed and in hand). Handing the rest to a global pool buys no parallelism the workers don't already have — one worker per core — and costs a thread wake-up per request.

Under load the pool speculates all the way up to its ceiling and the tail collapses. Measured on a 28-core container, benchmark server with three routes (`/ping` plain text, `/pool`, `/consulta` returning 50 JSON rows), `wrk` 4 threads, 10s per point:

| Symptom | Measured |
| --- | --- |
| Threads in the process | 30 idle → **2078 under load**, in under 6s |
| `wchan` census under load | **6146 samples in `futex_do_wait`** vs 84 in `epoll_wait` |
| Non-voluntary context switches | ~671k in ~20s |
| CPU actually used | ~2 cores out of 28 — the ceiling was queue + wake-up, not work |

`perf` and `ptrace` were unavailable in that environment (WSL2 kernel, `perf_event_paranoid=2`, no `CAP_SYS_PTRACE`), so the evidence above is from `/proc/<pid>/task/*/wchan`, thread counts and `/proc/*/status`, plus temporary instrumentation compiled into the provider and reverted afterwards.

## Change

Bind the existing anonymous procedure to a local `TProc` and call it synchronously. **The body is byte-identical** — no logic touched, no reordering. The diff is 7 insertions / 3 deletions in one file; the FPC path (`GTaskPool` / `HORSE_EPOLL_SYNCHRONOUS`) is untouched.

## Results

Same benchmark, same box, before → after:

| Route | Concurrency | Before | After | p99 |
| --- | --- | --- | --- | --- |
| `/ping` | 4 | 6 900 | 14 902 | 515 ms + 4 socket timeouts → **0.44 ms, zero timeouts** |
| `/ping` | 100 | 7 327 | **92 024** | 88 ms → **3.8 ms** |
| `/consulta` | 4 / 16 / 100 | 1 640 / 1 155 / 1 447 | 3 119 / 5 122 / 3 417 | up to 4.4× better |

Threads under load: **2078 → 29 stable**, `wchan` 100% `epoll_wait`, zero futex waits.

One caveat found while measuring, in case it saves someone else the trip: once this patch is in, the server becomes efficient enough to **saturate a container CPU quota** that the old design never reached. The residual c100 timeouts we chased for a while turned out to be cgroup throttling (~150 throttle events in a 15s run at `cpu.max = 400000/100000`), not the provider. Worth checking `/sys/fs/cgroup/cpu.stat` before blaming code.

## Known trade-off

Inline processing means a slow handler now blocks the other connections pinned to that same worker (head-of-line blocking per worker), where before it only occupied a pool thread. For the routes above the trade is overwhelmingly worth it, but a deployment with genuinely slow handlers may want a small dedicated pool or selective dispatch for those routes rather than the global `TThreadPool.Default`. Happy to shape it that way instead if you prefer — e.g. inline by default with an opt-in define for async dispatch.

## Testing

Built and exercised on Delphi 12 / Linux64 with `HORSE_PROVIDER_EPOLL`. The three routes above were served correctly (status, headers, JSON bodies) throughout every run; the change has been running as the provider for our framework's benchmark and integration server.
