### PR TITLE
chore: prepare version 3.3.5

### DIFF
--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
   "name": "horse",
   "description": "Express-inspired web framework for Delphi and Lazarus",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "homepage": "https://github.com/HashLoad/horse",
   "license": "MIT",
   "mainsrc": "src/",

--- a/src/Horse.Constants.pas
+++ b/src/Horse.Constants.pas
@@ -10,7 +10,7 @@ const
   DEFAULT_HOST = '0.0.0.0';
   DEFAULT_PORT = 9000;
   START_RUNNING = 'Server is running on %s:%d';
-  HORSE_VERSION = '3.3.4';
+  HORSE_VERSION = '3.3.5';
 
 implementation
 


### PR DESCRIPTION
## Summary

Prepare Horse 3.3.5 by updating the public version constant and Boss manifest from 3.3.4 to 3.3.5.

## Why a patch release

Horse 3.3.4 enabled FPC keep-alive across platforms, but its no-delay socket handler remained Unix-only. The follow-up fix in #566 restores FPC 3.3.1+ Windows compilation and applies `TCP_NODELAY` to reused Windows connections. This release also includes the FPC/epoll WebSocket EAGAIN regression gate from #564.

## Validation

- 74/74 compile-matrix combinations passed across Delphi 10, 11, 12, 13 and FPC/Linux.
- 24/24 Delphi DUnitX provider/router combinations passed; Delphi 11/HttpSys had one transient integration run failure and passed 207/207 on an immediate clean isolated rerun.
- FPC 3.2.2 WebSocket/epoll regression: 5/5 checks passed in Docker.
- FPC trunk 3.3.1 keep-alive regression on Linux: median 0.153 ms, p95 0.274 ms.
- FPC trunk 3.3.1 Win64 cross-build executed natively on Windows: median 0.249 ms, p95 0.384 ms.
- `boss.json` parsed successfully and the workflow passed `actionlint`.