### PR TITLE
fix(cookies): correct minimum compiler version for TCookie.HttpOnly

### DIFF
--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -924,7 +924,7 @@ begin
     if LState.HasExpires then
       LWebCookie.Expires := LState.Expires;   // TCookie has no Max-Age — use .Expires() on Indy
     LWebCookie.Secure := LState.Secure;
-{$IF CompilerVersion >= 31}   // Delphi 10.1 Berlin+ — TCookie.HttpOnly
+{$IF CompilerVersion >= 32}   // Delphi 10.2 Tokyo+ — TCookie.HttpOnly (Berlin's Web.HTTPApp lacks it)
     LWebCookie.HttpOnly := LState.HttpOnly;
 {$IFEND}
 {$IF CompilerVersion >= 34}   // Delphi 10.4 Sydney+ — TCookie.SameSite (string)


### PR DESCRIPTION
## Problem

The RFC 6265 cookie mapper (`Horse.Response.FlushCookiesToWebResponse`) gated the `TCookie.HttpOnly` assignment with `{$IF CompilerVersion >= 31}`, assuming **Delphi 10.1 Berlin** already exposed the property.

Berlin's `Web.HTTPApp.TCookie` only exposes `Name`, `Value`, `Domain`, `Path`, `Expires`, `Secure` and `HeaderValue`, so compiling Horse on Berlin fails with:

```
src\Horse.Response.pas(928) Error: E2003 Undeclared identifier: 'HttpOnly'
```

## Fix

`TCookie.HttpOnly` was introduced in **Delphi 10.2 Tokyo** (CompilerVersion 32.0), so the gate is now `CompilerVersion >= 32`.

Versions below Tokyo simply skip the flag, the same way the existing `SameSite` gate (`>= 34`, Sydney) already handles older RTLs.

## Verification

Compiled the full 16-scenario provider matrix (`tests/src/CompileCheck.dpr`, same scenarios as `run_compile_matrix.ps1`) with Delphi 10.1 Berlin (Studio 18.0, compiler version 31.0): **16/16 scenarios build** (Default/IOCP/HttpSys/Apache/CGI/ISAPI/Daemon/VCL, each also with `HORSE_RADIX_ROUTER`).