### PR TITLE
fix(apache): isolate raw adapters from host modules

### DIFF
--- a/src/Horse.Core.Param.Header.pas
+++ b/src/Horse.Core.Param.Header.pas
@@ -64,7 +64,9 @@ uses
   IdCustomHTTPServer,
   System.SysUtils,
 {$ENDIF}
+{$IF DEFINED(HORSE_PROVIDER_EPOLL) or DEFINED(HORSE_PROVIDER_IOCP) or DEFINED(HORSE_PROVIDER_HTTPSYS)}
   Horse.Provider.RawAdapters,
+{$IFEND}
   Horse.Rtti;
 
 {$IF DEFINED(FPC)}
@@ -136,12 +138,15 @@ var
 begin
   Result := TStringList.create;
   try
+    {$IF DEFINED(HORSE_PROVIDER_EPOLL)}
     if AWebRequest is TInterfacedWebRequest then
     begin
       Result.NameValueSeparator := '=';
       TInterfacedWebRequest(AWebRequest).RawReq.PopulateHeaders(Result);
     end
-    else if AWebRequest is TFPHTTPConnectionRequest then
+    else
+    {$IFEND}
+    if AWebRequest is TFPHTTPConnectionRequest then
     begin
       LRequest := TFPHTTPConnectionRequest(AWebRequest);
       Result.NameValueSeparator := '=';
@@ -178,11 +183,13 @@ begin
   try
     Result.NameValueSeparator := ':';
 
+{$IF DEFINED(HORSE_PROVIDER_EPOLL) or DEFINED(HORSE_PROVIDER_IOCP) or DEFINED(HORSE_PROVIDER_HTTPSYS)}
     if AWebRequest is TInterfacedWebRequest then
     begin
       TInterfacedWebRequest(AWebRequest).RawReq.PopulateHeaders(Result);
       Exit;
     end;
+{$IFEND}
 
 {$IF DEFINED(HORSE_ISAPI)}
     Result.Text := AWebRequest.GetFieldByName('ALL_RAW');

--- a/src/Horse.Provider.RawAdapters.pas
+++ b/src/Horse.Provider.RawAdapters.pas
@@ -29,6 +29,10 @@ unit Horse.Provider.RawAdapters;
   {$MODE DELPHI}{$H+}
 {$ENDIF}
 
+{$IF DEFINED(HORSE_APACHE) or DEFINED(HORSE_ISAPI) or DEFINED(HORSE_CGI) or DEFINED(HORSE_FCGI)}
+  {$MESSAGE FATAL 'Horse.Provider.RawAdapters is for self-hosted providers and must not be linked into Apache, ISAPI, CGI, or FastCGI applications.'}
+{$IFEND}
+
 interface
 
 uses

--- a/src/Horse.Response.pas
+++ b/src/Horse.Response.pas
@@ -284,8 +284,10 @@ uses
   Horse.Request,
   Horse.Core,
   Horse.Exception.Interrupted,
-  Horse.Core.MemoryBufferPool,
-  Horse.Provider.RawAdapters
+  Horse.Core.MemoryBufferPool
+  {$IF DEFINED(HORSE_PROVIDER_EPOLL) or DEFINED(HORSE_PROVIDER_IOCP) or DEFINED(HORSE_PROVIDER_HTTPSYS)}
+  , Horse.Provider.RawAdapters
+  {$IFEND}
   {$IF DEFINED(FPC)}
   , fphttpserver
   , ssockets
@@ -506,7 +508,7 @@ begin
   Result := FCSContentStream;
   if (Result = nil) and Assigned(FCSRawWebResponse) then
   begin
-    {$IF NOT DEFINED(FPC)}
+    {$IF NOT DEFINED(FPC) and (DEFINED(HORSE_PROVIDER_EPOLL) or DEFINED(HORSE_PROVIDER_IOCP) or DEFINED(HORSE_PROVIDER_HTTPSYS))}
     if FCSRawWebResponse is TInterfacedWebResponse then
       Result := TInterfacedWebResponse(FCSRawWebResponse).ContentStream
     else


### PR DESCRIPTION
## Summary

- keep `Horse.Provider.RawAdapters` out of Apache, ISAPI, CGI, and FastCGI dependency graphs
- retain raw request/response handling for epoll, IOCP, and HttpSys providers
- fail compilation if a host-managed application accidentally links `RawAdapters` again

This restores the initialization order expected by `Web.HTTPD24Impl`, preventing the exported Apache module record from being observed zero-filled.

Fixes #558.

## Validation

- Apache Win64 full build: Delphi 10 Seattle, Delphi 11, and Delphi 13
- confirmed no `Horse.Provider.Raw*.dcu` is emitted in the Apache build graph
- confirmed the Apache DLL exports `apache_horse_module`
- ISAPI Win32 and CGI Win32 full builds on Delphi 13, also with zero raw-adapter DCUs
- IOCP Win64 and HttpSys Win64 full builds on Delphi 13, both retaining raw-adapter DCUs
- epoll Linux64 full build on Delphi 13
- epoll Linux64 full build with FPC 3.2.2 in Docker
- direct `HORSE_APACHE` compilation of `Horse.Provider.RawAdapters` fails with the intended guard

An Apache runtime was not available locally, so runtime loading with `httpd.exe -t` was not performed.